### PR TITLE
feat!: one router per RoutingClass, exposed as route

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ This separation enables:
 
 ## Key Features
 
-1. **Instance-scoped routers** - Each object instantiates its own routers (`Router(self, ...)`) with isolated state.
+1. **One class, one router** - Every `RoutingClass` owns exactly one router with isolated state, auto-created and exposed as the `route` property.
 2. **Friendly registration** - `@route(...)` accepts explicit names, auto-strips prefixes, and supports custom metadata.
-3. **Simple hierarchies** - `attach_instance(child, name="alias")` (method on `RoutingClass`) connects instances with path access (`parent.api.node("child/method")`).
+3. **Simple hierarchies** - `attach_instance(child, name="alias")` (method on `RoutingClass`) connects instances with path access (`parent.route.node("child/method")`).
 4. **Plugin pipeline** - `BasePlugin` provides `on_decore`/`wrap_handler` hooks and plugins inherit from parents automatically.
 5. **Runtime configuration** - `routing.configure()` applies global or per-handler overrides with wildcards and returns reports (`"?"`).
 6. **Built-in plugins** - `logging`, `pydantic`, `auth`, `env`, `openapi`, and `channel` plugins are included out of the box.
@@ -53,30 +53,29 @@ This separation enables:
 ## Quick Example
 
 ```python
-from genro_routes import RoutingClass, Router, route
+from genro_routes import RoutingClass, route
 
 class OrdersAPI(RoutingClass):
     def __init__(self, label: str):
         self.label = label
-        self.api = Router(self, name="orders")
 
-    @route("orders")
+    @route()
     def list(self):
         return ["order-1", "order-2"]
 
-    @route("orders")
+    @route()
     def retrieve(self, ident: str):
         return f"{self.label}:{ident}"
 
-    @route("orders")
+    @route()
     def create(self, payload: dict):
         return {"status": "created", **payload}
 
 orders = OrdersAPI("acme")
-print(orders.api.node("list")())        # ["order-1", "order-2"]
-print(orders.api.node("retrieve")("42"))  # acme:42
+print(orders.route.node("list")())        # ["order-1", "order-2"]
+print(orders.route.node("retrieve")("42"))  # acme:42
 
-overview = orders.api.nodes()
+overview = orders.route.nodes()
 print(overview["entries"].keys())      # dict_keys(['list', 'retrieve', 'create'])
 ```
 
@@ -86,26 +85,22 @@ Build nested service structures with path access:
 
 ```python
 class UsersAPI(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="api")
-
-    @route("api")
+    @route()
     def list(self):
         return ["alice", "bob"]
 
 class Application(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api")
         self.users = UsersAPI()
 
         # Attach child service
         self.attach_instance(self.users, name="users")
 
 app = Application()
-print(app.api.node("users/list")())  # ["alice", "bob"]
+print(app.route.node("users/list")())  # ["alice", "bob"]
 
 # Introspect hierarchy
-info = app.api.nodes()
+info = app.route.nodes()
 print(info["routers"].keys())  # dict_keys(['users'])
 ```
 
@@ -162,7 +157,7 @@ Arguments:
 
 Features:
 
-- **Routers become command groups** - Multiple routers create nested subcommands
+- **Child routers become command groups** - Attached child services create nested subcommands
 - **Parameters from signatures** - Type hints map to click types (int, bool flags, Choice for Literal/Enum, multiple for list)
 - **Tab completion** - Native bash/zsh/fish via click (`eval "$(_MYAPP_COMPLETE=bash_source myapp)"`)
 - **Output formatting** - Auto (JSON for dicts, plain for strings), or force `json`/`table`/`raw`
@@ -194,7 +189,7 @@ Annotate return types to generate response schemas automatically. Bridges (MCP, 
 
 ```python
 from typing import TypedDict
-from genro_routes import RoutingClass, Router, route
+from genro_routes import RoutingClass, route
 
 class UserResponse(TypedDict):
     id: int
@@ -203,21 +198,21 @@ class UserResponse(TypedDict):
 
 class UsersAPI(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("pydantic")
+        self.route.plug("pydantic")
 
-    @route("api")
+    @route()
     def get_user(self, user_id: int) -> UserResponse:
         return {"id": user_id, "name": "alice", "active": True}
 
 api = UsersAPI()
 
 # Response schema is available in route metadata
-entry = api.api._entries["get_user"]
+entry = api.route._entries["get_user"]
 schema = entry.metadata["pydantic"]["response_schema"]
 # {"type": "object", "properties": {"id": {"type": "integer"}, ...}}
 
 # OpenAPI translation includes it automatically
-openapi = api.api.nodes(mode="openapi")
+openapi = api.route.nodes(mode="openapi")
 # paths["/get_user"]["get"]["responses"]["200"]["content"]["application/json"]["schema"]
 ```
 
@@ -225,9 +220,10 @@ Supported types: `TypedDict`, `dict[str, int]`, `list[...]`, `str`, `int`, `bool
 
 ## Core Concepts
 
-- **`Router`** - Runtime router bound directly to an object via `Router(self, name="api")`
-- **`@route("name")`** - Decorator that marks bound methods for the router with the matching name
-- **`RoutingClass`** - Mixin that tracks routers per instance and exposes the `routing` proxy
+- **`Router`** - Runtime router owned by a `RoutingClass` instance, auto-created lazily and exposed as the read-only `route` property (never instantiated by user code)
+- **`@route()`** - Decorator that marks bound methods for the class's single router (keyword-only options: `name`, `endpoint_id`, plugin flags)
+- **`RoutingClass`** - Mixin that binds a class to its single router and exposes the `routing` proxy
+- **`Section`** - Empty `RoutingClass` used as a grouping node: `svc.attach_instance(Section("Admin area"), name="admin")`
 - **`RoutingContext`** - Extensible execution context with parent chain delegation. Attach any attribute (`ctx.db`, `ctx.user`, `ctx.session`); missing lookups walk up `RoutingContext(parent=...)`. Stored in a `_ctx` slot on each instance — children inherit via `_routing_parent` chain. See [Execution Context Guide](docs/guide/context.md).
 - **`BasePlugin`** - Base class for creating plugins with `on_decore` and `wrap_handler` hooks
 - **`obj.routing`** - Proxy exposed by every RoutingClass that provides helpers like `get_router(...)` and `configure(...)` for managing routers/plugins without polluting the instance namespace.
@@ -244,14 +240,14 @@ See [Why One Name Per Operation](docs/guide/why-one-name-per-operation.md) for t
 
 ## Pattern Highlights
 
-- **Explicit naming + prefixes** - `@route("api", name="detail")` and `Router(self, prefix="handle_")` separate method names from public route names.
-- **Explicit instance hierarchies** - `self.attach_instance(child, name="alias")` connects RoutingClass instances. Retrieve children later with `routing.instance("api/alias")`.
-- **Endpoint ID** - `@route("api", endpoint_id="USR-001")` assigns a stable identifier for reverse lookup via `router.node("@USR-001")`.
-- **Branch routers** - `Router(self, branch=True)` creates pure organizational nodes without handlers.
-- **Built-in and custom plugins** - `Router(self, ...).plug("logging")`, `Router(self, ...).plug("pydantic")`, or custom plugins.
-- **Shorthand plugin syntax** - `@route("api", auth="admin")` instead of `@route("api", auth_rule="admin")`. Plugins declare their default parameter via `plugin_default_param`.
-- **Channel filtering** - `@route("api", channel="mcp,bot_.*")` controls which transport channels can access each handler. Supports regex patterns.
-- **Runtime configuration** - `routing.configure("api:logging/_all_", enabled=False)` applies targeted overrides with wildcards or batch updates.
+- **Explicit naming + prefixes** - `@route(name="detail")` and `self.route.prefix = "handle_"` separate method names from public route names.
+- **Explicit instance hierarchies** - `self.attach_instance(child, name="alias")` connects RoutingClass instances. Retrieve children later with `routing.instance("alias")`.
+- **Endpoint ID** - `@route(endpoint_id="USR-001")` assigns a stable identifier for reverse lookup via `router.node("@USR-001")`.
+- **Grouping nodes** - `attach_instance(Section("Admin area"), name="admin")` creates pure organizational nodes without handlers.
+- **Built-in and custom plugins** - `self.route.plug("logging")`, `self.route.plug("pydantic")`, or custom plugins.
+- **Shorthand plugin syntax** - `@route(auth="admin")` instead of `@route(auth_rule="admin")`. Plugins declare their default parameter via `plugin_default_param`.
+- **Channel filtering** - `@route(channel="mcp,bot_.*")` controls which transport channels can access each handler. Supports regex patterns.
+- **Runtime configuration** - `routing.configure("logging/_all_", enabled=False)` applies targeted overrides with wildcards or batch updates.
 - **Lazy binding** - Routers auto-bind on first use; no explicit `bind()` call needed.
 
 ## Documentation

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,19 +7,21 @@ This document is the source of truth for how routing, hierarchy, and plugins wor
 ```mermaid
 graph TD
   RC[RoutingClass instance]
-  Router[Router (per instance)]
+  Router[Router (route property, one per instance)]
   ChildRC[Child RoutingClass]
   ChildRouter[Child Router]
 
-  RC -->|attribute| Router
+  RC -->|route property| Router
   RC -->|attribute| ChildRC
-  ChildRC -->|attribute| ChildRouter
-  RC -->|attach_instance(name/mapping)| ChildRouter
+  ChildRC -->|route property| ChildRouter
+  RC -->|attach_instance(name)| ChildRC
+  Router -->|include(child.route, name)| ChildRouter
   Router -->|nodes| M[Nodes tree]
 ```
 
-- Hierarchies are built via `attach_instance` (method on `RoutingClass`) and torn down via `detach_instance` (method on `Router`).
-- Branch routers (`branch=True`) exist but do not auto-discover handlers.
+- Every `RoutingClass` owns exactly one `Router`, created lazily on first access of the read-only `route` property. User code never instantiates `Router` directly; router options (`description`, `prefix`, `default_entry`) are set on `self.route` in `__init__`.
+- Hierarchies are built via `attach_instance(child, name=alias)` (method on `RoutingClass`), which links `child.route` into the parent's router under the alias, and torn down via `detach_instance` (method on `Router`).
+- `Section` (an empty `RoutingClass`) provides pure grouping nodes without handlers: `svc.attach_instance(Section("Admin area"), name="admin")`.
 - `default_entry` (default: `"index"`) specifies which handler to use for catch-all routing (best-match resolution).
 - Introspection: `nodes()` is the sole API; it returns router/instance, handlers (with metadata, doc, signature, plugins, params), children, and `plugin_info`.
 
@@ -198,9 +200,9 @@ graph TD
 ### Data flow
 
 1. `RoutingCli(target)` — accepts class or instance.
-2. `CliBuilder.build()` — iterates `instance._iter_registered_routers()`:
-   - Single router → entries become root commands.
-   - Multiple routers → each router becomes a `click.Group`.
+2. `CliBuilder.build()` — reads `instance.route.nodes()`:
+   - Entries become root commands.
+   - Child routers (attached instances) become nested `click.Group`s.
 3. For each entry, `ParamConverter.to_click_params(handler)` maps `inspect.signature` + `get_type_hints` to click parameters.
 4. The command callback invokes the handler and pipes the result through `OutputFormatter`.
 

--- a/docs/CODE_READING_GUIDE.md
+++ b/docs/CODE_READING_GUIDE.md
@@ -1,198 +1,215 @@
-# genro-routes — Guida alla Lettura del Codice
+# genro-routes — Code Reading Guide
 
-**Version**: 0.16.0
+**Version**: 0.22.0
 **Status**: 🔴 DA REVISIONARE — Documento non ancora approvato
 
-Questa guida accompagna chi legge il codice sorgente per la prima volta.
-Per ogni modulo spiega **cosa fa**, **come funziona** e soprattutto
-**perché è fatto così** quando il pattern non è ovvio.
+This guide accompanies a first-time reader of the source code. For each module
+it explains **what it does**, **how it works** and above all **why it is built
+that way** when the pattern is not obvious.
 
-> **Ordine di lettura consigliato**: segui la numerazione dei capitoli.
-> Ogni capitolo presuppone la comprensione dei precedenti.
+> **Recommended reading order**: follow the chapter numbering.
+> Each chapter assumes you understood the previous ones.
 
 ---
 
-## Indice
+## Table of Contents
 
-1. [La grande idea](#1-la-grande-idea)
-2. [Mappa dei file](#2-mappa-dei-file)
-3. [Il decoratore `@route` — markers, non mutazioni](#3-il-decoratore-route--markers-non-mutazioni)
-4. [RouterInterface — il contratto minimo](#4-routerinterface--il-contratto-minimo)
-5. [BaseRouter — il cuore del routing](#5-baserouter--il-cuore-del-routing)
-6. [RouterNode — il wrapper callable](#6-routernode--il-wrapper-callable)
-7. [RoutingClass — il mixin che collega tutto](#7-routingclass--il-mixin-che-collega-tutto)
+1. [The big idea](#1-the-big-idea)
+2. [File map](#2-file-map)
+3. [The `@route` decorator — markers, not mutations](#3-the-route-decorator--markers-not-mutations)
+4. [RouterInterface — the minimal contract](#4-routerinterface--the-minimal-contract)
+5. [BaseRouter — the routing core](#5-baserouter--the-routing-core)
+6. [RouterNode — the callable wrapper](#6-routernode--the-callable-wrapper)
+7. [RoutingClass — the mixin that ties everything together](#7-routingclass--the-mixin-that-ties-everything-together)
 8. [Router — BaseRouter + plugin pipeline](#8-router--baserouter--plugin-pipeline)
-9. [Il sistema di plugin](#9-il-sistema-di-plugin)
-10. [I plugin built-in](#10-i-plugin-built-in)
-11. [Eccezioni](#11-eccezioni)
-12. [Pattern non standard — riepilogo ragionato](#12-pattern-non-standard--riepilogo-ragionato)
-13. [Il CLI adapter](#13-il-cli-adapter)
-14. [Glossario rapido](#14-glossario-rapido)
+9. [The plugin system](#9-the-plugin-system)
+10. [The built-in plugins](#10-the-built-in-plugins)
+11. [Exceptions](#11-exceptions)
+12. [Non-standard patterns — reasoned recap](#12-non-standard-patterns--reasoned-recap)
+13. [The CLI adapter](#13-the-cli-adapter)
+14. [Quick glossary](#14-quick-glossary)
 
 ---
 
-## 1. La grande idea
+## 1. The big idea
 
-genro-routes è un **motore di routing agnostico rispetto al trasporto**.
+genro-routes is a **transport-agnostic routing engine**.
 
-In Flask/FastAPI/Django le route sono legate a HTTP: verbi, URL pattern,
-status code. Qui le route sono **operazioni con nome** (`list_orders`,
-`create_user`) registrate su **istanze di oggetti**. Il protocollo
-(HTTP, WebSocket, MCP, Telegram, CLI) è un adattatore separato che vive
-in un altro pacchetto (es. `genro-asgi`).
+In Flask/FastAPI/Django routes are tied to HTTP: verbs, URL patterns, status
+codes. Here routes are **named operations** (`list_orders`, `create_user`)
+registered on **object instances**. The protocol (HTTP, WebSocket, MCP,
+Telegram, CLI) is a separate adapter living in another package (e.g.
+`genro-asgi`).
 
-```
+```text
 ┌──────────────────────────────┐     ┌────────────────────────┐
 │  genro-routes                │     │  Transport adapter     │
-│  - registra handler          │     │  (genro-asgi, ecc.)    │
-│  - organizza in gerarchie    │     │  - mappa HTTP → node() │
-│  - applica plugin            │     │  - gestisce I/O        │
-│  - espone introspezione      │     │  - serializza risposte │
+│  - registers handlers        │     │  (genro-asgi, etc.)    │
+│  - organizes hierarchies     │     │  - maps HTTP → node()  │
+│  - applies plugins           │     │  - handles I/O         │
+│  - exposes introspection     │     │  - serializes results  │
 └──────────────────────────────┘     └────────────────────────┘
 ```
 
-Conseguenza fondamentale: **i router vivono sulle istanze, non come
-singleton globali**. Ogni `MyService()` crea i propri router con i
-propri plugin. Nessuno stato condiviso.
+Two fundamental consequences:
+
+- **Routers live on instances, not as global singletons.** Every `MyService()`
+  creates its own router with its own plugins. No shared state.
+- **One class, one router.** Every `RoutingClass` owns exactly one `Router`,
+  created lazily and exposed as the read-only property `route`. Hierarchy and
+  multiple "surfaces" are expressed by **composing instances**
+  (`attach_instance`), never by adding routers to a class.
 
 ---
 
-## 2. Mappa dei file
+## 2. File map
 
-```
+```text
 src/genro_routes/
-├── __init__.py              ← API pubblica + auto-import dei plugin
-├── exceptions.py            ← 4 eccezioni (NotFound, NotAuthorized, ecc.)
+├── __init__.py              ← public API + plugin auto-import
+├── exceptions.py            ← 4 exceptions (NotFound, NotAuthorized, ...)
 ├── core/
 │   ├── __init__.py          ← re-export aggregator
-│   ├── router_interface.py  ← ABC con 2 metodi: node() e nodes()
-│   ├── decorators.py        ← @route — puro marker, zero side-effect
-│   ├── context.py           ← RoutingContext — container estensibile con parent chain
-│   ├── base_router.py       ← 977 righe — cuore: binding, risoluzione, introspezione
-│   ├── router_node.py       ← wrapper callable restituito da node()
-│   ├── router.py            ← estende BaseRouter con plugin e middleware
-│   └── routing.py           ← RoutingClass mixin + _RoutingProxy
+│   ├── router_interface.py  ← ABC with 2 methods: node() and nodes()
+│   ├── decorators.py        ← @route — pure marker, zero side effects
+│   ├── context.py           ← RoutingContext — extensible container with parent chain
+│   ├── base_router.py       ← ~1050 lines — core: binding, resolution, introspection
+│   ├── router_node.py       ← callable wrapper returned by node()
+│   ├── router.py            ← extends BaseRouter with plugins and middleware
+│   └── routing.py           ← RoutingClass mixin + Section + _RoutingProxy
 ├── cli/
-│   ├── __init__.py          ← RoutingCli — API pubblica del CLI adapter
-│   ├── _builder.py          ← CliBuilder — genera albero click da nodes()
-│   ├── _type_map.py         ← ParamConverter — tipi Python → click
+│   ├── __init__.py          ← RoutingCli — public API of the CLI adapter
+│   ├── _builder.py          ← CliBuilder — builds a click tree from nodes()
+│   ├── _type_map.py         ← ParamConverter — Python types → click
 │   └── _formatters.py       ← OutputFormatter — JSON / table / raw
 └── plugins/
-    ├── __init__.py           ← solo docstring, nessun import
+    ├── __init__.py           ← docstring only, no imports
     ├── _base_plugin.py       ← MethodEntry + BasePlugin + _wrap_configure
-    ├── logging.py            ← LoggingPlugin — timing e logging
-    ├── pydantic.py           ← PydanticPlugin — validazione input + response schema
-    ├── auth.py               ← AuthPlugin — RBAC con tag-matching
-    ├── env.py                ← EnvPlugin + CapabilitiesSet — feature flags dinamici
-    ├── openapi.py            ← OpenAPIPlugin + OpenAPITranslator
-    └── channel.py            ← ChannelPlugin — filtraggio per canale di trasporto
+    ├── logging.py            ← LoggingPlugin — timing and logging
+    ├── pydantic.py            ← PydanticPlugin — input validation + response schema
+    ├── auth.py                ← AuthPlugin — RBAC with tag matching
+    ├── env.py                 ← EnvPlugin + CapabilitiesSet — dynamic feature flags
+    ├── openapi.py             ← OpenAPIPlugin + OpenAPITranslator
+    └── channel.py             ← ChannelPlugin — transport-channel filtering
 ```
 
-**Dimensioni**: ~4.300 righe totali di codice sorgente.
+**Size**: ~5,200 lines of source code in total.
 
 ---
 
-## 3. Il decoratore `@route` — markers, non mutazioni
+## 3. The `@route` decorator — markers, not mutations
 
-**File**: `core/decorators.py` (88 righe)
+**File**: `core/decorators.py` (78 lines)
 
 ```python
-@route("api")
+@route()
 def list_orders(self):
     ...
 
-@route("api", name="detail", auth="admin")
+@route(name="detail", auth="admin")
 def handle_detail(self, order_id: int):
     ...
 ```
 
-### Cosa fa
+### What it does
 
-Appende un dizionario nella lista `func._route_decorator_kw`.
-Non tocca nessun router. Non importa nessun modulo pesante.
-Restituisce la funzione **identica**.
+Appends a dict to the list `func._route_decorator_kw`. It touches no router,
+imports no heavy module, and returns the function **unchanged**.
 
-### Perché è sorprendente
+### Why it is surprising
 
-In Flask `@app.route("/path")` muta immediatamente il router globale.
-Qui il decoratore viene eseguito a **tempo di definizione della classe**
-(import time), quando l'istanza del router non esiste ancora.
+In Flask `@app.route("/path")` immediately mutates the global router. Here the
+decorator runs at **class definition time** (import time), when the router
+instance does not exist yet.
 
-### Perché è fatto così
+### Why it is built this way
 
-Il router è instance-scoped. La classe `MyService` può essere istanziata
-N volte, ognuna con il proprio router. Il decoratore deve essere
-condiviso a livello di classe (via MRO), quindi non può parlare con
-nessuna istanza specifica. La soluzione: annota la funzione e lascia
-che il router scopra i marker più tardi (lazy binding).
+The router is instance-scoped. Class `MyService` can be instantiated N times,
+each with its own router. The decorator is shared at class level (via the MRO),
+so it cannot talk to any specific instance. The solution: annotate the function
+and let the router discover the markers later (lazy binding).
 
-### Dettagli da notare
+### Details worth noting
 
-- **Stackabile**: più `@route` sulla stessa funzione creano marker
-  multipli → la funzione viene registrata su più router.
-- **`router=None`**: significa "usa il default_router", che funziona
-  solo se la classe ha esattamente un router.
-- **`**kwargs`** extra (es. `auth="admin"`, `logging_before=False`)
-  finiscono nel payload e vengono poi smistati ai plugin.
-
----
-
-## 4. RouterInterface — il contratto minimo
-
-**File**: `core/router_interface.py` (83 righe)
-
-ABC con due soli metodi astratti:
-
-| Metodo | Scopo |
-|--------|-------|
-| `node(path, **kwargs)` | Risolvi un path → RouterNode callable |
-| `nodes(basepath, lazy, mode, pattern, forbidden, **kwargs)` | Introspezione: restituisci l'albero di entry e child router |
-
-Qualsiasi oggetto che implementa questa interfaccia può essere usato
-dove serve un router (duck typing). Questo permette a pacchetti esterni
-come `genro-asgi` di creare oggetti router-compatibili senza dipendere
-dall'implementazione di BaseRouter.
+- **Keyword-only**: `route()` takes no positional arguments. There is no router
+  selector — all markers belong to the class's single router.
+- **Payload keys**: `name` becomes `entry_name` (explicit logical name),
+  `endpoint_id` enables reverse lookup via `node("@endpoint_id")` and
+  `get_url()`. Any extra `**kwargs` (e.g. `auth="admin"`,
+  `logging_before=False`) are copied verbatim into the payload and later
+  dispatched to plugins.
+- **Stackable**: multiple `@route` on the same function create multiple markers
+  → the same function is registered under multiple entry names (aliases).
 
 ---
 
-## 5. BaseRouter — il cuore del routing
+## 4. RouterInterface — the minimal contract
 
-**File**: `core/base_router.py` (977 righe)
+**File**: `core/router_interface.py` (83 lines)
 
-Questa è la classe più importante. Implementa tutto il routing senza
-alcuna logica di plugin. Router (sottoclasse) aggiunge solo plugin e
-middleware.
+An ABC with only two abstract methods:
 
-### 5.1 Costruttore e slot
+| Method | Purpose |
+|--------|---------|
+| `node(path, **kwargs)` | Resolve a path → callable RouterNode |
+| `nodes(basepath, lazy, mode, pattern, forbidden, **kwargs)` | Introspection: return the tree of entries and child routers |
+
+Any object implementing this interface can be used where a router is expected
+(duck typing). This lets external packages such as `genro-asgi` create
+router-compatible objects without depending on the BaseRouter implementation.
+
+---
+
+## 5. BaseRouter — the routing core
+
+**File**: `core/base_router.py` (~1050 lines)
+
+This is the most important class. It implements all the routing with no plugin
+logic. Router (the subclass) only adds plugins and middleware.
+
+### 5.1 Constructor and slots
+
+```python
+BaseRouter(owner, *, prefix=None, description=None,
+           default_entry="index", get_default_handler=None,
+           get_kwargs=None)
+```
+
+- `owner` is required and must be a `RoutingClass` instance (`ValueError` if
+  `None`, `TypeError` otherwise). Routers are bound to that instance and never
+  re-bound.
+- The router's `name` is always `"route"` — users never pass a name.
+- At the end of `__init__` the router registers itself unconditionally:
+  `self.instance._register_router(self)`. RoutingClass stores it in a single
+  private slot (see chapter 7).
 
 ```python
 __slots__ = (
-    "instance",        # owner: l'istanza di RoutingClass
-    "name",            # nome del router (es. "api")
-    "prefix",          # prefisso da strippare (es. "handle_")
-    "description",     # descrizione human-readable
+    "instance",        # owner: the RoutingClass instance
+    "name",            # always "route"
+    "prefix",          # prefix to strip (e.g. "handle_")
+    "description",     # human-readable description
     "default_entry",   # fallback entry (default: "index")
-    "__entries_raw",   # dict nome → MethodEntry (⚠️ name-mangled!)
+    "__entries_raw",   # dict name → MethodEntry (⚠️ name-mangled!)
     "_children",       # dict alias → child router
-    "_get_defaults",   # kwargs di default per get_kwargs
-    "_is_branch",      # se True, non accetta handler diretti
-    "_bound",          # flag lazy binding
+    "_get_defaults",   # default kwargs (get_kwargs / get_default_handler)
+    "_bound",          # lazy-binding flag
 )
 ```
 
-**⚠️ Pattern: name mangling di `__entries_raw`**
+**⚠️ Pattern: name mangling of `__entries_raw`**
 
-L'attributo `__entries_raw` (doppio underscore) subisce il name mangling
-di Python → diventa `_BaseRouter__entries_raw`. Questo è intenzionale:
-protegge l'attributo dall'accesso accidentale da parte dei consumer.
-In `router.py` vedrai l'accesso esplicito:
+The attribute `__entries_raw` (double underscore) undergoes Python name
+mangling → it becomes `_BaseRouter__entries_raw`. This is intentional: it
+protects the attribute from accidental access by consumers. In `router.py` you
+will see the explicit access:
 
 ```python
 for entry in self._BaseRouter__entries_raw.values():
 ```
 
-Questo è necessario quando Router vuole accedere ai dati grezzi senza
-triggerare il lazy binding (la property `_entries` chiamerebbe `_bind()`).
+This is needed when Router wants the raw data without triggering lazy binding
+(the `_entries` property would call `_bind()`).
 
 ### 5.2 Lazy binding
 
@@ -204,127 +221,161 @@ def _entries(self):
     return self.__entries_raw
 ```
 
-La prima volta che qualcuno accede a `_entries` (via `node()`, `nodes()`,
-o qualsiasi operazione), viene chiamato `_bind()` che esegue `add_entry("*")`.
+The first time anything accesses `_entries` (via `node()`, `nodes()`, or any
+operation), `_bind()` runs and executes `add_entry("*")`.
 
-`add_entry("*")` scatena `_register_marked()`, che:
+`add_entry("*")` triggers `_register_marked()`, which iterates
+`_iter_marked_methods()`:
 
-1. Cammina la MRO di `type(self.instance)` (classe derivata prima)
-2. Per ogni classe nella MRO, scansiona `__dict__` cercando funzioni
-   con l'attributo `_route_decorator_kw`
-3. Per ogni marker il cui `name` corrisponde a questo router, registra
-   la funzione come entry
+1. Walks the MRO of `type(self.instance)` (derived classes first, so overrides
+   win)
+2. For each class in the MRO, scans `__dict__` looking for plain functions
+   carrying the `_route_decorator_kw` attribute
+3. Deduplicates by method name (MRO priority) and by function identity
+   (so a class-level alias of the same function is not registered twice)
+4. Registers every marker as an entry — **all markers belong to this router**
+   (one router per class, so there is no per-router filtering)
 
-**Perché lazy**: l'ordine di creazione dei router e dei plugin nel
-`__init__` non importa. Plugin possono essere aggiunti dopo la creazione
-del router. Tutto si risolve al primo uso.
+**Why lazy**: the order of router and plugin setup inside `__init__` does not
+matter. Plugins can be added after the router is created. Everything resolves
+at first use.
 
-### 5.3 Registrazione degli handler
+### 5.3 Handler registration
 
-`add_entry(target)` accetta:
+`add_entry(target)` accepts:
 
-| Tipo di target | Comportamento |
-|----------------|--------------|
-| `"*"`, `"_all_"`, `"__all__"` | Scopri tutti i `@route` marker (wildcard) |
-| Stringa con virgole `"a,b,c"` | Registra ogni nome come entry separato |
-| Stringa semplice `"my_method"` | Cerca `getattr(self.instance, "my_method")` |
-| Callable | Registra direttamente come entry |
-| Lista/tupla/set | Itera e registra ognuno |
+| Target type | Behavior |
+|-------------|----------|
+| `"*"`, `"_all_"`, `"__all__"` | Discover all `@route` markers (wildcard) |
+| Comma string `"a,b,c"` | Register each name as a separate entry |
+| Plain string `"my_method"` | Look up `getattr(self.instance, "my_method")` |
+| Callable | Register directly as entry |
+| List/tuple/set | Iterate and register each one |
 
-**Smistamento delle opzioni plugin**: le keyword con `_` vengono
-analizzate. Se la parte prima dell'underscore è un nome di plugin noto,
-la keyword viene raggruppata come opzione plugin. Es:
+**Plugin option dispatch**: keywords containing `_` are analyzed. If the part
+before the underscore is a known plugin name, the keyword is grouped as a
+plugin option. E.g.:
 
 ```python
-@route("api", auth_rule="admin", logging_before=False, meta_category="users")
+@route(auth_rule="admin", logging_before=False, meta_category="users")
 ```
 
-Diventa:
+becomes:
+
 - `plugin_options = {"auth": {"rule": "admin"}, "logging": {"before": False}}`
 - `core_options = {"meta": {"category": "users"}}`
 
-**Shorthand**: se la keyword **senza underscore** è un nome di plugin
-noto e quel plugin dichiara `plugin_default_param`, viene mappata al
-parametro di default. Così `auth="admin"` equivale a `auth_rule="admin"`.
+**Shorthand**: if the keyword **without underscore** is a known plugin name and
+that plugin declares `plugin_default_param`, it is mapped to the default
+parameter. So `auth="admin"` is equivalent to `auth_rule="admin"`.
 
-### 5.4 Risoluzione dei path — `_find_candidate_node(path)`
+### 5.4 Path resolution — `_find_candidate_node(path)`
 
-Questo è l'algoritmo di routing. Non usa regex, non usa URL pattern.
+This is the routing algorithm. No regex, no URL patterns.
 
-```
+```text
 Path: "orders/create"
          │       │
-         │       └─ cerca in entries del child router
-         └─ cerca in _children del router corrente
+         │       └─ looked up in the child router's entries
+         └─ looked up in the current router's _children
 ```
 
-Algoritmo step by step:
+Step by step:
 
-1. Se il path è vuoto → ritorna il `default_entry` del router
-2. Splitta per `/` → `["orders", "create"]`
-3. Per ogni segmento:
-   - Se è una entry → **trovata**, i segmenti rimanenti diventano `partial`
-   - Se è un child router → **naviga** nel child e continua
-4. Se la navigazione si esaurisce senza entry → usa il `default_entry`
-   dell'ultimo router raggiunto, con i segmenti rimasti come `partial`
+1. Empty path → return the router's `default_entry`
+2. Split on `/` → `["orders", "create"]`
+3. For each segment:
+   - If it is an entry → **found**; remaining segments become `partial`
+   - If it is a child router → **navigate** into the child and continue
+4. If navigation runs out without an entry → use the `default_entry` of the
+   last router reached, with the leftover segments as `partial`
 
-I segmenti `partial` vengono poi mappati ai parametri posizionali
-dell'handler tramite ispezione della signature (vedi RouterNode).
+The `partial` segments are then mapped to the handler's positional parameters
+via signature inspection (see RouterNode).
 
-**Esempio**:
-```
+**Example**:
+
+```text
 router.node("users/get_user/42")
-→ naviga nel child "users"
-→ trova entry "get_user"
+→ navigates into child "users"
+→ finds entry "get_user"
 → partial = ["42"]
-→ "42" viene mappato al primo parametro posizionale di get_user()
+→ "42" is mapped to the first positional parameter of get_user()
 ```
 
-### 5.5 Introspezione — `nodes()`
+**Reverse lookup**: a path starting with `@` is an `endpoint_id` lookup:
+`node("@invoice.detail")` searches the whole tree recursively for the entry
+registered with `@route(endpoint_id="invoice.detail")`. The companion
+`get_url(path_or_id, **kwargs)` builds a URL path, appending keyword values
+that match the handler's positional parameters as path segments.
 
-`nodes()` costruisce un dizionario annidato dell'intero albero di routing.
-Supporta:
+### 5.5 Children — `include()` and `detach_instance()`
 
-| Parametro | Effetto |
-|-----------|---------|
-| `basepath="child/grand"` | Naviga e restituisce solo quel sottoalbero |
-| `lazy=True` | I child router restano come riferimenti (non espansi) |
-| `mode="openapi"` | Output in formato OpenAPI flat |
-| `mode="h_openapi"` | Output in formato OpenAPI gerarchico |
-| `pattern="^get_"` | Filtra entry per regex |
-| `forbidden=True` | Include entry bloccate con il motivo |
-| `**kwargs` | Filtri plugin (es. `auth_tags="admin"`) |
+`include(source, name=...)` links a source into this router:
 
-### 5.6 Hook per sottoclassi
+- **Router source**: `self._children[alias] = source`. If the source's owner
+  has no parent yet, this is the **primary** attachment: plugin inheritance is
+  triggered via `_on_attached_to_parent` and `_routing_parent` is set on the
+  owner. Subsequent includes of the same router are **secondary** links —
+  navigational shortcuts only, no inheritance, no parent change.
+- **RouterNode source**: creates an **entry alias** — the same `MethodEntry`
+  is stored under a new name in this router. No copy; `_rebuild_handlers`
+  skips aliases (`entry.router is not self`) so the wrapping pipeline of the
+  source router stays in charge.
 
-BaseRouter definisce 4 hook no-op che Router sovrascrive:
+`detach_instance(child)` removes every alias whose router belongs to the child
+instance and clears `child._routing_parent`.
 
-| Hook | Quando è chiamato | Cosa fa Router |
-|------|-------------------|----------------|
-| `_wrap_handler(entry, call_next)` | Rebuild dei handler | Costruisce la pipeline middleware |
-| `_after_entry_registered(entry)` | Dopo la registrazione | Applica plugin config e `on_decore` |
-| `_on_attached_to_parent(parent)` | Dopo `attach_instance` (su RoutingClass) | Eredita i plugin dal parent |
-| `_describe_entry_extra(entry, desc)` | Durante nodes() | Aggiunge info plugin per introspezione |
+User code normally calls neither directly: `RoutingClass.attach_instance`
+(chapter 7) sets the parent relation and delegates the link to `include()`.
+
+### 5.6 Introspection — `nodes()`
+
+`nodes()` builds a nested dict of the whole routing tree. It supports:
+
+| Parameter | Effect |
+|-----------|--------|
+| `basepath="child/grand"` | Navigate and return only that subtree |
+| `lazy=True` | Child routers stay as references (not expanded) |
+| `mode="openapi"` | Flat OpenAPI output |
+| `mode="h_openapi"` | Hierarchical OpenAPI output |
+| `pattern="^get_"` | Filter entries by regex |
+| `forbidden=True` | Include blocked entries with the reason |
+| `**kwargs` | Plugin filters (e.g. `auth_tags="admin"`) |
+
+### 5.7 Hooks for subclasses
+
+BaseRouter defines four no-op hooks that Router overrides:
+
+| Hook | When it runs | What Router does |
+|------|--------------|------------------|
+| `_wrap_handler(entry, call_next)` | Handler rebuild | Builds the middleware pipeline |
+| `_after_entry_registered(entry)` | After registration | Applies plugin config and `on_decore` |
+| `_on_attached_to_parent(parent)` | Primary `include()` of this router into a parent | Inherits the parent's plugins |
+| `_describe_entry_extra(entry, desc)` | During nodes() | Adds plugin info for introspection |
 
 ---
 
-## 6. RouterNode — il wrapper callable
+## 6. RouterNode — the callable wrapper
 
-**File**: `core/router_node.py` (233 righe)
+**File**: `core/router_node.py` (240 lines)
 
-RouterNode è ciò che `router.node("path")` restituisce. È un oggetto
-**callable**: `node()()` invoca l'handler.
+RouterNode is what `router.node("path")` returns. It is a **callable** object:
+`node()()` invokes the handler.
 
-### Cosa fa
+### What it does
 
-1. Riceve il router, il nome dell'entry (opzionale) e i segmenti `partial`
-2. Risolve l'entry (dal nome o dal `default_entry`)
-3. Mappa i segmenti partial ai parametri posizionali dell'handler
+1. Receives the router, the entry name (optional) and the `partial` segments
+2. Resolves the entry (from the name or from `default_entry`)
+3. Maps the partial segments to the handler's positional parameters
    (`_assign_partial`)
-4. Quando viene chiamato (`__call__`), mergia i partial con gli args
-   espliciti e invoca `entry.handler`
+4. When called (`__call__`), merges the partials with the explicit args and
+   invokes `entry.handler`
 
-### Mapping path → parametri (`_assign_partial`)
+It also exposes `endpoint_id`, `doc` and `metadata` (the `meta_*` kwargs from
+the decorator) as read-only properties.
+
+### Path → parameter mapping (`_assign_partial`)
 
 ```python
 # Handler: def get_user(self, user_id, detail=None): ...
@@ -333,55 +384,81 @@ RouterNode è ciò che `router.node("path")` restituisce. È un oggetto
 # → partial_kwargs = {"user_id": "42", "detail": "full"}
 ```
 
-L'ispezione avviene via `inspect.signature`. Se ci sono segmenti extra
-e la funzione non ha `*args`, il nodo è invalido (NotFound).
+Inspection happens via `inspect.signature`. If there are extra segments and the
+function has no `*args`, the node is invalid (NotFound).
 
-### Precedenza path > kwargs
+### Precedence: path > kwargs
 
 ```python
 filtered_kwargs = {k: v for k, v in kwargs.items() if k not in self._partial_kwargs}
 ```
 
-I valori estratti dal path **vincono** su quelli passati come keyword.
+Values extracted from the path **win** over those passed as keywords.
 
 ### Exception mapping
 
-Ogni RouterNode ha un dizionario `_exceptions` che mappa codici errore
-a classi di eccezione. Il chiamante può personalizzarle:
+Every RouterNode has an `_exceptions` dict mapping error codes to exception
+classes. The caller can customize them:
 
 ```python
 node = router.node("action", errors={"not_found": MyHTTPNotFound})
 ```
 
-Se il nodo ha `error` settato, `__call__` lancia l'eccezione mappata.
+If the node has `error` set, `__call__` raises the mapped exception.
 
 ---
 
-## 7. RoutingClass — il mixin che collega tutto
+## 7. RoutingClass — the mixin that ties everything together
 
-**File**: `core/routing.py` (572 righe)
+**File**: `core/routing.py` (518 lines)
 
-Questo mixin è il ponte tra le classi utente e i router. Chi usa
-genro-routes eredita da `RoutingClass`.
+This mixin is the bridge between user classes and routers. Users of
+genro-routes inherit from `RoutingClass`.
 
-### 7.1 `__slots__` — isolamento dello stato
+### 7.1 `__slots__` — state isolation
 
 ```python
 __slots__ = (
     "__routing_proxy__",
-    "__genro_routes_router_registry__",
+    "__genro_routes_router__",
     "_routing_parent",
-    "_context",
+    "_ctx",
     "_capabilities",
 )
 ```
 
-Tutti gli attributi del framework sono in slot dedicati → non inquinano
-il namespace dell'utente. `__routing_proxy__` e
-`__genro_routes_router_registry__` hanno nomi volutamente lunghi per
-evitare collisioni.
+All framework attributes live in dedicated slots → they do not pollute the
+user's namespace. `__routing_proxy__` and `__genro_routes_router__` have
+deliberately long names to avoid collisions.
 
-### 7.2 `__setattr__` — auto-detach dei child ⚠️
+### 7.2 The `route` property — one router per instance
+
+```python
+@property
+def route(self) -> Router:
+    router = getattr(self, _ROUTER_ATTR_NAME, None)
+    if router is None:
+        router = Router(self)
+    return router
+```
+
+The router is created **lazily on first access** and stored in the
+`__genro_routes_router__` slot by `_register_router` (called by the Router
+constructor). Users never call `Router(...)` directly; configuration happens on
+the existing router in `__init__` (binding is lazy, so this is race-free):
+
+```python
+class MyService(RoutingClass):
+    def __init__(self):
+        self.route.description = "My service API"
+        self.route.plug("logging")
+```
+
+`_register_router` raises `ValueError` if a *different* router is already
+registered — the one-router invariant is enforced, not just conventional.
+A class with no plugins and no options needs no `__init__` at all.
+
+### 7.3 `__setattr__` — child auto-detach ⚠️
 
 ```python
 def __setattr__(self, name, value):
@@ -391,26 +468,47 @@ def __setattr__(self, name, value):
     object.__setattr__(self, name, value)
 ```
 
-**Questo è un side-effect importante**: ogni assegnamento di attributo
-su un RoutingClass passa per questa logica. Se l'attributo precedente
-era un child RoutingClass collegato a questo parent, viene automaticamente
-staccato da tutti i router.
+**This is an important side effect**: every attribute assignment on a
+RoutingClass goes through this logic. If the previous attribute value was a
+child RoutingClass bound to this parent, it is automatically detached from the
+router.
 
-**Perché**: evita memory leak e router orfani. Se fai
-`parent.child = AltroChild()`, il vecchio child viene rimosso dalla
-gerarchia senza bisogno di chiamare `detach_instance()` manualmente.
+**Why**: it avoids memory leaks and orphan routers. If you do
+`parent.child = OtherChild()`, the old child is removed from the hierarchy
+without a manual `detach_instance()` call.
 
-**Nota**: `object.__setattr__` è usato in diversi punti del codice
-per *bypassare* questo `__setattr__` custom quando non si vuole il
-controllo di auto-detach (es. durante l'inizializzazione interna).
+**Note**: `object.__setattr__` is used in several places to *bypass* this
+custom `__setattr__` when the auto-detach check is not wanted (e.g. during
+internal initialization).
 
-### 7.3 `_register_router(router)` — registrazione automatica
+### 7.4 `attach_instance` — hierarchical composition
 
-Quando crei `Router(self, name="api")`, il costruttore di BaseRouter
-chiama `self.instance._register_router(self)`. Il router si
-auto-registra nel registry dell'owner.
+`attach_instance` is a method of **RoutingClass** (not of Router or the proxy).
+There is a single calling style:
 
-### 7.4 `routing` property — il proxy
+```python
+self.attach_instance(child, name="sales")
+```
+
+It sets `child._routing_parent = self` and, when `name` is given, delegates the
+routing link to `self.route.include(child.route, name=name)` (which triggers
+plugin inheritance on the primary attachment). Without `name`, only the parent
+relationship is set — useful for `ctx` propagation without routing.
+
+`detach_instance` stays on **Router**.
+
+### 7.5 `Section` — the grouping node
+
+```python
+svc.attach_instance(Section("Admin area"), name="admin")
+```
+
+`Section` is a minimal concrete RoutingClass carrying an empty router. It is
+used to build intermediate levels of a routing tree (namespacing, dynamically
+discovered hierarchies) without defining a dedicated class. Multiple surfaces
+(api + admin) are separate RoutingClass instances composed by attach.
+
+### 7.6 `routing` property — the proxy
 
 ```python
 @property
@@ -422,54 +520,31 @@ def routing(self):
     return proxy
 ```
 
-Restituisce un `_RoutingProxy` cached. Il proxy raggruppa tutte le
-operazioni di management senza inquinare il namespace della classe:
+Returns a cached `_RoutingProxy`. The proxy groups the management operations
+without polluting the class namespace:
 
-| Metodo del proxy | Scopo |
-|------------------|-------|
-| `get_router(name)` | Lookup di un router per nome |
-| `configure(target, **opts)` | Configurazione plugin via target syntax |
-| `configure("?")` | Introspezione: descrive tutti i router |
+| Proxy method | Purpose |
+|--------------|---------|
+| `get_router(path=None)` | The owner's router, or a child router at path |
+| `instance(path)` | The RoutingClass instance owning the child router at path |
+| `configure(target, **opts)` | Plugin configuration via target syntax |
+| `configure("?")` | Introspection: returns the router description dict |
+| `attach_instance(child, name=...)` | Delegates to the owner's `attach_instance` |
 
-**Nota**: `attach_instance` non è sul proxy ma direttamente su
-RoutingClass. Vedi sezione 7.5 sotto.
-
-**Target syntax per configure**: `"router:plugin/selector"`
-
-```python
-svc.routing.configure("api:logging/_all_", before=False)
-svc.routing.configure("api:auth/admin_*", rule="admin")
-```
-
-Il selettore supporta glob pattern (`fnmatchcase`).
-
-### 7.5 `attach_instance` — composizione gerarchica
-
-`attach_instance` è un metodo di **RoutingClass** (non di Router o del proxy).
-Collega un child RoutingClass a uno o piu router del parent:
+**Target syntax for configure**: `"plugin/selector"`
 
 ```python
-# Shortcut 1:1 — funziona solo se il child ha un singolo router
-self.attach_instance(child, name="sales")
-
-# Cross-mapping esplicito — usa kwargs router_<nome_router_parent>
-self.attach_instance(child,
-    router_api="orders:sales,billing:invoices",
-    router_admin="mgmt:management",
-)
+svc.routing.configure("logging/_all_", before=False)
+svc.routing.configure("auth/admin_*", rule="admin")
 ```
 
-Ogni kwarg `router_<parent_router>` specifica una lista di mapping
-`child_router:alias` separati da virgola. Non esiste piu l'auto-mapping
-(senza parametri): il collegamento e sempre esplicito.
+The selector supports glob patterns (`fnmatchcase`). Child routers belong to
+child instances: configure them through the child's own `routing` proxy.
 
-`detach_instance` resta invece su **Router** (invariato).
+### 7.7 `ctx` property — slot + parent chain
 
-### 7.6 `ctx` property — slot + parent chain
-
-Il context (`RoutingContext`) viene settato dall'adapter (ASGI, ecc.)
-nello slot `_ctx` dell'istanza. La lettura risale la catena
-`_routing_parent` — lo stesso pattern usato da `_routing_parent` stesso:
+The context (`RoutingContext`) is set by the adapter (ASGI, etc.) in the
+instance's `_ctx` slot. Reading walks up the `_routing_parent` chain:
 
 ```python
 @property
@@ -487,8 +562,8 @@ def ctx(self, value):
     object.__setattr__(self, "_ctx", value)
 ```
 
-La stratificazione (server → app → request) è gestita dal parent chain
-dentro `RoutingContext`, non da `RoutingClass`:
+Layering (server → app → request) is handled by the parent chain inside
+`RoutingContext`, not by `RoutingClass`:
 
 ```python
 server_ctx = RoutingContext()
@@ -501,56 +576,58 @@ ctx = RoutingContext(parent=app_ctx)
 ctx.db = db_connection
 
 svc.ctx = ctx
-# svc.ctx.db → locale
-# svc.ctx.server → risale il parent chain fino a server_ctx
+# svc.ctx.db → local
+# svc.ctx.server → walks the parent chain up to server_ctx
 ```
 
-L'isolamento per concorrenza (ContextVar per async, threading.local per
-thread) è responsabilità dell'adapter, non di genro-routes.
+Concurrency isolation (ContextVar for async, threading.local for threads) is
+the adapter's responsibility, not genro-routes'.
 
 ---
 
 ## 8. Router — BaseRouter + plugin pipeline
 
-**File**: `core/router.py` (549 righe)
+**File**: `core/router.py` (551 lines)
 
-Router estende BaseRouter aggiungendo:
+Router extends BaseRouter adding:
 
-- Registry globale dei plugin (`_PLUGIN_REGISTRY` — unico stato globale)
-- Istanze plugin per-router
-- Pipeline middleware
-- Ereditarietà plugin nelle gerarchie
+- The global plugin registry (`_PLUGIN_REGISTRY` — the only global state)
+- Per-router plugin instances
+- The middleware pipeline
+- Plugin inheritance across hierarchies
 
-### 8.1 Registry globale
+### 8.1 Global registry
 
 ```python
 _PLUGIN_REGISTRY: dict[str, type[BasePlugin]] = {}
 ```
 
-I plugin si auto-registrano alla fine del loro modulo:
+Plugins self-register at the end of their module:
 
 ```python
-# In auth.py, ultima riga:
+# In auth.py, last line:
 Router.register_plugin(AuthPlugin)
 ```
 
-L'import avviene in `__init__.py`:
+The import happens in `__init__.py`:
 
 ```python
 for _plugin in ("logging", "pydantic", "auth", "env", "openapi", "channel"):
     import_module(f"{__name__}.plugins.{_plugin}")
 ```
 
-### 8.2 `plug(name)` — attaccare un plugin
+### 8.2 `plug(name)` — attaching a plugin
 
 ```python
-self.api = Router(self, name="api").plug("logging").plug("auth")
+self.route.plug("logging").plug("auth")
 ```
 
-`plug()` è chainable (restituisce `self`). Crea una `_PluginSpec`,
-istanzia il plugin, e lo aggiunge alle strutture interne.
+`plug()` is chainable (returns `self`). It creates a `_PluginSpec`,
+instantiates the plugin, and adds it to the internal structures. If the router
+is already bound, `on_decore` is applied to existing entries and handlers are
+rebuilt.
 
-### 8.3 `__getattr__` — accesso fluente ai plugin
+### 8.3 `__getattr__` — fluent plugin access
 
 ```python
 def __getattr__(self, name):
@@ -560,97 +637,100 @@ def __getattr__(self, name):
     return plugin
 ```
 
-Questo permette `router.logging.configure(before=False)`. I plugin
-diventano attributi virtuali del router.
+This enables `router.logging.configure(before=False)`. Plugins become virtual
+attributes of the router.
 
-### 8.4 Pipeline middleware — `_wrap_handler`
+### 8.4 Middleware pipeline — `_wrap_handler`
 
 ```python
-wrapped = call_next  # = entry.func (il metodo originale)
+wrapped = call_next  # = entry.func (the original method)
 for plugin in reversed(self._plugins):
     plugin_call = plugin.wrap_handler(self, entry, wrapped)
     wrapped = self._create_wrapper(plugin, entry, plugin_call, wrapped)
 ```
 
-L'ultimo plugin attaccato è il più vicino all'handler reale. Il primo
-è il più esterno (primo a eseguire, ultimo a completare).
+The last attached plugin is closest to the real handler. The first one is the
+outermost (first to run, last to complete).
 
-**Il wrapper controlla `is_plugin_enabled` a runtime**: se il plugin
-è disabilitato, salta direttamente al `next_handler`. Questo consente
-di abilitare/disabilitare plugin **senza ricostruire la catena**.
+**The wrapper checks `is_plugin_enabled` at runtime**: if the plugin is
+disabled, it jumps straight to `next_handler`. This allows enabling/disabling
+plugins **without rebuilding the chain**.
 
-### 8.5 Ereditarietà plugin — `_on_attached_to_parent`
+### 8.5 Plugin inheritance — `_on_attached_to_parent`
 
-Quando un child router viene attaccato a un parent:
+When a child router is attached to a parent (primary `include()`):
 
-1. Per ogni plugin del parent **non presente** nel child: viene creata
-   una nuova istanza e aggiunta al child
-2. Per ogni plugin del parent **già presente** nel child: viene
-   chiamato `on_attached_to_parent(parent_plugin)` per decidere
-   come gestire l'ereditarietà
+1. For each parent plugin **not present** in the child: a new instance of the
+   same plugin class is created and added to the child
+2. For each parent plugin **already present** in the child:
+   `on_attached_to_parent(parent_plugin)` is called so the plugin decides how
+   to handle inheritance
 
-La lista `_plugin_children` traccia i child per la propagazione
-delle modifiche di configurazione.
+The `_inherited_from` set (parent ids) prevents inheriting twice from the same
+parent; `_plugin_children` tracks children for configuration-change
+propagation.
 
-### 8.6 `is_plugin_enabled` — cascata a 5 livelli
+### 8.6 `is_plugin_enabled` — 5-level cascade
 
-Ordine di risoluzione (primo trovato vince):
+Resolution order (first match wins):
 
 1. **entry locals** (runtime override via `set_plugin_enabled`)
-2. **entry config** (statico via `configure(_target=handler)`)
+2. **entry config** (static via `configure(_target=handler)`)
 3. **global locals** (runtime override via `set_plugin_enabled("_all_")`)
-4. **global config** (statico via `configure()`)
+4. **global config** (static via `configure()`)
 5. **default**: `True`
 
-La separazione config/locals permette override runtime che possono
-essere impostati e rimossi indipendentemente dalla configurazione statica.
+The config/locals separation allows runtime overrides that can be set and
+removed independently of the static configuration.
 
 ---
 
-## 9. Il sistema di plugin
+## 9. The plugin system
 
-**File**: `plugins/_base_plugin.py` (380 righe)
+**File**: `plugins/_base_plugin.py` (381 lines)
 
-### 9.1 `MethodEntry` — la scheda di un handler
+### 9.1 `MethodEntry` — the record of a handler
 
 ```python
 @dataclass
 class MethodEntry:
-    name: str                        # nome logico (es. "list_orders")
-    func: Callable                   # il bound method originale
-    router: Any                      # il router che lo contiene
-    plugins: list[str]               # nomi dei plugin applicati
-    metadata: dict[str, Any]         # metadati (plugin_config, meta_*, ecc.)
-    handler: Callable = None         # il metodo dopo il wrapping middleware
+    name: str                        # logical name (e.g. "list_orders")
+    func: Callable                   # the original bound method
+    router: Any                      # the router that owns it
+    plugins: list[str]               # names of the applied plugins
+    metadata: dict[str, Any]         # metadata (plugin_config, meta_*, ...)
+    handler: Callable = None         # the method after middleware wrapping
+    endpoint_id: str | None = None   # optional globally unique id (reverse lookup)
 ```
 
-`handler` parte uguale a `func` e viene sostituito dalla pipeline
-middleware quando i plugin costruiscono i wrapper.
+`handler` starts equal to `func` and is replaced by the middleware pipeline
+when plugins build the wrappers.
 
-### 9.2 `BasePlugin` — il contratto
+### 9.2 `BasePlugin` — the contract
 
-Ogni plugin eredita da `BasePlugin` e definisce:
+Every plugin inherits from `BasePlugin` and defines:
 
-**Attributi di classe (obbligatori)**:
+**Class attributes (required)**:
+
 ```python
-plugin_code = "auth"            # identificativo univoco
-plugin_description = "..."      # descrizione human-readable
-plugin_default_param = "rule"   # parametro shorthand (opzionale)
+plugin_code = "auth"            # unique identifier
+plugin_description = "..."      # human-readable description
+plugin_default_param = "rule"   # shorthand parameter (optional)
 ```
 
-**Hook sovrascrivibili**:
+**Overridable hooks**:
 
-| Hook | Quando | Scopo |
-|------|--------|-------|
-| `configure(*, _target, flags, ...)` | Configurazione | Definire la schema tramite la firma |
-| `on_decore(router, func, entry)` | Registrazione handler | Analizzare/trasformare l'entry |
-| `wrap_handler(router, entry, call_next)` | Build middleware | Restituire wrapper callable |
-| `deny_reason(entry, **filters)` | `node()` / `nodes()` | Decidere l'accessibilità |
-| `entry_metadata(router, entry)` | `nodes()` | Fornire metadati per introspezione |
-| `on_attached_to_parent(parent_plugin)` | `attach_instance` (su RoutingClass) | Gestire ereditarietà config |
-| `on_parent_config_changed(old, new)` | Parent modifica config | Decidere se seguire o ignorare |
+| Hook | When | Purpose |
+|------|------|---------|
+| `configure(*, _target, flags, ...)` | Configuration | Declare the schema via the signature |
+| `on_decore(router, func, entry)` | Handler registration | Analyze/transform the entry |
+| `wrap_handler(router, entry, call_next)` | Middleware build | Return a wrapper callable |
+| `deny_reason(entry, **filters)` | `node()` / `nodes()` | Decide accessibility |
+| `entry_metadata(router, entry)` | `nodes()` | Provide introspection metadata |
+| `on_attached_to_parent(parent_plugin)` | Primary attachment | Handle config inheritance |
+| `on_parent_config_changed(old, new)` | Parent changes config | Decide whether to follow or ignore |
 
-### 9.3 `__init_subclass__` — il pattern più elegante ⚠️
+### 9.3 `__init_subclass__` — the most elegant pattern ⚠️
 
 ```python
 class BasePlugin:
@@ -660,32 +740,32 @@ class BasePlugin:
             cls.configure = _wrap_configure(cls.__dict__["configure"])
 ```
 
-Ogni sottoclasse che definisce `configure()` se la vede automaticamente
-wrappata da `_wrap_configure`. L'autore del plugin scrive:
+Every subclass defining `configure()` gets it automatically wrapped by
+`_wrap_configure`. The plugin author writes:
 
 ```python
 class AuthPlugin(BasePlugin):
     def configure(self, *, rule: str = "", enabled: bool = True,
                   _target: str = "_all_", flags: str | None = None):
-        pass  # Il body è letteralmente vuoto!
+        pass  # The body is literally empty!
 ```
 
-La **firma dei parametri È la specifica di configurazione**.
+The **parameter signature IS the configuration schema**.
 
-`_wrap_configure` aggiunge:
-1. Validazione Pydantic via `@validate_call` sulla firma originale
-2. Parsing di `flags` (stringa `"enabled,before:off"` → dict booleano)
-3. Gestione di target multipli (comma-separated)
-4. Scrittura automatica nello store `_plugin_info` del router
+`_wrap_configure` adds:
 
-**Perché è fatto così**: elimina completamente il boilerplate di
-configurazione. Zero codice di validazione, zero codice di persistenza,
-zero codice di serializzazione. Il plugin developer dichiara solo
-i parametri accettati e i loro tipi.
+1. Pydantic validation via `@validate_call` on the original signature
+2. `flags` parsing (string `"enabled,before:off"` → boolean dict)
+3. Multiple-target handling (comma-separated)
+4. Automatic persistence in the router's `_plugin_info` store
 
-### 9.4 Store di configurazione
+**Why**: it removes all configuration boilerplate. Zero validation code, zero
+persistence code, zero serialization code. The plugin developer only declares
+the accepted parameters and their types.
 
-La configurazione vive in `Router._plugin_info`:
+### 9.4 Configuration store
+
+Configuration lives in `Router._plugin_info`:
 
 ```python
 {
@@ -696,88 +776,89 @@ La configurazione vive in `Router._plugin_info`:
 }
 ```
 
-`_all_` è la configurazione globale; le entry specifiche la sovrascrivono.
+`_all_` is the global configuration; specific entries override it.
 
-### 9.5 Ereditarietà "segui se allineato, ignora se personalizzato"
+### 9.5 Inheritance: "follow if aligned, ignore if customized"
 
-Quando il parent modifica la sua config, `_notify_children` chiama
-`on_parent_config_changed(old, new)` su ogni child. L'implementazione
-di default:
+When the parent changes its config, `_notify_children` calls
+`on_parent_config_changed(old, new)` on each child. The default implementation:
 
-- Se la config del child era **uguale** alla vecchia config del parent
-  → aggiorna alla nuova
-- Se la config del child era stata **personalizzata** → ignora
+- If the child's config was **equal** to the parent's old config → update to
+  the new one
+- If the child's config had been **customized** → ignore
 
-Questo evita sia la rigidità dell'ereditarietà forzata sia il caos
-dell'indipendenza totale. La cascata si propaga ricorsivamente ai
-nipoti ma si interrompe dove la config è stata personalizzata.
+This avoids both the rigidity of forced inheritance and the chaos of total
+independence. The cascade propagates recursively to grandchildren but stops
+where the config was customized.
 
 ---
 
-## 10. I plugin built-in
+## 10. The built-in plugins
 
-### 10.1 LoggingPlugin (`plugins/logging.py`, 175 righe)
+### 10.1 LoggingPlugin (`plugins/logging.py`, 175 lines)
 
 **Hook**: `wrap_handler`
 
-Aggiunge logging con timing a ogni chiamata handler. La closure `logged`
-legge la configurazione **a runtime** (non a wrap-time), permettendo
-toggle dinamici.
+Adds logging with timing to every handler call. The `logged` closure reads the
+configuration **at runtime** (not at wrap time), allowing dynamic toggles.
 
 ```python
 configure(enabled=True, before=True, after=True, log=True, print=False)
 ```
 
-Nota: `print` come nome parametro shadows il builtin — è intenzionale
-(ha il commento `# noqa: A002`).
+Note: `print` as a parameter name shadows the builtin — intentional (it carries
+the `# noqa: A002` comment).
 
-### 10.2 PydanticPlugin (`plugins/pydantic.py`, 247 righe)
+### 10.2 PydanticPlugin (`plugins/pydantic.py`, 247 lines)
 
-**Hook**: `on_decore`, `wrap_handler`, `entry_metadata`
+**Hooks**: `on_decore`, `wrap_handler`, `entry_metadata`
 
-**In `on_decore`** (alla registrazione):
-- Ispeziona signature e type hints
-- Crea un modello Pydantic dinamico per i parametri di input
-- Genera il response schema JSON dal return type hint
+**In `on_decore`** (at registration):
 
-**In `wrap_handler`** (a runtime):
-- Valida solo i parametri con type hint (quelli senza passano inalterati)
-- Il check `disabled` avviene a ogni chiamata, non a wrap-time
+- Inspects signature and type hints
+- Creates a dynamic Pydantic model for the input parameters
+- Generates the JSON response schema from the return type hint
 
-Nota: il parametro di configurazione è `disabled` (negativo), non
-`enabled`. Diverso dagli altri plugin.
+**In `wrap_handler`** (at runtime):
 
-### 10.3 AuthPlugin (`plugins/auth.py`, 170 righe)
+- Validates only the parameters with a type hint (untyped ones pass through)
+- The `disabled` check happens on every call, not at wrap time
 
-**Hook**: `deny_reason`
+Note: the configuration parameter is `disabled` (negative), not `enabled`.
+Different from the other plugins.
 
-Implementa RBAC con regole espressive:
-
-| Regola | Significato |
-|--------|-------------|
-| `"admin"` | Richiede il tag "admin" |
-| `"admin\|manager"` | OR: uno dei due basta |
-| `"admin&internal"` | AND: servono entrambi |
-| `"!guest"` | NOT: non deve avere "guest" |
-| `"(admin\|manager)&!guest"` | Combinazione |
-
-**Distinzione 401 vs 403**:
-- Entry con regola ma nessun tag fornito → `"not_authenticated"` (401)
-- Tag forniti ma non matchano → `"not_authorized"` (403)
-
-**Ricorsione sui RouterInterface**: se l'entry è un router (non un
-handler), itera su tutte le sue entry e child. Se almeno uno è
-accessibile, il router è visibile.
-
-### 10.4 EnvPlugin + CapabilitiesSet (`plugins/env.py`, 307 righe)
+### 10.3 AuthPlugin (`plugins/auth.py`, 170 lines)
 
 **Hook**: `deny_reason`
 
-Filtra le entry in base alle **capability** disponibili nel sistema.
-A differenza di AuthPlugin (chi sei tu), EnvPlugin riguarda **cosa è
-disponibile** (Redis è attivo? Stripe è configurato?).
+Implements RBAC with expressive rules:
 
-**`CapabilitiesSet`** è la classe base per definire capabilities dinamiche:
+| Rule | Meaning |
+|------|---------|
+| `"admin"` | Requires the "admin" tag |
+| `"admin\|manager"` | OR: either one suffices |
+| `"admin&internal"` | AND: both required |
+| `"!guest"` | NOT: must not have "guest" |
+| `"(admin\|manager)&!guest"` | Combination |
+
+**401 vs 403 distinction**:
+
+- Entry with a rule but no tags provided → `"not_authenticated"` (401)
+- Tags provided but not matching → `"not_authorized"` (403)
+
+**Recursion over RouterInterface**: if the entry is a router (not a handler),
+it iterates over all its entries and children. If at least one is accessible,
+the router is visible.
+
+### 10.4 EnvPlugin + CapabilitiesSet (`plugins/env.py`, 307 lines)
+
+**Hook**: `deny_reason`
+
+Filters entries based on the **capabilities** available in the system. Unlike
+AuthPlugin (who you are), EnvPlugin is about **what is available** (is Redis
+up? is Stripe configured?).
+
+**`CapabilitiesSet`** is the base class for defining dynamic capabilities:
 
 ```python
 class MyCapabilities(CapabilitiesSet):
@@ -790,145 +871,147 @@ class MyCapabilities(CapabilitiesSet):
         return self._stripe_key is not None
 ```
 
-Il pattern è sorprendente: `CapabilitiesSet.__iter__` usa `dir(self)`
-per scoprire i metodi marcati con `@capability`, li **chiama** a
-runtime, e yield il nome solo se ritornano `True`. Non c'è cache:
-ogni iterazione ri-valuta le capability.
+The pattern is surprising: `CapabilitiesSet.__iter__` uses `dir(self)` to
+discover the methods marked with `@capability`, **calls** them at runtime, and
+yields the name only if they return `True`. There is no cache: every iteration
+re-evaluates the capabilities.
 
-**Accumulazione nella gerarchia**: le capability si sommano risalendo
-la catena `_routing_parent`. Parent ha "redis", child ha "pyjwt" →
-un'entry che richiede `redis&pyjwt` è soddisfatta.
+**Accumulation in the hierarchy**: capabilities add up walking the
+`_routing_parent` chain (`BaseRouter.current_capabilities`). Parent has
+"redis", child has "pyjwt" → an entry requiring `redis&pyjwt` is satisfied.
 
-### 10.5 ChannelPlugin (`plugins/channel.py`, 143 righe)
+### 10.5 ChannelPlugin (`plugins/channel.py`, 143 lines)
 
 **Hook**: `deny_reason`
 
-Filtra le entry in base al **canale di trasporto** (mcp, rest, bot_*, ecc.).
+Filters entries based on the **transport channel** (mcp, rest, bot_*, etc.).
 
 ```python
-@route("api", channel="mcp,bot_.*")
+@route(channel="mcp,bot_.*")
 def mcp_and_bots_only(self): ...
 ```
 
-- **Default closed**: senza configurazione di canali, l'entry non è
-  disponibile su nessun canale
-- I pattern sono **regex full-match** (`re.fullmatch`)
-- `"*"` è un caso speciale (wildcard, tutto aperto)
+- **Default closed**: without channel configuration, the entry is not
+  available on any channel
+- Patterns are **full-match regexes** (`re.fullmatch`)
+- `"*"` is a special case (wildcard, everything open)
 
-### 10.6 OpenAPIPlugin + OpenAPITranslator (`plugins/openapi.py`, 594 righe)
+### 10.6 OpenAPIPlugin + OpenAPITranslator (`plugins/openapi.py`, 593 lines)
 
 **Hook**: `entry_metadata`
 
-Il plugin aggiunge metadati espliciti (method override, tags, summary,
-deprecated, security). L'`OpenAPITranslator` è una classe utility con
-soli metodi statici che traduce l'output di `nodes()` in formato OpenAPI.
+The plugin adds explicit metadata (method override, tags, summary, deprecated,
+security). `OpenAPITranslator` is a utility class of static methods that
+translates the `nodes()` output into OpenAPI format.
 
-**HTTP method guessing**: se non viene forzato esplicitamente, il metodo
-HTTP viene dedotto dalla signature:
-- Tutti parametri scalari (str, int, float, bool, Enum) → **GET**
-- Almeno un parametro complesso (dict, list, BaseModel) → **POST**
+**HTTP method guessing**: unless explicitly forced, the HTTP method is deduced
+from the signature:
 
-**Cross-plugin integration**: l'OpenAPITranslator legge i metadati di
-AuthPlugin (→ `security`) e EnvPlugin (→ `x-requires`) per generare
-l'output OpenAPI completo.
+- All scalar parameters (str, int, float, bool, Enum) → **GET**
+- At least one complex parameter (dict, list, BaseModel) → **POST**
 
----
-
-## 11. Eccezioni
-
-**File**: `exceptions.py` (74 righe)
-
-Quattro eccezioni, tutte con attributo `selector: str`:
-
-| Eccezione | Codice HTTP tipico | Quando |
-|-----------|--------------------|--------|
-| `NotFound` | 404 | Path non risolto |
-| `NotAuthenticated` | 401 | Servono credenziali, non fornite |
-| `NotAuthorized` | 403 | Credenziali fornite ma insufficienti |
-| `NotAvailable` | 501 | Capability mancante o canale non supportato |
-
-Il `selector` ha formato `"router_name:path"` (es. `"api:admin/create"`).
+**Cross-plugin integration**: the OpenAPITranslator reads AuthPlugin metadata
+(→ `security`) and EnvPlugin metadata (→ `x-requires`) to generate the full
+OpenAPI output.
 
 ---
 
-## 12. Pattern non standard — riepilogo ragionato
+## 11. Exceptions
 
-### 12.1 `@route` come puro marker
+**File**: `exceptions.py` (73 lines)
 
-| Pattern mainstream | Pattern genro-routes | Ragione |
-|--------------------|---------------------|---------|
-| `@app.route("/path")` muta il router globale | `@route("api")` annota la funzione | Router instance-scoped, no singleton |
+Four exceptions, all with a `selector: str` attribute:
+
+| Exception | Typical HTTP code | When |
+|-----------|-------------------|------|
+| `NotFound` | 404 | Path not resolved |
+| `NotAuthenticated` | 401 | Credentials required, not provided |
+| `NotAuthorized` | 403 | Credentials provided but insufficient |
+| `NotAvailable` | 501 | Missing capability or unsupported channel |
+
+The `selector` has the format `"router_name:path"` (e.g. `"route:admin/create"`).
+
+---
+
+## 12. Non-standard patterns — reasoned recap
+
+### 12.1 `@route` as pure marker
+
+| Mainstream pattern | genro-routes pattern | Reason |
+|--------------------|----------------------|--------|
+| `@app.route("/path")` mutates the global router | `@route()` annotates the function | Instance-scoped router, no singleton |
 
 ### 12.2 Lazy binding
 
-| Pattern mainstream | Pattern genro-routes | Ragione |
-|--------------------|---------------------|---------|
-| Registrazione esplicita o al tempo del decoratore | Binding al primo accesso a `_entries` | Ordine di setup irrilevante |
+| Mainstream pattern | genro-routes pattern | Reason |
+|--------------------|----------------------|--------|
+| Explicit registration or at decorator time | Binding at first `_entries` access | Setup order irrelevant |
 
-### 12.3 `__init_subclass__` su BasePlugin
+### 12.3 `__init_subclass__` on BasePlugin
 
-| Pattern mainstream | Pattern genro-routes | Ragione |
-|--------------------|---------------------|---------|
-| Metaclass o ABC con metodi concreti | `__init_subclass__` wrappa `configure` | La firma = la schema, zero boilerplate |
+| Mainstream pattern | genro-routes pattern | Reason |
+|--------------------|----------------------|--------|
+| Metaclass or ABC with concrete methods | `__init_subclass__` wraps `configure` | The signature = the schema, zero boilerplate |
 
-### 12.4 `__setattr__` su RoutingClass
+### 12.4 `__setattr__` on RoutingClass
 
-| Pattern mainstream | Pattern genro-routes | Ragione |
-|--------------------|---------------------|---------|
-| Chiamata esplicita `detach()` | Auto-detach alla riassegnazione dell'attributo | GC implicito della gerarchia |
+| Mainstream pattern | genro-routes pattern | Reason |
+|--------------------|----------------------|--------|
+| Explicit `detach()` call | Auto-detach on attribute reassignment | Implicit GC of the hierarchy |
 
-### 12.5 `__getattr__` su Router
+### 12.5 `__getattr__` on Router
 
-| Pattern mainstream | Pattern genro-routes | Ragione |
-|--------------------|---------------------|---------|
-| `router.get_plugin("logging")` | `router.logging` | Sintassi naturale |
+| Mainstream pattern | genro-routes pattern | Reason |
+|--------------------|----------------------|--------|
+| `router.get_plugin("logging")` | `router.logging` | Natural syntax |
 
-### 12.6 `object.__setattr__` sparso nel codice
+### 12.6 `object.__setattr__` scattered through the code
 
-Usato per **bypassare** il `__setattr__` custom di RoutingClass quando
-si impostano attributi interni che non devono triggerare l'auto-detach.
-Lo vedrai in: `attach_instance`, `detach_instance`, `_register_router`,
-`capabilities.setter`, `_RoutingProxy.__init__`.
+Used to **bypass** RoutingClass's custom `__setattr__` when setting internal
+attributes that must not trigger the auto-detach. You will see it in:
+`attach_instance`, `_register_router`, the `ctx` and `capabilities` setters,
+`_RoutingProxy.__init__`, and in `base_router.py` inside `_include_router` and
+`detach_instance` (which set/clear `_routing_parent` on the owner).
 
-### 12.7 `safe_is_instance` con stringa
+### 12.7 `safe_is_instance` with a string
 
 ```python
 safe_is_instance(obj, "genro_routes.core.routing.RoutingClass")
 ```
 
-Type check tramite nome completo della classe anziché import diretto.
-Serve per rompere le dipendenze circolari tra `routing.py`,
-`base_router.py` e `router.py` che si referenziano mutualmente.
+Type check via the full class name instead of a direct import. It breaks the
+circular dependencies between `routing.py`, `base_router.py` and `router.py`,
+which reference each other.
 
-### 12.8 Name mangling intenzionale (`__entries_raw`)
+### 12.8 Intentional name mangling (`__entries_raw`)
 
-Attributo con doppio underscore per protezione. Router accede
-esplicitamente a `self._BaseRouter__entries_raw` quando serve
-l'accesso diretto senza triggerare il lazy binding.
+Double-underscore attribute for protection. Router explicitly accesses
+`self._BaseRouter__entries_raw` when it needs raw access without triggering
+lazy binding.
 
-### 12.9 Operations-first, non REST
+### 12.9 Operations-first, not REST
 
-| REST | genro-routes | Ragione |
-|------|-------------|---------|
-| `GET /users/{id}` | `node("get_user/42")()` | Il protocollo è un dettaglio del transport |
-| Verbo HTTP esplicito | Metodo HTTP inferito dalla firma | Agnostico al trasporto |
+| REST | genro-routes | Reason |
+|------|--------------|--------|
+| `GET /users/{id}` | `node("get_user/42")()` | The protocol is a transport detail |
+| Explicit HTTP verb | HTTP method inferred from the signature | Transport-agnostic |
 
-### 12.10 CapabilitiesSet con `dir()` e chiamata dinamica
+### 12.10 CapabilitiesSet with `dir()` and dynamic calls
 
-Un set il cui contenuto è calcolato a ogni iterazione chiamando i
-metodi marcati `@capability`. Non c'è equivalente nei framework web.
-Il pattern permette capability che cambiano a runtime (Redis va giù,
-una feature viene attivata, ecc.).
+A set whose content is computed on every iteration by calling the methods
+marked `@capability`. There is no equivalent in web frameworks. The pattern
+allows capabilities that change at runtime (Redis goes down, a feature gets
+activated, etc.).
 
 ---
 
-## 13. Il CLI adapter
+## 13. The CLI adapter
 
-**Package**: `cli/` (4 file, ~250 righe)
+**Package**: `cli/` (4 files, ~375 lines)
 
-Il CLI adapter è un **transport adapter** come genro-asgi, ma per la riga
-di comando. Data una RoutingClass, genera automaticamente un'interfaccia
-click completa con tab-completion, help e parametri tipizzati.
+The CLI adapter is a **transport adapter** like genro-asgi, but for the command
+line. Given a RoutingClass, it automatically generates a complete click
+interface with help and typed parameters.
 
 ```python
 from genro_routes.cli import RoutingCli
@@ -937,83 +1020,83 @@ cli = RoutingCli(MyService)
 cli.run()
 ```
 
-### Architettura interna
+### Internal architecture
 
-Il flusso è: **RoutingCli → CliBuilder → click.Group tree**.
+The flow is: **RoutingCli → CliBuilder → click.Group tree**.
 
-1. `RoutingCli` (`__init__.py`) — accetta una classe o un'istanza. Se
-   riceve una classe la istanzia senza argomenti. Delega a `CliBuilder`.
+1. `RoutingCli` (`__init__.py`) — accepts a class or an instance. If it
+   receives a class it instantiates it with no arguments. Delegates to
+   `CliBuilder`.
 
-2. `CliBuilder` (`_builder.py`) — chiama `router.nodes()` e percorre
-   ricorsivamente l'output:
-   - Un solo router → le entry diventano comandi diretti sul group root
-   - Più router → ogni router diventa un sotto-gruppo
-   - I child router (`routers` in nodes) diventano sotto-gruppi annidati
-   - I nomi vengono convertiti da `snake_case` a `kebab-case` (convenzione CLI)
+2. `CliBuilder` (`_builder.py`) — calls `instance.route.nodes()` and walks the
+   output recursively:
+   - Entries become commands on the root group
+   - Child routers (`routers` in nodes) become nested sub-groups
+   - Names are converted from `snake_case` to `kebab-case` (CLI convention)
 
-3. `ParamConverter` (`_type_map.py`) — mappa `inspect.Parameter` + type
-   hint a parametri click:
-   - Nessun default → `click.Argument` (posizionale)
-   - Con default → `click.Option` (`--nome`)
+3. `ParamConverter` (`_type_map.py`) — maps `inspect.Parameter` + type hints
+   to click parameters:
+   - No default → `click.Argument` (positional)
+   - With default → `click.Option` (`--name`)
    - `bool` → flag (`--verbose/--no-verbose`)
    - `Literal` / `Enum` → `click.Choice`
    - `list[X]` → `multiple=True`
-   - `dict` / tipi complessi → stringa JSON
+   - `dict` / complex types → JSON string
 
-4. `OutputFormatter` (`_formatters.py`) — formatta il valore di ritorno
-   dell'handler: `auto` (str diretto, JSON per dict/list), `json`,
-   `table` (rich se disponibile), `raw`.
+4. `OutputFormatter` (`_formatters.py`) — formats the handler's return value:
+   `auto` (plain str, JSON for dict/list), `json`, `table` (rich if available),
+   `raw`.
 
-### Scelte progettuali del CLI
+### CLI design choices
 
-- **Non è un plugin**: il CLI non aggiunge comportamento agli handler,
-  li invoca. È un adapter esterno come genro-asgi.
-- **click come dipendenza opzionale**: `pip install genro-routes[cli]`.
-  L'import di `genro_routes.cli` fallisce con `ImportError` se click
-  non è installato.
-- **Enum roundtrip**: click `Choice` restituisce stringhe. Il callback
-  riconverte le stringhe in membri Enum prima di invocare l'handler.
-- **Handler async**: rilevati con `inspect.iscoroutinefunction`,
-  invocati con `asyncio.run()`.
-
----
-
-## 14. Glossario rapido
-
-| Termine | Significato |
-|---------|-------------|
-| **Entry** | Un handler registrato con nome logico in un router |
-| **Router** | Contenitore di entry e child router, legato a un'istanza |
-| **RouterNode** | Wrapper callable restituito da `node()` |
-| **RoutingClass** | Mixin per classi che espongono router |
-| **Plugin** | Componente che aggiunge comportamento (logging, auth, ecc.) |
-| **Marker** | Attributo `_route_decorator_kw` su una funzione decorata |
-| **Lazy binding** | Il router scopre i marker al primo uso |
-| **Partial** | Segmenti di path non risolti, passati come argomenti |
-| **Branch router** | Router organizzativo senza handler diretti |
-| **Plugin store** | `Router._plugin_info` — configurazione per-plugin per-entry |
-| **CapabilitiesSet** | Set di feature flags dinamici valutati a runtime |
-| **Transport adapter** | Pacchetto esterno che mappa un protocollo a `node()` |
-| **RoutingCli** | CLI adapter built-in che genera comandi click da `nodes()` |
+- **Not a plugin**: the CLI does not add behavior to handlers, it invokes
+  them. It is an external adapter like genro-asgi.
+- **click as optional dependency**: `pip install genro-routes[cli]`. Importing
+  `genro_routes.cli` fails with `ImportError` if click is not installed.
+- **Enum roundtrip**: click `Choice` returns strings. The callback converts
+  strings back into Enum members before invoking the handler.
+- **Async handlers**: detected with `inspect.iscoroutinefunction`, invoked
+  with `asyncio.run()`.
 
 ---
 
-**Ordine di lettura consigliato dei file sorgente**:
+## 14. Quick glossary
 
-1. `core/decorators.py` — 88 righe, il punto di ingresso concettuale
-2. `core/router_interface.py` — 83 righe, il contratto
-3. `plugins/_base_plugin.py` — 380 righe, MethodEntry e BasePlugin
-4. `core/base_router.py` — 977 righe, il cuore (leggi i primi 500)
-5. `core/router_node.py` — 233 righe, come viene invocato un handler
-6. `core/routing.py` — 572 righe, il mixin e il proxy
-7. `core/router.py` — 549 righe, plugin pipeline
-8. I plugin in qualsiasi ordine
-9. `cli/__init__.py` → `cli/_builder.py` — il CLI adapter
+| Term | Meaning |
+|------|---------|
+| **Entry** | A handler registered with a logical name in a router |
+| **Router** | Container of entries and child routers, bound to an instance |
+| **RouterNode** | Callable wrapper returned by `node()` |
+| **RoutingClass** | Mixin for classes exposing a router (`route` property) |
+| **Section** | Empty RoutingClass used as a grouping node |
+| **Plugin** | Component adding behavior (logging, auth, ...) |
+| **Marker** | `_route_decorator_kw` attribute on a decorated function |
+| **Lazy binding** | The router discovers markers at first use |
+| **Partial** | Unresolved path segments, passed as arguments |
+| **endpoint_id** | Globally unique entry id for reverse lookup (`node("@id")`, `get_url`) |
+| **Plugin store** | `Router._plugin_info` — per-plugin per-entry configuration |
+| **CapabilitiesSet** | Set of dynamic feature flags evaluated at runtime |
+| **Transport adapter** | External package mapping a protocol to `node()` |
+| **RoutingCli** | Built-in CLI adapter generating click commands from `nodes()` |
 
-**Per i test**, inizia da:
+---
 
-- `test_router_basic.py` — uso base
-- `test_node_resolution.py` — come funziona la risoluzione dei path
-- `test_auth_plugin.py` — il sistema di autorizzazione
-- `test_env_plugin.py` — le capabilities dinamiche
-- `test_cli.py` — il CLI adapter
+**Recommended source reading order**:
+
+1. `core/decorators.py` — 78 lines, the conceptual entry point
+2. `core/router_interface.py` — 83 lines, the contract
+3. `plugins/_base_plugin.py` — 381 lines, MethodEntry and BasePlugin
+4. `core/base_router.py` — ~1050 lines, the core (read the first 500)
+5. `core/router_node.py` — 240 lines, how a handler gets invoked
+6. `core/routing.py` — 518 lines, the mixin, Section and the proxy
+7. `core/router.py` — 551 lines, the plugin pipeline
+8. The plugins, in any order
+9. `cli/__init__.py` → `cli/_builder.py` — the CLI adapter
+
+**For the tests**, start from:
+
+- `test_router_basic.py` — basic usage
+- `test_node_resolution.py` — how path resolution works
+- `test_auth_plugin.py` — the authorization system
+- `test_env_plugin.py` — dynamic capabilities
+- `test_cli.py` — the CLI adapter

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -14,23 +14,20 @@
 
 **Example**:
 ```python
-from genro_routes import RoutingClass, Router, route
+from genro_routes import RoutingClass, route
 
 class OrdersAPI(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="orders")
-
-    @route("orders")
+    @route()
     def list(self):
         return ["order-1", "order-2"]
 
-    @route("orders")
+    @route()
     def create(self, payload: dict):
         return {"status": "created", **payload}
 
 orders = OrdersAPI()
-orders.api.node("list")()  # Calls list()
-orders.api.node("create")({"name": "order-3"})  # Calls create()
+orders.route.node("list")()  # Calls list()
+orders.route.node("create")({"name": "order-3"})  # Calls create()
 ```
 
 ### Genro Routes vs function dictionary?
@@ -70,44 +67,43 @@ You can use Genro Routes **alongside** FastAPI to organize your internal handler
 1. **Registers handlers**: methods decorated with `@route()`
 2. **Resolves by name**: `router.node("method_name")` → callable RouterNode
 3. **Applies plugins**: intercepts decoration and execution
-4. **Is isolated per instance**: each object has its own router
+4. **Is isolated per instance**: every `RoutingClass` instance owns exactly one router, auto-created and exposed as the `route` property
 
 ```python
 class Service(RoutingClass):
     def __init__(self, label: str):
         self.label = label
-        self.api = Router(self, name="api")
 
-    @route("api")
+    @route()
     def info(self):
         return f"service:{self.label}"
 
 s1 = Service("alpha")
 s2 = Service("beta")
-s1.api.node("info")()  # "service:alpha"
-s2.api.node("info")()  # "service:beta"
+s1.route.node("info")()  # "service:alpha"
+s2.route.node("info")()  # "service:beta"
 ```
 
-Each instance (`s1`, `s2`) has a **separate and isolated** router.
+Each instance (`s1`, `s2`) has a **separate and isolated** router. You never call `Router(...)` yourself.
 
 ### How does the @route decorator work?
 
-**Question**: What does `@route("api")` exactly do?
+**Question**: What does `@route()` exactly do?
 
 <!-- test: test_router_basic.py::test_prefix_and_name_override -->
 
-**Answer**: The `@route("router_name")` decorator marks a method to be registered in a specific router. When you create the instance and call `Router(self, name="api")`, the router finds all methods marked with `@route("api")` and registers them automatically.
+**Answer**: The `@route()` decorator marks a method for registration on the class's single router. The router is created lazily on first access of `self.route` and automatically discovers all marked methods. All options are keyword-only.
 
 **Options**:
 ```python
-@route("api")  # Auto name (method name)
+@route()  # Auto name (method name)
 def list_users(self): ...
 
-@route("api", name="users")  # Explicit name
+@route(name="users")  # Explicit name
 def handle_users(self): ...
 
-# With Router(prefix="handle_")
-@route("api")
+# With self.route.prefix = "handle_" set in __init__
+@route()
 def handle_create(self): ...  # Registered as "create" (strips prefix)
 ```
 
@@ -115,13 +111,14 @@ def handle_create(self): ...  # Registered as "create" (strips prefix)
 
 **Question**: Do I always need to inherit from `RoutingClass`?
 
-**Answer**: **Recommended but not required**. `RoutingClass` provides:
+**Answer**: **Yes**. `RoutingClass` is the mixin that binds a class to its router:
 
-- `obj.routing` proxy to access all routers
-- `obj.routing.configure()` for global configuration
-- Automatic router registry management
+- `obj.route` — the instance's single router, created lazily (read-only property)
+- `obj.routing` — proxy for configuration and lookup (`configure()`, `get_router()`, `instance()`)
+- `obj.attach_instance(child, name=...)` — connects child instances into a hierarchy
+- `obj.ctx` — execution context with parent-chain lookup
 
-**Without RoutingClass** you can still use `Router` directly, but you lose the unified proxy.
+A `Router` can only be owned by a `RoutingClass` instance.
 
 ## Hierarchies and Child Routers
 
@@ -134,18 +131,25 @@ def handle_create(self): ...  # Registered as "create" (strips prefix)
 ```python
 class Dashboard(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api")
         self.sales = SalesModule()
         self.finance = FinanceModule()
 
-        # Attach child instances (1:1 shortcut — each child has a single router)
+        # Attach child instances — each child's router is linked under the alias
         self.attach_instance(self.sales, name="sales")
         self.attach_instance(self.finance, name="finance")
 
 dashboard = Dashboard()
 # Access with path separator
-dashboard.api.node("sales/report")()
-dashboard.api.node("finance/summary")()
+dashboard.route.node("sales/report")()
+dashboard.route.node("finance/summary")()
+```
+
+For a pure grouping level without a dedicated class, attach a `Section`:
+
+```python
+from genro_routes import Section
+
+dashboard.attach_instance(Section("Admin area"), name="admin")
 ```
 
 ### How do I access child routers?
@@ -155,13 +159,13 @@ dashboard.api.node("finance/summary")()
 **Answer**: Use **path separator** `/`:
 ```python
 # Path separator
-dashboard.api.node("sales/report")()
+dashboard.route.node("sales/report")()
 
 # Or direct access
-dashboard.sales.api.node("report")()
+dashboard.sales.route.node("report")()
 
 # Introspection
-nodes = dashboard.api.nodes()
+nodes = dashboard.route.nodes()
 # {
 #   "entries": {...},
 #   "routers": {
@@ -180,13 +184,13 @@ nodes = dashboard.api.nodes()
 ```python
 class Parent(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("logging", level="debug")
+        self.route.plug("logging")
         self.child_obj = Child()
         self.attach_instance(self.child_obj, name="child")
 
 # Child automatically inherits logging plugin
 parent = Parent()
-parent.api.node("child/method")()  # Logs with level=debug
+parent.route.node("child/method")()  # Logged via inherited plugin
 ```
 
 ## Plugin System
@@ -216,57 +220,61 @@ parent.api.node("child/method")()  # Logs with level=debug
 
 **1. LoggingPlugin** - Automatic logging
 ```python
-router = Router(self, name="api").plug("logging")
-router.node("method")()  # Auto-logs the call
+self.route.plug("logging")     # in __init__
+svc.route.node("method")()     # Auto-logs the call
 ```
 
 **2. PydanticPlugin** - Input validation + response schemas
 <!-- test: test_pydantic_plugin.py::test_pydantic_plugin_accepts_valid_input -->
 
 ```python
-@route("api")
+self.route.plug("pydantic")    # in __init__
+
+@route()
 def concat(self, text: str, number: int = 1) -> str:
     return f"{text}:{number}"
 
-router.plug("pydantic")
-router.node("concat")("hello", 3)    # OK → "hello:3"
-router.node("concat")(123, "oops")   # ValidationError
+svc.route.node("concat")("hello", 3)    # OK → "hello:3"
+svc.route.node("concat")(123, "oops")   # ValidationError
 
 # Response schema auto-generated from return type annotation
-router._entries["concat"].metadata["pydantic"]["response_schema"]
+svc.route._entries["concat"].metadata["pydantic"]["response_schema"]
 # {"type": "string"}
 ```
 
 **3. AuthPlugin** - Role-based access control
 ```python
-@route("api", auth_rule="admin")
+self.route.plug("auth")        # in __init__
+
+@route(auth_rule="admin")
 def admin_action(self):
     return "secret"
 
-router.plug("auth")
-router.node("admin_action", auth_tags="admin")()  # OK
-router.node("admin_action", auth_tags="guest")()  # NotAuthorized
+svc.route.node("admin_action", auth_tags="admin")()  # OK
+svc.route.node("admin_action", auth_tags="guest")()  # NotAuthorized
 ```
 
 **4. EnvPlugin** - Capability-based filtering
 
 ```python
-@route("api", env_requires="redis")
+self.route.plug("env")         # in __init__
+
+@route(env_requires="redis")
 def cached_action(self):
     return "cached"
 
-router.plug("env")
 # Entry only visible if instance has "redis" capability
 ```
 
 **5. OpenAPIPlugin** - Schema metadata and response schemas
 
 ```python
-@route("api", openapi_method="post", openapi_tags="users")
+self.route.plug("openapi")     # in __init__
+
+@route(openapi_method="post", openapi_tags="users")
 def create_user(self, name: str) -> dict:
     return {"name": name}
 
-router.plug("openapi")
 # Provides metadata for OpenAPI schema generation
 # Response schemas auto-included from return type annotations
 ```
@@ -281,15 +289,16 @@ router.plug("openapi")
 
 ```python
 # Global for all handlers
-obj.routing.configure("api:logging/_all_", level="warning")
+obj.routing.configure("logging/_all_", before=False)
 
 # For specific handler
-obj.routing.configure("api:logging/create", enabled=False)
+obj.routing.configure("logging/create", enabled=False)
 
 # With glob patterns
-obj.routing.configure("api:logging/admin_*", level="debug")
+obj.routing.configure("logging/admin_*", enabled=False)
 
-# Query configuration
+# Query configuration — returns the router description dict
+# (keys: name, plugins, entries, routers)
 report = obj.routing.configure("?")
 ```
 
@@ -316,9 +325,9 @@ class AuditPlugin(BasePlugin):
             return result
         return wrapper
 
-# Register and use
+# Register globally, then attach in __init__
 Router.register_plugin(AuditPlugin)
-router = Router(self, name="api").plug("audit")
+self.route.plug("audit")
 ```
 
 ## Advanced Use Cases
@@ -413,7 +422,7 @@ node()            # raises NotFound
 # Structure snapshot
 nodes = router.nodes()
 # {
-#   "name": "api",
+#   "name": "route",
 #   "router": <Router>,
 #   "instance": <owner>,
 #   "plugin_info": {...},
@@ -460,7 +469,7 @@ Different use cases: `singledispatch` for typed polymorphism, Genro Routes for d
 
 **Solution**: The plugin wasn't attached. Use `.plug()`:
 ```python
-router.plug("logging")  # Now router.logging exists
+self.route.plug("logging")  # Now self.route.logging exists
 ```
 
 ### "Handler name collision"
@@ -469,10 +478,10 @@ router.plug("logging")  # Now router.logging exists
 
 **Solution**: Use explicit names or prefixes:
 ```python
-@route("api", name="create_user")
+@route(name="create_user")
 def handle_create_user(self): ...
 
-@route("api", name="create_order")
+@route(name="create_order")
 def handle_create_order(self): ...
 ```
 
@@ -483,12 +492,12 @@ def handle_create_order(self): ...
 **Solution**: Make sure to attach plugins to the parent router **before** connecting children:
 ```python
 # CORRECT
-self.api = Router(self, name="api").plug("logging")
+self.route.plug("logging")
 self.attach_instance(child, name="child")  # Child inherits logging
 
 # WRONG
 self.attach_instance(child, name="child")
-self.api.plug("logging")  # Child does NOT inherit
+self.route.plug("logging")  # Child does NOT inherit
 ```
 
 ### ValidationError with Pydantic
@@ -497,9 +506,9 @@ self.api.plug("logging")  # Child does NOT inherit
 
 **Solution**: Verify:
 
-1. PydanticPlugin attached: `router.plug("pydantic")`
+1. PydanticPlugin attached: `self.route.plug("pydantic")`
 2. Type hint correct: `def method(self, req: MyModel)`
-3. Input is dict or model instance: `router.node("method")({"field": "value"})`
+3. Input is dict or model instance: `svc.route.node("method")({"field": "value"})`
 
 ## Best Practices
 
@@ -523,7 +532,7 @@ self.api.plug("logging")  # Child does NOT inherit
 
 **Answer**: **Yes**. Plugins are applied **in attachment order**:
 ```python
-router.plug("logging").plug("pydantic")
+self.route.plug("logging").plug("pydantic")
 # Execution: logging → pydantic → handler → pydantic → logging
 ```
 
@@ -543,7 +552,7 @@ def test_handler_logic():
 # Test via router
 def test_router_integration():
     obj = MyClass()
-    node = obj.api.node("my_handler")
+    node = obj.route.node("my_handler")
     assert node({"input": "test"}) == expected
 ```
 
@@ -556,13 +565,10 @@ def test_router_integration():
 **Answer**: Use `RoutingContext`. The adapter creates a context, attaches what it needs, and sets it on any `RoutingClass` instance. All handlers read it via `self.ctx`:
 
 ```python
-from genro_routes import RoutingClass, RoutingContext, Router, route
+from genro_routes import RoutingClass, RoutingContext, route
 
 class OrderService(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="api")
-
-    @route("api")
+    @route()
     def list_orders(self):
         return self.ctx.db.query("SELECT * FROM orders")
 

--- a/docs/genro-routes-for-dummies.html
+++ b/docs/genro-routes-for-dummies.html
@@ -350,7 +350,7 @@
 pip install genro-routes[pydantic] <span class="cmt"># With validation support</span></code></pre>
 
 <h3>Write your service</h3>
-<pre><code><span class="kw">from</span> genro_routes <span class="kw">import</span> <span class="cls">RoutingClass</span>, <span class="cls">Router</span>, <span class="fn">route</span>
+<pre><code><span class="kw">from</span> genro_routes <span class="kw">import</span> <span class="cls">RoutingClass</span>, <span class="fn">route</span>
 
 <span class="kw">class</span> <span class="cls">BookStore</span>(<span class="cls">RoutingClass</span>):
     <span class="kw">def</span> <span class="fn">__init__</span>(self):
@@ -358,44 +358,45 @@ pip install genro-routes[pydantic] <span class="cmt"># With validation support</
             {<span class="str">"id"</span>: <span class="num">1</span>, <span class="str">"title"</span>: <span class="str">"Dune"</span>, <span class="str">"author"</span>: <span class="str">"Herbert"</span>},
             {<span class="str">"id"</span>: <span class="num">2</span>, <span class="str">"title"</span>: <span class="str">"Neuromancer"</span>, <span class="str">"author"</span>: <span class="str">"Gibson"</span>},
         ]
-        self.api = <span class="cls">Router</span>(self, name=<span class="str">"api"</span>)
 
-    <span class="dec">@route</span>(<span class="str">"api"</span>)
+    <span class="dec">@route</span>()
     <span class="kw">def</span> <span class="fn">list_books</span>(self):
         <span class="kw">return</span> self.catalog
 
-    <span class="dec">@route</span>(<span class="str">"api"</span>)
+    <span class="dec">@route</span>()
     <span class="kw">def</span> <span class="fn">find_book</span>(self, book_id: <span class="cls">int</span>):
         <span class="kw">return</span> next((b <span class="kw">for</span> b <span class="kw">in</span> self.catalog <span class="kw">if</span> b[<span class="str">"id"</span>] == book_id), <span class="kw">None</span>)
 
-    <span class="dec">@route</span>(<span class="str">"api"</span>)
+    <span class="dec">@route</span>()
     <span class="kw">def</span> <span class="fn">add_book</span>(self, title: <span class="cls">str</span>, author: <span class="cls">str</span>):
         book = {<span class="str">"id"</span>: len(self.catalog) + <span class="num">1</span>, <span class="str">"title"</span>: title, <span class="str">"author"</span>: author}
         self.catalog.append(book)
         <span class="kw">return</span> book</code></pre>
 
+<p class="dim">Every <code class="il">RoutingClass</code> owns exactly one router, created automatically and exposed as <code class="il">self.route</code> &mdash; you never instantiate it yourself.</p>
+
 <h3>Call it directly &mdash; no server needed</h3>
 <pre><code>store = <span class="cls">BookStore</span>()
 
-store.api.node(<span class="str">"list_books"</span>)()              <span class="cmt"># [{"id": 1, ...}, {"id": 2, ...}]</span>
-store.api.node(<span class="str">"find_book"</span>)(book_id=<span class="num">1</span>)      <span class="cmt"># {"id": 1, "title": "Dune", ...}</span>
-store.api.node(<span class="str">"add_book"</span>)(title=<span class="str">"Snow Crash"</span>, author=<span class="str">"Stephenson"</span>)
+store.route.node(<span class="str">"list_books"</span>)()              <span class="cmt"># [{"id": 1, ...}, {"id": 2, ...}]</span>
+store.route.node(<span class="str">"find_book"</span>)(book_id=<span class="num">1</span>)      <span class="cmt"># {"id": 1, "title": "Dune", ...}</span>
+store.route.node(<span class="str">"add_book"</span>)(title=<span class="str">"Snow Crash"</span>, author=<span class="str">"Stephenson"</span>)
 
 <span class="cmt"># Introspect all registered handlers</span>
-info = store.api.nodes()
+info = store.route.nodes()
 print(info[<span class="str">"entries"</span>].keys())  <span class="cmt"># dict_keys(['list_books', 'find_book', 'add_book'])</span></code></pre>
 
 <h3>Test it &mdash; this is your entire test</h3>
 <pre><code><span class="kw">def</span> <span class="fn">test_find_book</span>():
     store = <span class="cls">BookStore</span>()
-    result = store.api.node(<span class="str">"find_book"</span>)(book_id=<span class="num">1</span>)
+    result = store.route.node(<span class="str">"find_book"</span>)(book_id=<span class="num">1</span>)
     <span class="kw">assert</span> result[<span class="str">"title"</span>] == <span class="str">"Dune"</span>
 
 <span class="kw">def</span> <span class="fn">test_add_book</span>():
     store = <span class="cls">BookStore</span>()
-    book = store.api.node(<span class="str">"add_book"</span>)(title=<span class="str">"Snow Crash"</span>, author=<span class="str">"Stephenson"</span>)
+    book = store.route.node(<span class="str">"add_book"</span>)(title=<span class="str">"Snow Crash"</span>, author=<span class="str">"Stephenson"</span>)
     <span class="kw">assert</span> book[<span class="str">"id"</span>] == <span class="num">3</span>
-    <span class="kw">assert</span> len(store.api.node(<span class="str">"list_books"</span>)()) == <span class="num">3</span></code></pre>
+    <span class="kw">assert</span> len(store.route.node(<span class="str">"list_books"</span>)()) == <span class="num">3</span></code></pre>
 
 <div class="callout">
 <p><strong>No HTTP client, no mock server, no fixtures.</strong> Your tests call the same methods your HTTP adapter will call. If the test passes, the API works.</p>
@@ -408,9 +409,9 @@ print(info[<span class="str">"entries"</span>].keys())  <span class="cmt"># dict
 store = <span class="cls">BookStore</span>()
 app = <span class="cls">GenroASGI</span>(store)  <span class="cmt"># That's it. uvicorn app:app</span>
 
-<span class="cmt"># GET  /api/list_books     &rarr; [{"id": 1, ...}]</span>
-<span class="cmt"># GET  /api/find_book?book_id=1  &rarr; {"id": 1, "title": "Dune"}</span>
-<span class="cmt"># POST /api/add_book       &rarr; {"id": 3, ...}</span></code></pre>
+<span class="cmt"># GET  /list_books     &rarr; [{"id": 1, ...}]</span>
+<span class="cmt"># GET  /find_book?book_id=1  &rarr; {"id": 1, "title": "Dune"}</span>
+<span class="cmt"># POST /add_book       &rarr; {"id": 3, ...}</span></code></pre>
 
 <p class="dim">Same BookStore, same logic, zero changes. The ASGI adapter maps router entries to HTTP endpoints, infers GET/POST from parameter types, and handles serialization.</p>
 
@@ -442,7 +443,7 @@ app = <span class="cls">GenroASGI</span>(store)  <span class="cmt"># That's it. 
   <line x1="370" y1="60" x2="405" y2="60" stroke="#8b90a0" stroke-width="1" marker-end="url(#a2)"/>
   <line x1="495" y1="60" x2="530" y2="60" stroke="#8b90a0" stroke-width="1" marker-end="url(#a2)"/>
   <text x="350" y="20" text-anchor="middle" fill="#8b90a0" font-size="10">Plugin pipeline &mdash; each handler passes through all attached plugins</text>
-  <text x="350" y="110" text-anchor="middle" fill="#8b90a0" font-size="10">Attach: <tspan fill="#6c9eff">Router(self, name="api").plug("pydantic").plug("auth")</tspan></text>
+  <text x="350" y="110" text-anchor="middle" fill="#8b90a0" font-size="10">Attach: <tspan fill="#6c9eff">self.route.plug("pydantic").plug("auth")</tspan></text>
   <defs><marker id="a2" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="6" markerHeight="6" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" fill="#8b90a0"/></marker></defs>
 </svg>
 </div>
@@ -450,15 +451,15 @@ app = <span class="cls">GenroASGI</span>(store)  <span class="cmt"># That's it. 
 <h3>Three ways to configure</h3>
 
 <p><strong>1. In the decorator</strong> &mdash; static, per-handler</p>
-<pre><code><span class="dec">@route</span>(<span class="str">"api"</span>, auth_rule=<span class="str">"admin"</span>, pydantic_disabled=<span class="kw">True</span>)</code></pre>
+<pre><code><span class="dec">@route</span>(auth_rule=<span class="str">"admin"</span>, pydantic_disabled=<span class="kw">True</span>)</code></pre>
 
 <p><strong>2. On the plugin instance</strong> &mdash; runtime, global or targeted</p>
 <pre><code>router.auth.configure(rule=<span class="str">"user"</span>)                          <span class="cmt"># All handlers</span>
 router.auth.configure(_target=<span class="str">"admin_panel"</span>, rule=<span class="str">"admin"</span>)   <span class="cmt"># One handler</span></code></pre>
 
 <p><strong>3. Via the routing proxy</strong> &mdash; wildcards and introspection</p>
-<pre><code>svc.routing.configure(<span class="str">"api:auth/admin_*"</span>, rule=<span class="str">"admin"</span>)  <span class="cmt"># Glob pattern</span>
-svc.routing.configure(<span class="str">"?"</span>)                              <span class="cmt"># Show full config tree</span></code></pre>
+<pre><code>svc.routing.configure(<span class="str">"auth/admin_*"</span>, rule=<span class="str">"admin"</span>)  <span class="cmt"># Glob pattern</span>
+svc.routing.configure(<span class="str">"?"</span>)                          <span class="cmt"># Show full config tree</span></code></pre>
 
 <h3>At a glance</h3>
 <table>
@@ -491,39 +492,39 @@ svc.routing.configure(<span class="str">"?"</span>)                             
 <h3>What happens at runtime</h3>
 <pre><code><span class="kw">class</span> <span class="cls">API</span>(<span class="cls">RoutingClass</span>):
     <span class="kw">def</span> <span class="fn">__init__</span>(self):
-        self.api = <span class="cls">Router</span>(self, name=<span class="str">"api"</span>).plug(<span class="str">"auth"</span>)
+        self.route.plug(<span class="str">"auth"</span>)
 
-    <span class="dec">@route</span>(<span class="str">"api"</span>, auth_rule=<span class="str">"admin"</span>)
+    <span class="dec">@route</span>(auth_rule=<span class="str">"admin"</span>)
     <span class="kw">def</span> <span class="fn">delete_user</span>(self, user_id: <span class="cls">int</span>): ...
 
-    <span class="dec">@route</span>(<span class="str">"api"</span>)                       <span class="cmt"># No rule = public</span>
+    <span class="dec">@route</span>()                       <span class="cmt"># No rule = public</span>
     <span class="kw">def</span> <span class="fn">health</span>(self): ...
 
 svc = <span class="cls">API</span>()
 
 <span class="cmt"># Authorized &mdash; works</span>
-svc.api.node(<span class="str">"delete_user"</span>, auth_tags=<span class="str">"admin"</span>)(user_id=<span class="num">42</span>)
+svc.route.node(<span class="str">"delete_user"</span>, auth_tags=<span class="str">"admin"</span>)(user_id=<span class="num">42</span>)
 
 <span class="cmt"># Wrong tags &mdash; raises NotAuthorized (403)</span>
-svc.api.node(<span class="str">"delete_user"</span>, auth_tags=<span class="str">"guest"</span>)
+svc.route.node(<span class="str">"delete_user"</span>, auth_tags=<span class="str">"guest"</span>)
 
 <span class="cmt"># No tags at all &mdash; raises NotAuthenticated (401)</span>
-svc.api.node(<span class="str">"delete_user"</span>)
+svc.route.node(<span class="str">"delete_user"</span>)
 
 <span class="cmt"># Public handler &mdash; always works</span>
-svc.api.node(<span class="str">"health"</span>)()</code></pre>
+svc.route.node(<span class="str">"health"</span>)()</code></pre>
 
 <h3>Filtered introspection</h3>
 <pre><code><span class="cmt"># nodes() shows only what the user can access:</span>
-svc.api.nodes(auth_tags=<span class="str">"admin"</span>)            <span class="cmt"># Sees: delete_user, health</span>
-svc.api.nodes(auth_tags=<span class="str">"guest"</span>)            <span class="cmt"># Sees: health only</span>
-svc.api.nodes()                            <span class="cmt"># Sees: health only (no tags = no access)</span></code></pre>
+svc.route.nodes(auth_tags=<span class="str">"admin"</span>)            <span class="cmt"># Sees: delete_user, health</span>
+svc.route.nodes(auth_tags=<span class="str">"guest"</span>)            <span class="cmt"># Sees: health only</span>
+svc.route.nodes()                            <span class="cmt"># Sees: health only (no tags = no access)</span></code></pre>
 
 <h3>Rule expressions</h3>
-<pre><code><span class="dec">@route</span>(<span class="str">"api"</span>, auth_rule=<span class="str">"admin|moderator"</span>)     <span class="cmt"># Admin OR moderator</span>
-<span class="dec">@route</span>(<span class="str">"api"</span>, auth_rule=<span class="str">"admin&amp;internal"</span>)      <span class="cmt"># Admin AND internal</span>
-<span class="dec">@route</span>(<span class="str">"api"</span>, auth_rule=<span class="str">"!guest"</span>)              <span class="cmt"># NOT guest</span>
-<span class="dec">@route</span>(<span class="str">"api"</span>, auth_rule=<span class="str">"(admin|mod)&amp;!banned"</span>) <span class="cmt"># Grouping</span></code></pre>
+<pre><code><span class="dec">@route</span>(auth_rule=<span class="str">"admin|moderator"</span>)     <span class="cmt"># Admin OR moderator</span>
+<span class="dec">@route</span>(auth_rule=<span class="str">"admin&amp;internal"</span>)      <span class="cmt"># Admin AND internal</span>
+<span class="dec">@route</span>(auth_rule=<span class="str">"!guest"</span>)              <span class="cmt"># NOT guest</span>
+<span class="dec">@route</span>(auth_rule=<span class="str">"(admin|mod)&amp;!banned"</span>) <span class="cmt"># Grouping</span></code></pre>
 
 <table>
   <tr><th>Operator</th><th>Meaning</th><th>Example</th></tr>
@@ -563,19 +564,19 @@ svc.api.nodes()                            <span class="cmt"># Sees: health only
 
 <span class="kw">class</span> <span class="cls">API</span>(<span class="cls">RoutingClass</span>):
     <span class="kw">def</span> <span class="fn">__init__</span>(self):
-        self.api = <span class="cls">Router</span>(self, name=<span class="str">"api"</span>).plug(<span class="str">"pydantic"</span>)
+        self.route.plug(<span class="str">"pydantic"</span>)
 
-    <span class="dec">@route</span>(<span class="str">"api"</span>)
+    <span class="dec">@route</span>()
     <span class="kw">def</span> <span class="fn">get_book</span>(self, book_id: <span class="cls">int</span>) -> <span class="cls">BookResponse</span>:
         <span class="kw">return</span> {<span class="str">"id"</span>: book_id, <span class="str">"title"</span>: <span class="str">"Dune"</span>, <span class="str">"author"</span>: <span class="str">"Herbert"</span>}
 
 svc = <span class="cls">API</span>()
-svc.api.node(<span class="str">"get_book"</span>)(book_id=<span class="num">1</span>)       <span class="cmt"># OK &rarr; {"id": 1, ...}</span>
-svc.api.node(<span class="str">"get_book"</span>)(book_id=<span class="str">"abc"</span>)   <span class="cmt"># ValidationError!</span></code></pre>
+svc.route.node(<span class="str">"get_book"</span>)(book_id=<span class="num">1</span>)       <span class="cmt"># OK &rarr; {"id": 1, ...}</span>
+svc.route.node(<span class="str">"get_book"</span>)(book_id=<span class="str">"abc"</span>)   <span class="cmt"># ValidationError!</span></code></pre>
 
 <h3>Response schema for free</h3>
 <pre><code><span class="cmt"># The return type annotation auto-generates a JSON Schema:</span>
-entry = svc.api._entries[<span class="str">"get_book"</span>]
+entry = svc.route._entries[<span class="str">"get_book"</span>]
 schema = entry.metadata[<span class="str">"pydantic"</span>][<span class="str">"response_schema"</span>]
 <span class="cmt"># {"type": "object", "properties": {"id": {"type": "integer"}, ...}}</span>
 
@@ -584,7 +585,7 @@ schema = entry.metadata[<span class="str">"pydantic"</span>][<span class="str">"
 <p><strong>Supported return types:</strong> TypedDict, dataclass, dict, list, str, int, bool, Pydantic models &mdash; anything Pydantic can serialize.</p>
 
 <h3>Skip validation for a handler</h3>
-<pre><code><span class="dec">@route</span>(<span class="str">"api"</span>, pydantic_disabled=<span class="kw">True</span>)
+<pre><code><span class="dec">@route</span>(pydantic_disabled=<span class="kw">True</span>)
 <span class="kw">def</span> <span class="fn">raw_handler</span>(self, data): ...  <span class="cmt"># No validation, no schema</span></code></pre>
 
 <h3>Parameters</h3>
@@ -607,20 +608,20 @@ schema = entry.metadata[<span class="str">"pydantic"</span>][<span class="str">"
 
 <p>Controls OpenAPI 3.1 schema generation. Overrides HTTP methods, adds tags, marks deprecated. Integrates with auth + env + pydantic automatically.</p>
 
-<pre><code>self.api = <span class="cls">Router</span>(self, name=<span class="str">"api"</span>).plug(<span class="str">"openapi"</span>).plug(<span class="str">"auth"</span>).plug(<span class="str">"pydantic"</span>)
+<pre><code>self.route.plug(<span class="str">"openapi"</span>).plug(<span class="str">"auth"</span>).plug(<span class="str">"pydantic"</span>)
 
-<span class="dec">@route</span>(<span class="str">"api"</span>, auth_rule=<span class="str">"admin"</span>,
+<span class="dec">@route</span>(auth_rule=<span class="str">"admin"</span>,
        openapi_tags=<span class="str">"admin"</span>,
        openapi_deprecated=<span class="kw">True</span>,
        openapi_method=<span class="str">"delete"</span>)
 <span class="kw">def</span> <span class="fn">remove_item</span>(self, item_id: <span class="cls">int</span>): ...
 
-<span class="cmt"># Generate full spec:</span>
-spec = svc.api.nodes(mode=<span class="str">"openapi"</span>)
+<span class="cmt"># Generate full spec (auth_tags to include protected handlers):</span>
+spec = svc.route.nodes(mode=<span class="str">"openapi"</span>, auth_tags=<span class="str">"admin"</span>)
 <span class="cmt"># {"paths": {"/remove_item": {"delete": {"security": [...], ...}}}}</span>
 
 <span class="cmt"># Or hierarchical (preserves router tree):</span>
-spec = svc.api.nodes(mode=<span class="str">"h_openapi"</span>)</code></pre>
+spec = svc.route.nodes(mode=<span class="str">"h_openapi"</span>, auth_tags=<span class="str">"admin"</span>)</code></pre>
 
 <h3>Auto-inference</h3>
 <p>Without explicit <code class="il">method</code>: <strong>GET</strong> for scalar-only params (str, int, bool), <strong>POST</strong> for complex params (dict, list, models).</p>
@@ -673,21 +674,21 @@ spec = svc.api.nodes(mode=<span class="str">"h_openapi"</span>)</code></pre>
 
 <span class="kw">class</span> <span class="cls">PaymentAPI</span>(<span class="cls">RoutingClass</span>):
     <span class="kw">def</span> <span class="fn">__init__</span>(self):
-        self.api = <span class="cls">Router</span>(self, name=<span class="str">"api"</span>).plug(<span class="str">"env"</span>)
+        self.route.plug(<span class="str">"env"</span>)
         self.capabilities = <span class="cls">SystemCaps</span>()
 
-    <span class="dec">@route</span>(<span class="str">"api"</span>, env_requires=<span class="str">"redis"</span>)
+    <span class="dec">@route</span>(env_requires=<span class="str">"redis"</span>)
     <span class="kw">def</span> <span class="fn">cached_lookup</span>(self): ...        <span class="cmt"># Visible (redis available)</span>
 
-    <span class="dec">@route</span>(<span class="str">"api"</span>, env_requires=<span class="str">"stripe|paypal"</span>)
+    <span class="dec">@route</span>(env_requires=<span class="str">"stripe|paypal"</span>)
     <span class="kw">def</span> <span class="fn">charge</span>(self): ...                <span class="cmt"># Hidden (neither available)</span>
 
 svc = <span class="cls">PaymentAPI</span>()
-svc.api.nodes()  <span class="cmt"># Shows cached_lookup only. charge is invisible.</span>
-svc.api.node(<span class="str">"charge"</span>)()  <span class="cmt"># Raises NotAvailable!</span>
+svc.route.nodes()  <span class="cmt"># Shows cached_lookup only. charge is invisible.</span>
+svc.route.node(<span class="str">"charge"</span>)()  <span class="cmt"># Raises NotAvailable!</span>
 
 <span class="cmt"># Provide capabilities at request time:</span>
-svc.api.node(<span class="str">"charge"</span>, env_capabilities=<span class="str">"stripe"</span>)()  <span class="cmt"># Now works</span></code></pre>
+svc.route.node(<span class="str">"charge"</span>, env_capabilities=<span class="str">"stripe"</span>)()  <span class="cmt"># Now works</span></code></pre>
 
 <p><strong>Same rule syntax as auth:</strong> <code class="il">|</code> OR, <code class="il">&amp;</code> AND, <code class="il">!</code> NOT, <code class="il">()</code> grouping.</p>
 <p><strong>Accumulation:</strong> Capabilities from parent instances are inherited. Request-time capabilities add to the set.</p>
@@ -713,9 +714,9 @@ svc.api.node(<span class="str">"charge"</span>, env_capabilities=<span class="st
 
 <p>Wraps handler calls with timing. Logs "start" before and "end (X ms)" after. Useful for debugging and monitoring.</p>
 
-<pre><code>self.api = <span class="cls">Router</span>(self, name=<span class="str">"api"</span>).plug(<span class="str">"logging"</span>)
+<pre><code>self.route.plug(<span class="str">"logging"</span>)
 
-<span class="dec">@route</span>(<span class="str">"api"</span>)
+<span class="dec">@route</span>()
 <span class="kw">def</span> <span class="fn">slow_op</span>(self):
     time.sleep(<span class="num">0.1</span>)
     <span class="kw">return</span> <span class="str">"done"</span>
@@ -725,13 +726,13 @@ svc.api.node(<span class="str">"charge"</span>, env_capabilities=<span class="st
 <span class="cmt">#   slow_op end (100.45 ms)</span></code></pre>
 
 <h3>Fine-grained control</h3>
-<pre><code><span class="dec">@route</span>(<span class="str">"api"</span>, logging_flags=<span class="str">"before,after:off"</span>)  <span class="cmt"># Start only, skip timing</span>
+<pre><code><span class="dec">@route</span>(logging_flags=<span class="str">"before,after:off"</span>)  <span class="cmt"># Start only, skip timing</span>
 <span class="kw">def</span> <span class="fn">fast_op</span>(self): ...
 
 <span class="cmt"># At runtime:</span>
-router.logging.configure(enabled=<span class="kw">False</span>)                    <span class="cmt"># Silence all</span>
-router.logging.configure(_target=<span class="str">"slow_op"</span>, after=<span class="kw">True</span>)    <span class="cmt"># Re-enable one</span>
-router.logging.configure(print=<span class="kw">True</span>)                       <span class="cmt"># Force print()</span></code></pre>
+svc.route.logging.configure(enabled=<span class="kw">False</span>)                    <span class="cmt"># Silence all</span>
+svc.route.logging.configure(_target=<span class="str">"slow_op"</span>, after=<span class="kw">True</span>)    <span class="cmt"># Re-enable one</span>
+svc.route.logging.configure(print=<span class="kw">True</span>)                       <span class="cmt"># Force print()</span></code></pre>
 
 <h3>Parameters</h3>
 <table>
@@ -760,7 +761,7 @@ router.logging.configure(print=<span class="kw">True</span>)                    
 <svg viewBox="0 0 680 280" xmlns="http://www.w3.org/2000/svg" font-family="Inter, sans-serif">
   <rect x="240" y="10" width="200" height="50" rx="10" fill="#232733" stroke="#6c9eff" stroke-width="1.5"/>
   <text x="340" y="32" text-anchor="middle" fill="#6c9eff" font-size="12" font-weight="600">App</text>
-  <text x="340" y="48" text-anchor="middle" fill="#8b90a0" font-size="9">Router: api (branch) + auth plugin</text>
+  <text x="340" y="48" text-anchor="middle" fill="#8b90a0" font-size="9">route property + auth plugin</text>
   <rect x="40" y="110" width="170" height="50" rx="10" fill="#232733" stroke="#4ade80" stroke-width="1.2"/>
   <text x="125" y="132" text-anchor="middle" fill="#4ade80" font-size="11" font-weight="600">UsersService</text>
   <text x="125" y="148" text-anchor="middle" fill="#8b90a0" font-size="9">list_users, create_user</text>
@@ -778,15 +779,15 @@ router.logging.configure(print=<span class="kw">True</span>)                    
   <text x="500" y="80" text-anchor="middle" fill="#8b90a0" font-size="9">"notify"</text>
   <rect x="40" y="195" width="600" height="72" rx="10" fill="#1a1d27" stroke="#2d3140" stroke-width="1"/>
   <text x="60" y="216" fill="#8b90a0" font-size="10">Path resolution:</text>
-  <text x="60" y="235" fill="#4ade80" font-size="10.5" font-family="JetBrains Mono, monospace">app.api.node("users/list_users")()</text>
-  <text x="60" y="252" fill="#a78bfa" font-size="10.5" font-family="JetBrains Mono, monospace">app.api.node("orders/approve_order")(order_id="123")</text>
+  <text x="60" y="235" fill="#4ade80" font-size="10.5" font-family="JetBrains Mono, monospace">app.route.node("users/list_users")()</text>
+  <text x="60" y="252" fill="#a78bfa" font-size="10.5" font-family="JetBrains Mono, monospace">app.route.node("orders/approve_order")(order_id="123")</text>
   <defs><marker id="a3" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="6" markerHeight="6" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" fill="#8b90a0"/></marker></defs>
 </svg>
 </div>
 
 <pre><code><span class="kw">class</span> <span class="cls">App</span>(<span class="cls">RoutingClass</span>):
     <span class="kw">def</span> <span class="fn">__init__</span>(self):
-        self.api = <span class="cls">Router</span>(self, name=<span class="str">"api"</span>, branch=<span class="kw">True</span>).plug(<span class="str">"auth"</span>)
+        self.route.plug(<span class="str">"auth"</span>)
 
         self.users = <span class="cls">UsersService</span>()
         self.orders = <span class="cls">OrdersService</span>()
@@ -797,24 +798,24 @@ router.logging.configure(print=<span class="kw">True</span>)                    
         self.attach_instance(self.notify, name=<span class="str">"notify"</span>)
 
 app = <span class="cls">App</span>()
-app.api.node(<span class="str">"users/list_users"</span>)()
-app.api.node(<span class="str">"orders/approve_order"</span>)(order_id=<span class="str">"123"</span>)
+app.route.node(<span class="str">"users/list_users"</span>)()
+app.route.node(<span class="str">"orders/approve_order"</span>)(order_id=<span class="str">"123"</span>)
 
 <span class="cmt"># Introspect the entire tree:</span>
-tree = app.api.nodes()
+tree = app.route.nodes()
 print(tree[<span class="str">"routers"</span>].keys())  <span class="cmt"># dict_keys(['users', 'orders', 'notify'])</span></code></pre>
 
 <div class="callout">
-<p><strong>Auth plugin was plugged once on App.api.</strong> All three child services inherit it automatically. UsersService, OrdersService, and NotifyService know nothing about auth &mdash; it's managed at the root.</p>
+<p><strong>Auth plugin was plugged once on App's router.</strong> All three child services inherit it automatically. UsersService, OrdersService, and NotifyService know nothing about auth &mdash; it's managed at the root.</p>
 </div>
 
 <h3>Composition features</h3>
 <ul>
-  <li><code class="il">branch=True</code> &mdash; pure namespace, no handlers at root level</li>
-  <li><code class="il">prefix="handle_"</code> &mdash; strip method prefixes (<code class="il">handle_list</code> &rarr; entry <code class="il">list</code>)</li>
+  <li><code class="il">Section("Admin area")</code> &mdash; pure grouping node, no handlers; attach it like any child instance</li>
+  <li><code class="il">self.route.prefix = "handle_"</code> &mdash; strip method prefixes (<code class="il">handle_list</code> &rarr; entry <code class="il">list</code>)</li>
   <li>Auto-detach on attribute replacement &mdash; swap child services at runtime</li>
   <li>Dotted path resolution &mdash; <code class="il">"users/list_users"</code> walks the tree</li>
-  <li><code class="il">routing.instance("api/users")</code> &mdash; retrieve any attached child instance without storing it as an attribute</li>
+  <li><code class="il">routing.instance("users")</code> &mdash; retrieve any attached child instance without storing it as an attribute</li>
 </ul>
 
 </div>
@@ -895,7 +896,7 @@ request_ctx.user = request.state.user</code></pre>
 svc.ctx = request_ctx
 
 <span class="cmt"># Every handler reads it (walks parent chain)</span>
-<span class="kw">@route</span>(<span class="str">"api"</span>)
+<span class="kw">@route</span>()
 <span class="kw">def</span> <span class="fn">list_orders</span>(self):
     db = self.ctx.db        <span class="cmt"># from request_ctx (local)</span>
     user = self.ctx.user    <span class="cmt"># from request_ctx (local)</span>
@@ -927,20 +928,19 @@ svc.ctx = <span class="kw">None</span></code></pre>
 <h3>Minimal Script</h3>
 
 <pre><code class="language-python">#!/usr/bin/env python
-from genro_routes import RoutingClass, Router, route
+from genro_routes import RoutingClass, route
 from genro_routes.cli import RoutingCli
 
 class OrdersAPI(RoutingClass):
     def __init__(self, label: str):
         self.label = label
-        self.api = Router(self, name="orders")
 
-    @route("orders")
+    @route()
     def list(self):
         """List all orders."""
         return ["order-1", "order-2"]
 
-    @route("orders")
+    @route()
     def retrieve(self, ident: str):
         """Retrieve a single order."""
         return f"{self.label}:{ident}"
@@ -971,7 +971,7 @@ Usage: ordersapi retrieve [OPTIONS] IDENT
 
 <table>
   <tr><th>genro-routes concept</th><th>CLI equivalent</th></tr>
-  <tr><td>Router</td><td>Command group (subcommand namespace)</td></tr>
+  <tr><td>The instance's router (<code class="il">route</code>)</td><td>Root command group</td></tr>
   <tr><td>Handler (entry)</td><td>Command</td></tr>
   <tr><td>Parameter without default</td><td>Positional argument</td></tr>
   <tr><td>Parameter with default</td><td><code class="il">--option</code></td></tr>
@@ -983,16 +983,15 @@ Usage: ordersapi retrieve [OPTIONS] IDENT
   <tr><td>Handler docstring</td><td>Command help text</td></tr>
 </table>
 
-<h3>Multiple Routers</h3>
+<h3>Nested Commands</h3>
 
-<p>With a single router, entries are commands at root level. With multiple routers, each becomes a sub-group:</p>
+<p>Entries on the class's router are commands at root level. Attached child services become sub-groups:</p>
 
-<pre><code class="language-bash"># Single router:
+<pre><code class="language-bash"># Root handlers:
 $ myapp list
 $ myapp retrieve 42
 
-# Multiple routers:
-$ myapp api list
+# Attached child ("admin"):
 $ myapp admin reset</code></pre>
 
 <h3>Tab Completion</h3>
@@ -1045,24 +1044,24 @@ cli = RoutingCli(svc)</code></pre>
 <h3>Essentials</h3>
 <table>
   <tr><th>I want to...</th><th>Code</th></tr>
-  <tr><td>Create a router on my class</td><td><code class="il">self.api = Router(self, name="api")</code></td></tr>
-  <tr><td>Register a handler</td><td><code class="il">@route("api") def my_handler(self): ...</code></td></tr>
-  <tr><td>Call a handler by name</td><td><code class="il">svc.api.node("my_handler")(arg1, arg2)</code></td></tr>
-  <tr><td>See all available handlers</td><td><code class="il">svc.api.nodes()</code></td></tr>
-  <tr><td>Get OpenAPI for the whole router</td><td><code class="il">svc.api.nodes(mode="openapi")</code></td></tr>
+  <tr><td>Get my class's router (auto-created)</td><td><code class="il">self.route</code></td></tr>
+  <tr><td>Register a handler</td><td><code class="il">@route() def my_handler(self): ...</code></td></tr>
+  <tr><td>Call a handler by name</td><td><code class="il">svc.route.node("my_handler")(arg1, arg2)</code></td></tr>
+  <tr><td>See all available handlers</td><td><code class="il">svc.route.nodes()</code></td></tr>
+  <tr><td>Get OpenAPI for the whole router</td><td><code class="il">svc.route.nodes(mode="openapi")</code></td></tr>
 </table>
 
 <h3>Plugins</h3>
 <table>
   <tr><th>I want to...</th><th>Code</th></tr>
-  <tr><td>Attach a plugin</td><td><code class="il">Router(self, name="api").plug("auth")</code></td></tr>
-  <tr><td>Set auth rule on a handler</td><td><code class="il">@route("api", auth_rule="admin")</code></td></tr>
+  <tr><td>Attach a plugin</td><td><code class="il">self.route.plug("auth")</code></td></tr>
+  <tr><td>Set auth rule on a handler</td><td><code class="il">@route(auth_rule="admin")</code></td></tr>
   <tr><td>Validate inputs with type hints</td><td><code class="il">.plug("pydantic")</code> + add type annotations</td></tr>
-  <tr><td>Require a system capability</td><td><code class="il">@route("api", env_requires="redis")</code></td></tr>
-  <tr><td>Override HTTP method for OpenAPI</td><td><code class="il">@route("api", openapi_method="delete")</code></td></tr>
-  <tr><td>Configure a plugin globally</td><td><code class="il">svc.api.auth.configure(rule="user")</code></td></tr>
-  <tr><td>Configure for one handler only</td><td><code class="il">svc.api.auth.configure(_target="x", rule="admin")</code></td></tr>
-  <tr><td>Configure with wildcard matching</td><td><code class="il">svc.routing.configure("api:auth/admin_*", ...)</code></td></tr>
+  <tr><td>Require a system capability</td><td><code class="il">@route(env_requires="redis")</code></td></tr>
+  <tr><td>Override HTTP method for OpenAPI</td><td><code class="il">@route(openapi_method="delete")</code></td></tr>
+  <tr><td>Configure a plugin globally</td><td><code class="il">svc.route.auth.configure(rule="user")</code></td></tr>
+  <tr><td>Configure for one handler only</td><td><code class="il">svc.route.auth.configure(_target="x", rule="admin")</code></td></tr>
+  <tr><td>Configure with wildcard matching</td><td><code class="il">svc.routing.configure("auth/admin_*", ...)</code></td></tr>
   <tr><td>See current plugin config</td><td><code class="il">svc.routing.configure("?")</code></td></tr>
 </table>
 
@@ -1080,16 +1079,15 @@ cli = RoutingCli(svc)</code></pre>
 <h3>Composition</h3>
 <table>
   <tr><th>I want to...</th><th>Code</th></tr>
-  <tr><td>Attach a child service (single router)</td><td><code class="il">parent.attach_instance(child, name="x")</code></td></tr>
-  <tr><td>Attach with explicit cross-mapping</td><td><code class="il">parent.attach_instance(child, router_api="orders:sales")</code></td></tr>
-  <tr><td>Retrieve attached child instance</td><td><code class="il">parent.routing.instance("api/x")</code></td></tr>
-  <tr><td>Call through hierarchy</td><td><code class="il">parent.api.node("x/handler")()</code></td></tr>
-  <tr><td>Resolve by endpoint_id</td><td><code class="il">parent.api.node("@MY-EP")()</code></td></tr>
-  <tr><td>Create a pure namespace (no handlers)</td><td><code class="il">Router(self, name="api", branch=True)</code></td></tr>
-  <tr><td>Strip method name prefixes</td><td><code class="il">Router(self, name="api", prefix="handle_")</code></td></tr>
+  <tr><td>Attach a child service</td><td><code class="il">parent.attach_instance(child, name="x")</code></td></tr>
+  <tr><td>Retrieve attached child instance</td><td><code class="il">parent.routing.instance("x")</code></td></tr>
+  <tr><td>Call through hierarchy</td><td><code class="il">parent.route.node("x/handler")()</code></td></tr>
+  <tr><td>Resolve by endpoint_id</td><td><code class="il">parent.route.node("@MY-EP")()</code></td></tr>
+  <tr><td>Create a pure grouping node (no handlers)</td><td><code class="il">parent.attach_instance(Section("Admin"), name="admin")</code></td></tr>
+  <tr><td>Strip method name prefixes</td><td><code class="il">self.route.prefix = "handle_"</code> (in <code class="il">__init__</code>)</td></tr>
   <tr><td>Auto-propagate db to children</td><td>Set <code class="il">ctx.db = conn</code> on <code class="il">RoutingContext</code> — parent chain handles propagation</td></tr>
-  <tr><td>Filter by user permissions</td><td><code class="il">svc.api.nodes(auth_tags="admin")</code></td></tr>
-  <tr><td>Filter by system capabilities</td><td><code class="il">svc.api.nodes(env_capabilities="redis")</code></td></tr>
+  <tr><td>Filter by user permissions</td><td><code class="il">svc.route.nodes(auth_tags="admin")</code></td></tr>
+  <tr><td>Filter by system capabilities</td><td><code class="il">svc.route.nodes(env_capabilities="redis")</code></td></tr>
 </table>
 
 <h3>CLI</h3>

--- a/docs/guide/attach-instance-visual-guide.md
+++ b/docs/guide/attach-instance-visual-guide.md
@@ -4,21 +4,22 @@ How to connect RoutingClass instances into hierarchies.
 
 ## Core Concept
 
-`attach_instance` lives on **RoutingClass** (not on Router). It does two things:
+`attach_instance` lives on **RoutingClass** (not on Router). Every RoutingClass
+owns exactly one router (`self.route`). Attaching does two things:
 
 1. Sets the parent-child relationship (`child._routing_parent = self`)
-2. Links child routers into parent routers (`parent_router._children[alias] = child_router`)
+2. Links the child's router into the parent's router (`parent.route._children[alias] = child.route`, via `include()`)
 
 ```mermaid
 graph LR
     subgraph "RoutingClass (parent)"
         P["self"]
-        PR["api (Router)"]
+        PR["route (Router)"]
         P --> PR
     end
     subgraph "RoutingClass (child)"
         C["child"]
-        CR["api (Router)"]
+        CR["route (Router)"]
         C --> CR
     end
     P -- "_routing_parent" --> C
@@ -29,20 +30,20 @@ graph LR
 
 ---
 
-## Scenario 1: One-to-One
+## Scenario 1: Attaching a Child
 
-Parent has **1 router**, child has **1 router**.
+Parent and child each own one router. The child's router is linked under the alias.
 
 ```mermaid
 graph TB
     subgraph "Parent"
-        PA["api (Router)"]
+        PA["route (Router)"]
         PA --- E1["health &bull; entry"]
         PA --- E2["status &bull; entry"]
         PA === S1["[sales]"]
     end
     subgraph "Child (vendite)"
-        CA["api (Router)"]
+        CA["route (Router)"]
         CA --- E3["ordini &bull; entry"]
         CA --- E4["fatture &bull; entry"]
     end
@@ -62,81 +63,35 @@ self.attach_instance(vendite, name="sales")
 **Access paths:**
 
 ```python
-self.api.node("health")()         # local entry
-self.api.node("sales/ordini")()   # child entry
-self.api.node("sales/fatture")()  # child entry
+self.route.node("health")()         # local entry
+self.route.node("sales/ordini")()   # child entry
+self.route.node("sales/fatture")()  # child entry
 ```
 
-**Rule:** `name=` shortcut works only when child has exactly one router.
+**Rule:** `name=` is the alias in the parent's router. This is the only calling
+style — every RoutingClass has exactly one router, so there is nothing else to map.
 
 ---
 
-## Scenario 2: One parent router, two child routers — child "dissolves"
+## Scenario 2: Child with Its Own Children
 
-Child's routers are flattened into the parent's single router. The child instance does not appear as an intermediate node.
+An attached child brings its whole sub-tree along.
 
 ```mermaid
 graph TB
     subgraph "Parent"
-        PA["api (Router)"]
-        PA --- E1["health &bull; entry"]
-        PA === S1["[sales]"]
-        PA === S2["[tech]"]
-    end
-    subgraph "Child (vendite)"
-        CA["orders (Router)"]
-        CA --- E3["ordini &bull; entry"]
-        CB["support (Router)"]
-        CB --- E4["ticket &bull; entry"]
-    end
-    S1 --> CA
-    S2 --> CB
-
-    style PA fill:#bbdefb
-    style CA fill:#ffe0b2
-    style CB fill:#ffe0b2
-    style S1 fill:#c8e6c9,stroke:#2e7d32,stroke-width:2px
-    style S2 fill:#c8e6c9,stroke:#2e7d32,stroke-width:2px
-```
-
-**Syntax:**
-
-```python
-self.attach_instance(vendite, router_api="orders:sales,support:tech")
-```
-
-**Format:** `router_<parent_router>="<child_router>:<alias>,<child_router>:<alias>"`
-
-**Access paths:**
-
-```python
-self.api.node("sales/ordini")()   # from child.orders
-self.api.node("tech/ticket")()    # from child.support
-```
-
----
-
-## Scenario 3: One parent router, two child routers — child "appears" with one router
-
-Only one of the child's routers is linked. The child appears as a node in the hierarchy, and any sub-routers of the linked router come along.
-
-```mermaid
-graph TB
-    subgraph "Parent"
-        PA["api (Router)"]
+        PA["route (Router)"]
         PA --- E1["health &bull; entry"]
         PA === S1["[sales]"]
     end
     subgraph "Child (vendite)"
-        CA["api (Router)"]
+        CA["route (Router)"]
         CA --- E3["ordini &bull; entry"]
         CA --- E4["fatture &bull; entry"]
         CA === SS["[statistiche]"]
-        CB["admin (Router)"]
-        CB --- E5["gestione &bull; entry"]
     end
     subgraph "Grandchild"
-        GR["stats (Router)"]
+        GR["route (Router)"]
         GR --- E6["mensili &bull; entry"]
         GR --- E7["annuali &bull; entry"]
     end
@@ -145,7 +100,6 @@ graph TB
 
     style PA fill:#bbdefb
     style CA fill:#ffe0b2
-    style CB fill:#ffe0b2,stroke-dasharray: 5 5
     style S1 fill:#c8e6c9,stroke:#2e7d32,stroke-width:2px
     style SS fill:#c8e6c9
     style GR fill:#f3e5f5
@@ -154,83 +108,57 @@ graph TB
 **Syntax:**
 
 ```python
-self.attach_instance(vendite, router_api="api:sales")
-# Only vendite.api is linked. vendite.admin is NOT attached.
+vendite.attach_instance(statistiche, name="statistiche")
+self.attach_instance(vendite, name="sales")
 ```
 
 **Access paths:**
 
 ```python
-self.api.node("sales/ordini")()              # child entry
-self.api.node("sales/statistiche/mensili")() # grandchild entry
-# self.api.node("???/gestione")  -- NOT accessible (admin not linked)
+self.route.node("sales/ordini")()              # child entry
+self.route.node("sales/statistiche/mensili")() # grandchild entry
 ```
 
 ---
 
-## Scenario 4: Two parent routers, one child router — parent chooses where
+## Scenario 3: Multiple Surfaces — Composition
+
+One class exposes one router. A service that needs several surfaces (public API,
+admin, ...) is split into **one class per surface**, composed under grouping
+nodes. `Section` provides an empty grouping node without a dedicated class.
 
 ```mermaid
 graph TB
-    subgraph "Parent"
-        PA["api (Router)"]
+    subgraph "Application"
+        PA["route (Router)"]
         PA --- E1["health &bull; entry"]
-        PA === S1["[users]"]
-        PB["admin (Router)"]
-        PB --- E2["dashboard &bull; entry"]
+        PA === S1["[api]"]
+        PA === S2["[admin]"]
     end
-    subgraph "Child"
-        CA["api (Router)"]
-        CA --- E3["list &bull; entry"]
-        CA --- E4["detail &bull; entry"]
+    subgraph "Section (Public API)"
+        SA["route (Router)"]
+        SA === S3["[orders]"]
     end
-    S1 --> CA
+    subgraph "Section (Admin area)"
+        SB["route (Router)"]
+        SB === S4["[orders]"]
+    end
+    subgraph "OrdersApi"
+        CA["route (Router)"]
+        CA --- E3["get_data &bull; entry"]
+    end
+    subgraph "OrdersAdmin"
+        CB["route (Router)"]
+        CB --- E4["manage &bull; entry"]
+    end
+    S1 --> SA
+    S2 --> SB
+    S3 --> CA
+    S4 --> CB
 
     style PA fill:#bbdefb
-    style PB fill:#bbdefb
-    style CA fill:#ffe0b2
-    style S1 fill:#c8e6c9,stroke:#2e7d32,stroke-width:2px
-```
-
-**Syntax:**
-
-```python
-self.attach_instance(child, router_api="api:users")
-```
-
-The kwarg `router_api` targets the parent's `api` router. The child could be linked to `admin` instead:
-
-```python
-self.attach_instance(child, router_admin="api:users")
-```
-
-**Note:** `name=` does NOT work here because the parent has multiple routers.
-
----
-
-## Scenario 5: Two parent routers, two child routers — cross-mapping
-
-```mermaid
-graph TB
-    subgraph "Parent"
-        PA["api (Router)"]
-        PA --- E1["health &bull; entry"]
-        PA === S1["[sales]"]
-        PB["admin (Router)"]
-        PB --- E2["dashboard &bull; entry"]
-        PB === S2["[management]"]
-    end
-    subgraph "Child (vendite)"
-        CA["orders (Router)"]
-        CA --- E3["ordini &bull; entry"]
-        CB["mgmt (Router)"]
-        CB --- E4["gestione &bull; entry"]
-    end
-    S1 --> CA
-    S2 --> CB
-
-    style PA fill:#bbdefb
-    style PB fill:#bbdefb
+    style SA fill:#c5cae9
+    style SB fill:#c5cae9
     style CA fill:#ffe0b2
     style CB fill:#ffe0b2
     style S1 fill:#c8e6c9,stroke:#2e7d32,stroke-width:2px
@@ -240,47 +168,41 @@ graph TB
 **Syntax:**
 
 ```python
-self.attach_instance(vendite,
-    router_api="orders:sales",
-    router_admin="mgmt:management",
-)
-```
+from genro_routes import Section
 
-Each `router_<parent_router>` kwarg specifies which child routers go into which parent router.
+api = Section("Public API")
+admin = Section("Admin area")
+self.attach_instance(api, name="api")
+self.attach_instance(admin, name="admin")
+api.attach_instance(OrdersApi(), name="orders")
+admin.attach_instance(OrdersAdmin(), name="orders")
+```
 
 **Access paths:**
 
 ```python
-self.api.node("sales/ordini")()           # parent.api -> child.orders
-self.admin.node("management/gestione")()  # parent.admin -> child.mgmt
+self.route.node("api/orders/get_data")()   # public surface
+self.route.node("admin/orders/manage")()   # admin surface
 ```
+
+> **Note:** earlier versions supported multiple routers per class with a
+> `router_*` cross-mapping DSL in `attach_instance`. That feature was removed:
+> composition (one class per surface, `Section` for grouping) covers the same
+> use cases with a single calling style.
 
 ---
 
 ## Syntax Reference
 
-### `name=` shortcut (1:1)
+### `attach_instance(child, name=...)`
 
 ```python
 self.attach_instance(child, name="alias")
 ```
 
-- Child must have **exactly one** router
-- Parent must have **exactly one** router
-- The child's single router is linked under `alias` in the parent's single router
-
-### `router_*` kwargs (any mapping)
-
-```python
-self.attach_instance(child,
-    router_<parent_router>="<child_router>:<alias>,<child_router>:<alias>",
-    router_<parent_router>="<child_router>:<alias>",
-)
-```
-
-- Works with any number of parent/child routers
-- Multiple child routers can be linked to the same parent router (comma-separated)
-- Different child routers can go to different parent routers (separate kwargs)
+- The child's router is linked under `alias` in the parent's router
+- Sets `child._routing_parent = self`
+- Raises `ValueError` on alias collision or if the child is already bound to another parent
 
 ### Attach only (no routing)
 
@@ -299,19 +221,19 @@ Direct router-to-router or entry-alias linking.
 **Include a Router:**
 
 ```python
-self._sys_router.include(swagger.api, name="swagger")
+self._sys.route.include(swagger.route, name="swagger")
 ```
 
 - Links the source router as a child of this router
-- Sets `_routing_parent` on the source's owner
-- Triggers plugin inheritance
-- Use when the target is a nested router (e.g., created with `parent_router`)
+- On the **primary** attachment (source has no parent yet) it sets
+  `_routing_parent` on the source's owner and triggers plugin inheritance
+- Subsequent includes of the same router are navigational shortcuts only
 
 **Include a RouterNode (entry alias):**
 
 ```python
-fatture.api.include(
-    pagamenti.api.node("collega_a_fattura"),
+fatture.route.include(
+    pagamenti.route.node("collega_a_fattura"),
     name="collega_pagamento",
 )
 ```
@@ -323,28 +245,28 @@ fatture.api.include(
 ### `detach_instance` (on Router)
 
 ```python
-self.api.detach_instance(child)
+self.route.detach_instance(child)
 ```
 
-- Removes all of `child`'s routers from this router's `_children`
+- Removes every alias of `child`'s router from this router's `_children`
 - Clears `child._routing_parent`
 - Stays on **Router**, not RoutingClass
 
 ---
 
-## Scenario 6: Entry Alias
+## Scenario 4: Entry Alias
 
 The same handler declared in one service, visible in another's tree.
 
 ```mermaid
 graph TB
     subgraph "Pagamenti"
-        PA["api (Router)"]
+        PA["route (Router)"]
         PA --- E1["lista_pagamenti &bull; entry"]
         PA --- E2["collega_a_fattura &bull; entry"]
     end
     subgraph "Fatture"
-        FA["api (Router)"]
+        FA["route (Router)"]
         FA --- E3["lista_fatture &bull; entry"]
         FA -.- E4["collega_pagamento &bull; alias"]
     end
@@ -358,8 +280,8 @@ graph TB
 **Syntax:**
 
 ```python
-fatture.api.include(
-    pagamenti.api.node("collega_a_fattura"),
+fatture.route.include(
+    pagamenti.route.node("collega_a_fattura"),
     name="collega_pagamento",
 )
 ```
@@ -367,8 +289,8 @@ fatture.api.include(
 **Access paths:**
 
 ```python
-pagamenti.api.node("collega_a_fattura")(1, 2)    # original
-fatture.api.node("collega_pagamento")(1, 2)       # alias — same handler
+pagamenti.route.node("collega_a_fattura")(1, 2)   # original
+fatture.route.node("collega_pagamento")(1, 2)     # alias — same handler
 ```
 
 ---
@@ -377,21 +299,20 @@ fatture.api.node("collega_pagamento")(1, 2)       # alias — same handler
 
 ```mermaid
 flowchart TD
-    A["How many routers does the child have?"] --> B{"1 router"}
-    A --> C{"2+ routers"}
+    A["What do you need?"] --> B["Expose a child service\nunder an alias"]
+    A --> C["A pure grouping level\n(no handlers)"]
+    A --> D["Several surfaces\n(api, admin, ...)"]
+    A --> E["Make one entry visible\nfrom another tree"]
 
-    B --> D{"Parent has 1 router?"}
-    D -->|Yes| E["name='alias'"]
-    D -->|No| F["router_X='child_router:alias'"]
+    B --> F["attach_instance(child, name='alias')"]
+    C --> G["attach_instance(Section('...'), name='group')"]
+    D --> H["One RoutingClass per surface,\ncomposed with attach_instance"]
+    E --> I["router.include(node, name='alias')"]
 
-    C --> G{"All go to same parent router?"}
-    G -->|Yes| H["router_X='a:alias1,b:alias2'"]
-    G -->|No| I["router_X='a:alias1'\nrouter_Y='b:alias2'"]
-
-    style E fill:#c8e6c9,stroke:#2e7d32
-    style F fill:#fff3e0,stroke:#ef6c00
+    style F fill:#c8e6c9,stroke:#2e7d32
+    style G fill:#c8e6c9,stroke:#2e7d32
     style H fill:#fff3e0,stroke:#ef6c00
-    style I fill:#fff3e0,stroke:#ef6c00
+    style I fill:#f3e5f5,stroke:#7b1fa2
 ```
 
 ---
@@ -399,27 +320,21 @@ flowchart TD
 ## Real-World Example
 
 ```python
-from genro_routes import RoutingClass, Router, route
+from genro_routes import RoutingClass, route
 
 class AuthService(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="api")
-
-    @route("api")
+    @route()
     def login(self, username: str, password: str):
         return {"token": "..."}
 
 class UserService(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="api")
-
-    @route("api")
+    @route()
     def list_users(self):
         return ["alice", "bob"]
 
 class Application(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("logging")
+        self.route.plug("logging")
         self.auth = AuthService()
         self.users = UserService()
 
@@ -428,6 +343,6 @@ class Application(RoutingClass):
 
 app = Application()
 
-app.api.node("auth/login")("alice", "secret")
-app.api.node("users/list_users")()
+app.route.node("auth/login")("alice", "secret")
+app.route.node("users/list_users")()
 ```

--- a/docs/guide/basic-usage.md
+++ b/docs/guide/basic-usage.md
@@ -8,8 +8,8 @@ Genro Routes provides instance-scoped routing with hierarchical organization and
 
 **Key concepts**:
 
-- Routers are instantiated at runtime: `Router(self, name="api")`
-- Methods are marked with `@route("router_name")` decorator
+- Every `RoutingClass` owns exactly one router, auto-created lazily and exposed as `self.route`
+- Methods are marked with the `@route()` decorator (keyword-only options)
 - Each instance gets isolated routing state
 - Plugins apply per-instance, not globally
 
@@ -18,14 +18,13 @@ Genro Routes provides instance-scoped routing with hierarchical organization and
 Create a service with instance-scoped routing:
 
 ```python
-from genro_routes import RoutingClass, Router, route
+from genro_routes import RoutingClass, route
 
 class Service(RoutingClass):
     def __init__(self, label: str):
         self.label = label
-        self.api = Router(self, name="api")
 
-    @route("api")
+    @route()
     def describe(self):
         return f"service:{self.label}"
 
@@ -33,15 +32,15 @@ class Service(RoutingClass):
 first = Service("alpha")
 second = Service("beta")
 
-assert first.api.node("describe")() == "service:alpha"
-assert second.api.node("describe")() == "service:beta"
+assert first.route.node("describe")() == "service:alpha"
+assert second.route.node("describe")() == "service:beta"
 ```
 
 **Key points**:
 
-- `Router(self, name="api")` creates instance-scoped router in `__init__`
-- `@route("api")` marks method for registration
-- `RoutingClass` is **required** - all classes using `Router` must inherit from it
+- The router is created automatically on first access of `self.route` — never call `Router(...)` yourself
+- `@route()` marks a method for registration
+- `RoutingClass` is **required** - only its instances can own a router
 - Each instance has independent routing state
 
 ## Registering Handlers
@@ -52,50 +51,56 @@ Methods are automatically registered when decorated with `@route`:
 
 ```python
 class API(RoutingClass):
-    def __init__(self):
-        self.routes = Router(self, name="routes")
-
-    @route("routes")
+    @route()
     def echo(self, value: str):
         return value
 
-    @route("routes", name="alt_name")
+    @route(name="alt_name")
     def action(self):
         return "executed"
 
 api = API()
 
 # Direct name resolution
-assert api.routes.node("echo")("hello") == "hello"
+assert api.route.node("echo")("hello") == "hello"
 
 # Custom name resolution
-assert api.routes.node("alt_name")() == "executed"
+assert api.route.node("alt_name")() == "executed"
 ```
 
-**Registration happens automatically** when you inherit from `RoutingClass` and instantiate routers in `__init__`.
+**Registration happens automatically**: the router discovers marked methods lazily on first use — no explicit bind call, and no `__init__` needed unless you configure plugins or router options.
 
-## Single Router Default
+## One Class, One Router
 
 <!-- test: test_router_basic.py::TestSingleRouterDefault::test_route_without_args_uses_single_router -->
 
-When a class has exactly one router, `@route()` without arguments uses it automatically:
+`@route()` always registers the method on the class's single router:
 
 ```python
 class Table(RoutingClass):
-    def __init__(self):
-        self.table = Router(self, name="table")
-
-    @route()  # Uses the only router automatically
+    @route()
     def add(self, data):
         return f"added:{data}"
 
-    @route()  # Also uses the single router
+    @route()
     def remove(self, id):
         return f"removed:{id}"
 
 t = Table()
-assert t.table.node("add")("x") == "added:x"
-assert t.table.node("remove")(1) == "removed:1"
+assert t.route.node("add")("x") == "added:x"
+assert t.route.node("remove")(1) == "removed:1"
+```
+
+Router options (`description`, `prefix`, `default_entry`) are set on the existing router in `__init__` (binding is lazy, so this is race-free):
+
+```python
+class DocumentedTable(RoutingClass):
+    def __init__(self):
+        self.route.description = "Table operations"
+
+    @route()
+    def add(self, data):
+        return f"added:{data}"
 ```
 
 ## Database Access via Context
@@ -106,13 +111,10 @@ on any `RoutingClass` instance — all instances in the same task share it
 via the `_routing_parent` chain.
 
 ```python
-from genro_routes import RoutingClass, RoutingContext, Router, route
+from genro_routes import RoutingClass, RoutingContext, route
 
 class UsersModule(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="api")
-
-    @route("api")
+    @route()
     def list_users(self):
         return self.ctx.db.execute("SELECT * FROM users")
 
@@ -147,30 +149,36 @@ svc.ctx = request_ctx
 See the **[Execution Context Guide](context.md)** for the full explanation
 including adapter patterns and subclassing.
 
-### Accessing the Default Router
+### Multiple Surfaces via Composition
 
-You can access the default router programmatically via the `default_router` property:
+A class has exactly one router. When you need distinct surfaces (e.g. a public
+API and an admin area), compose separate `RoutingClass` instances:
 
 ```python
-class SingleAPI(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="api")
-
+class PublicAPI(RoutingClass):
     @route()
     def ping(self):
         return "pong"
 
-svc = SingleAPI()
-assert svc.default_router is svc.api  # Only one router = default
+class AdminAPI(RoutingClass):
+    @route()
+    def reset(self):
+        return "reset done"
 
-class MultiAPI(RoutingClass):
+class App(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api")
-        self.admin = Router(self, name="admin")
+        self.api = PublicAPI()
+        self.admin = AdminAPI()
+        self.attach_instance(self.api, name="api")
+        self.attach_instance(self.admin, name="admin")
 
-m = MultiAPI()
-assert m.default_router is None  # Multiple routers = no default
+app = App()
+assert app.route.node("api/ping")() == "pong"
+assert app.route.node("admin/reset")() == "reset done"
 ```
+
+For a grouping level without a dedicated class, attach a `Section` (an empty
+`RoutingClass`): `app.attach_instance(Section("Admin area"), name="admin")`.
 
 ## Calling Handlers
 
@@ -180,17 +188,14 @@ Use `node()` to retrieve handlers - it returns a callable `RouterNode`:
 
 ```python
 class Calculator(RoutingClass):
-    def __init__(self):
-        self.ops = Router(self, name="ops")
-
-    @route("ops")
+    @route()
     def add(self, a: int, b: int):
         return a + b
 
 calc = Calculator()
 
 # node() returns a RouterNode which is callable
-node = calc.ops.node("add")
+node = calc.route.node("add")
 assert node(2, 3) == 5
 
 # RouterNode also provides metadata access
@@ -214,23 +219,23 @@ Clean up method names with prefixes and provide alternative names with the `name
 class SubService(RoutingClass):
     def __init__(self, prefix: str):
         self.prefix = prefix
-        self.routes = Router(self, name="routes", prefix="handle_")
+        self.route.prefix = "handle_"
 
-    @route("routes")
+    @route()
     def handle_list(self):
         return f"{self.prefix}:list"
 
-    @route("routes", name="detail")
+    @route(name="detail")
     def handle_detail(self, ident: int):
         return f"{self.prefix}:detail:{ident}"
 
 sub = SubService("users")
 
 # Prefix stripped: "handle_list" → "list"
-assert sub.routes.node("list")() == "users:list"
+assert sub.route.node("list")() == "users:list"
 
 # Custom name used: "handle_detail" → "detail"
-assert sub.routes.node("detail")(10) == "users:detail:10"
+assert sub.route.node("detail")(10) == "users:detail:10"
 ```
 
 **Benefits**:
@@ -245,22 +250,19 @@ Use `node.error` to check if a path resolved correctly:
 
 ```python
 class Fallback(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="api")
-
-    @route("api")
+    @route()
     def known_action(self):
         return "success"
 
 fb = Fallback()
 
 # Existing handler - no error
-node = fb.api.node("known_action")
+node = fb.route.node("known_action")
 if not node.error:
     assert node() == "success"
 
 # Non-existing - node has error
-missing = fb.api.node("missing")
+missing = fb.route.node("missing")
 if missing.error:
     print(f"Handler error: {missing.error}")
 ```
@@ -289,47 +291,47 @@ from genro_routes import NotFound, NotAuthenticated, NotAuthorized, NotAvailable
 **Using `node()` with filters**:
 
 ```python
-from genro_routes import RoutingClass, Router, route, NotFound, NotAuthorized
+from genro_routes import RoutingClass, route, NotFound, NotAuthorized
 
 class SecureAPI(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("auth")
+        self.route.plug("auth")
 
-    @route("api", auth_rule="admin")
+    @route(auth_rule="admin")
     def admin_action(self):
         return "admin only"
 
-    @route("api", auth_rule="public")
+    @route(auth_rule="public")
     def public_action(self):
         return "public"
 
 api = SecureAPI()
 
 # Entry exists and tag matches - node is callable
-node = api.api.node("admin_action", auth_tags="admin")
+node = api.route.node("admin_action", auth_tags="admin")
 assert node() == "admin only"
 
 # Entry exists but tag doesn't match - node has error
-node = api.api.node("admin_action", auth_tags="public")
+node = api.route.node("admin_action", auth_tags="public")
 assert node.error == "not_authorized"  # Error reason
 # Calling raises NotAuthorized
 try:
     node()
 except NotAuthorized as e:
-    print(f"Access denied: {e.selector}")  # "api:admin_action"
+    print(f"Access denied: {e.selector}")  # "route:admin_action"
 
 # Entry doesn't exist - node has error
-node = api.api.node("nonexistent")
+node = api.route.node("nonexistent")
 # Calling raises NotFound
 try:
     node()
 except NotFound as e:
-    print(f"Not found: {e.selector}")  # "api:nonexistent"
+    print(f"Not found: {e.selector}")  # "route" (nothing resolved, path is empty)
 ```
 
 **Exception attributes**:
 
-- `selector`: The full selector in format `"router_name:path"` (e.g., `"api:admin_action"`)
+- `selector`: The full selector in format `"router_name:path"` (e.g., `"route:admin_action"` — the router name is always `"route"`; when nothing resolves, the path part is omitted)
 
 **RouterNode properties**:
 
@@ -352,7 +354,7 @@ result = node()  # calls handler("unknown", "path")
 Map router error codes to your framework's exception classes using the `errors` parameter in `node()`:
 
 ```python
-from genro_routes import RoutingClass, Router, route
+from genro_routes import RoutingClass, route
 
 # Define your framework's exceptions
 class HTTPNotFound(Exception):
@@ -366,16 +368,16 @@ class HTTPUnauthorized(Exception):
 
 class MyAPI(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("auth")
+        self.route.plug("auth")
 
-    @route("api", auth_rule="admin")
+    @route(auth_rule="admin")
     def admin_only(self):
         return "secret"
 
 api = MyAPI()
 
 # Map error codes to custom exceptions
-node = api.api.node("admin_only", auth_tags="guest", errors={
+node = api.route.node("admin_only", auth_tags="guest", errors={
     "not_found": HTTPNotFound,
     "not_authorized": HTTPForbidden,
     "not_authenticated": HTTPUnauthorized,
@@ -406,15 +408,15 @@ except HTTPForbidden:
 
 ## Catch-All Routing with `default_entry`
 
-Routers have a `default_entry` parameter (default: `"index"`) that enables catch-all routing patterns via best-match resolution:
+Routers have a `default_entry` option (default: `"index"`) that enables catch-all routing patterns via best-match resolution:
 
 ```python
 class FileServer(RoutingClass):
     def __init__(self):
         # default_entry="index" is the default, but can be customized
-        self.api = Router(self, name="api", default_entry="serve")
+        self.route.default_entry = "serve"
 
-    @route("api")
+    @route()
     def serve(self, *path_segments):
         return f"Serving: {'/'.join(path_segments)}"
 
@@ -422,7 +424,7 @@ server = FileServer()
 
 # node() uses best-match resolution - when path can't be fully resolved,
 # unconsumed segments become arguments to the handler
-node = server.api.node("docs/api/reference")
+node = server.route.node("docs/api/reference")
 assert node() == "Serving: docs/api/reference"
 ```
 
@@ -449,19 +451,18 @@ Create nested router structures with path-based access:
 class SubService(RoutingClass):
     def __init__(self, prefix: str):
         self.prefix = prefix
-        self.routes = Router(self, name="routes", prefix="handle_")
+        self.route.prefix = "handle_"
 
-    @route("routes")
+    @route()
     def handle_list(self):
         return f"{self.prefix}:list"
 
-    @route("routes", name="detail")
+    @route(name="detail")
     def handle_detail(self, ident: int):
         return f"{self.prefix}:detail:{ident}"
 
 class RootAPI(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api")
         self.users = SubService("users")
         self.products = SubService("products")
 
@@ -471,15 +472,15 @@ class RootAPI(RoutingClass):
 root = RootAPI()
 
 # Access with path separator
-assert root.api.node("users/list")() == "users:list"
-assert root.api.node("products/detail")(5) == "products:detail:5"
+assert root.route.node("users/list")() == "users:list"
+assert root.route.node("products/detail")(5) == "products:detail:5"
 ```
 
 **Key points**:
 
 - `attach_instance` is a method on `RoutingClass`, not on `Router`
-- `name="alias"` is a shortcut when the child has a single router
-- For multi-router children, use `router_<parent>=...` kwargs (see [Hierarchies Guide](hierarchies.md))
+- `name="alias"` links the child's router into the parent's router under that alias
+- For grouping levels without handlers, attach a `Section` (see [Hierarchies Guide](hierarchies.md))
 
 **Hierarchies enable**:
 
@@ -496,27 +497,26 @@ Inspect router structure and registered handlers:
 ```python
 class Inspectable(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api")
         self.child_service = SubService("child")
         self.attach_instance(self.child_service, name="sub")
 
-    @route("api")
+    @route()
     def action(self):
         pass
 
 insp = Inspectable()
 
 # Get metadata (single source: nodes)
-info = insp.api.nodes()
+info = insp.route.nodes()
 assert "action" in info["entries"]
 assert "sub" in info["routers"]
 
 # Get nodes starting from a specific path
-sub_info = insp.api.nodes(basepath="sub")
+sub_info = insp.route.nodes(basepath="sub")
 assert "list" in sub_info["entries"]
 
 # Use lazy=True for on-demand expansion of children
-lazy_info = insp.api.nodes(lazy=True)
+lazy_info = insp.route.nodes(lazy=True)
 sub_router = lazy_info["routers"]["sub"]  # Router reference, not expanded
 sub_expanded = sub_router.nodes()  # Expand on demand
 ```
@@ -537,13 +537,13 @@ sub_expanded = sub_router.nodes()  # Expand on demand
 
 ```python
 # Flat OpenAPI schema (all paths merged)
-schema = insp.api.nodes(mode="openapi")
+schema = insp.route.nodes(mode="openapi")
 
 # Hierarchical OpenAPI schema (preserves router structure)
-h_schema = insp.api.nodes(mode="h_openapi")
+h_schema = insp.route.nodes(mode="h_openapi")
 
 # Filter entries by name pattern
-admin_entries = insp.api.nodes(pattern="admin_.*")
+admin_entries = insp.route.nodes(pattern="admin_.*")
 ```
 
 **Including blocked entries**:
@@ -572,27 +572,24 @@ Add custom metadata to handlers using the `meta_` prefix in `@route()`:
 
 ```python
 class MetadataAPI(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="api")
-
-    @route("api", meta_mimetype="application/json", meta_deprecated=True)
+    @route(meta_mimetype="application/json", meta_deprecated=True)
     def get_data(self):
         """Return data in JSON format."""
         return {"foo": "bar"}
 
-    @route("api", meta_version="2.0", meta_auth_required=True)
+    @route(meta_version="2.0", meta_auth_required=True)
     def get_data_v2(self):
         return {"foo": "bar", "extra": True}
 
 api = MetadataAPI()
 
 # Access metadata via node() - returns meta dict directly
-node = api.api.node("get_data")
+node = api.route.node("get_data")
 assert node.metadata["mimetype"] == "application/json"
 assert node.metadata["deprecated"] is True
 
 # Or via nodes() for all entries - uses full path
-all_info = api.api.nodes()
+all_info = api.route.nodes()
 entry_meta = all_info["entries"]["get_data_v2"]["metadata"]["meta"]
 assert entry_meta["version"] == "2.0"
 assert entry_meta["auth_required"] is True
@@ -620,7 +617,7 @@ See the **[Execution Context Guide](context.md)** for the complete reference.
 
 Quick summary: `RoutingContext` is an extensible container with parent chain
 delegation. Adapters create layered contexts (server → app → request), set
-them via `svc.ctx = ctx` (stored in a the `_routing_parent` chain), and handlers read
+them via `svc.ctx = ctx` (stored in a `_ctx` slot on the instance), and handlers read
 shared state with `self.ctx.db`, `self.ctx.user`, etc. Missing
 attributes walk up the parent chain automatically.
 
@@ -629,19 +626,16 @@ attributes walk up the parent chain automatically.
 Use `ResultWrapper` to return handler results with metadata that the transport layer can use (e.g., for content-type negotiation).
 
 ```python
-from genro_routes import RoutingClass, Router, route, is_result_wrapper
+from genro_routes import RoutingClass, route, is_result_wrapper
 
 class APIService(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="api")
-
-    @route("api")
+    @route()
     def render_html(self):
         content = "<html><body>Hello</body></html>"
         return self.result_wrapper(content, mime_type="text/html")
 
 svc = APIService()
-result = svc.api.node("render_html")()
+result = svc.route.node("render_html")()
 
 # Check if result is wrapped
 if is_result_wrapper(result):

--- a/docs/guide/best-practices.md
+++ b/docs/guide/best-practices.md
@@ -4,67 +4,56 @@ This guide covers production-tested patterns and anti-patterns for Genro Routes.
 
 ## Router Design
 
-### Keep Routers Focused
+### Keep Services Focused
 
-Each router should have a clear, single responsibility:
+Each RoutingClass should have a clear, single responsibility. A class with
+no plugins or router options needs no `__init__` at all:
 
 ```python
-# Good: Focused routers
+# Good: Focused service
 class UserService(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="api")
-
-    @route("api")
+    @route()
     def list_users(self): ...
 
-    @route("api")
+    @route()
     def get_user(self, user_id: int): ...
 
-    @route("api")
+    @route()
     def create_user(self, data: dict): ...
 
 
-# Bad: Router doing too much
+# Bad: Service doing too much
 class EverythingService(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="api")
-
-    @route("api")
+    @route()
     def list_users(self): ...
 
-    @route("api")
+    @route()
     def send_email(self): ...
 
-    @route("api")
+    @route()
     def generate_report(self): ...
 ```
 
 ### Use Meaningful Names
 
-Router and handler names should be self-documenting:
+Handler names and attachment aliases should be self-documenting:
 
 ```python
 # Good: Clear, descriptive names
 class OrderService(RoutingClass):
-    def __init__(self):
-        self.orders = Router(self, name="orders")
-
-    @route("orders")
+    @route()
     def list_pending(self): ...
 
-    @route("orders")
+    @route()
     def mark_shipped(self, order_id: int): ...
 
 
 # Bad: Vague names
 class Service(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="api")
-
-    @route("api")
+    @route()
     def do_stuff(self): ...
 
-    @route("api")
+    @route()
     def process(self, id): ...
 ```
 
@@ -75,14 +64,14 @@ Use prefixes to group related handlers while keeping public names clean:
 ```python
 class AdminAPI(RoutingClass):
     def __init__(self):
-        self.admin = Router(self, name="admin", prefix="admin_")
+        self.route.prefix = "admin_"
 
-    @route("admin")
+    @route()
     def admin_list_users(self):
         """Exposed as 'list_users'"""
         ...
 
-    @route("admin")
+    @route()
     def admin_delete_user(self, user_id: int):
         """Exposed as 'delete_user'"""
         ...
@@ -96,27 +85,31 @@ Prefer shallow hierarchies over deeply nested ones:
 
 ```python
 # Good: Shallow, navigable hierarchy
-app.api.node("users/list")()
-app.api.node("orders/create")()
-app.api.node("reports/sales")()
+app.route.node("users/list")()
+app.route.node("orders/create")()
+app.route.node("reports/sales")()
 
 # Bad: Too deep, hard to navigate
-app.api.node("v1/internal/services/users/management/list")()
+app.route.node("v1/internal/services/users/management/list")()
 ```
 
-### Use Branch Routers for Organization
+### Use Sections for Organization
 
-Branch routers provide namespace organization without handlers:
+A `Section` is an empty RoutingClass that provides namespace organization
+without handlers:
 
 ```python
+from genro_routes import RoutingClass, Section
+
 class Application(RoutingClass):
     def __init__(self):
-        # Branch router as namespace container
-        self.api = Router(self, name="api", branch=True)
+        # Section as a namespace container
+        admin = Section("Admin area")
+        self.attach_instance(admin, name="admin")
 
-        # Attach actual services
-        self.attach_instance(self.users, name="users")
-        self.attach_instance(self.orders, name="orders")
+        # Attach actual services under the section
+        admin.attach_instance(UserAdmin(), name="users")
+        admin.attach_instance(OrderAdmin(), name="orders")
 ```
 
 ### Attaching Child Instances
@@ -126,12 +119,11 @@ Child instances can be attached directly — storing as an attribute is optional
 ```python
 class Parent(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api")
         # Both approaches work — the router tree keeps a strong reference
         self.attach_instance(ChildService(), name="child")
 
 # Retrieve the child instance later if needed
-child = parent.routing.instance("api/child")
+child = parent.routing.instance("child")
 ```
 
 ## Plugin Usage
@@ -144,7 +136,7 @@ Attach plugins where they make sense:
 # Good: Logging at root, validation where needed
 class Application(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("logging")  # All handlers logged
+        self.route.plug("logging")  # All handlers logged
 
         self.public = PublicAPI()  # No validation needed
         self.admin = AdminAPI()    # Has its own pydantic plugin
@@ -155,7 +147,7 @@ class Application(RoutingClass):
 
 class AdminAPI(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("pydantic")  # Strict validation
+        self.route.plug("pydantic")  # Strict validation
 ```
 
 ### Compose Simple Plugins
@@ -164,13 +156,12 @@ Multiple focused plugins beat one complex plugin:
 
 ```python
 # Good: Composable plugins
-self.api = Router(self, name="api")\
-    .plug("logging")\
+self.route.plug("logging")\
     .plug("pydantic")\
     .plug("caching")
 
 # Bad: Monolithic plugin
-self.api = Router(self, name="api").plug("do_everything")
+self.route.plug("do_everything")
 ```
 
 ### Configure Plugins Explicitly
@@ -179,11 +170,11 @@ Don't rely on defaults for production:
 
 ```python
 # Good: Explicit configuration
-svc.routing.configure("api:logging/_all_", level="info", enabled=True)
-svc.routing.configure("api:pydantic/_all_", strict=True)
+svc.routing.configure("logging/_all_", enabled=True, log=True)
+svc.routing.configure("pydantic/_all_", disabled=False)
 
 # Bad: Implicit defaults everywhere
-svc.api.plug("logging").plug("pydantic")  # What's the config?
+svc.route.plug("logging").plug("pydantic")  # What's the config?
 ```
 
 ## Error Handling
@@ -194,14 +185,14 @@ Don't swallow exceptions in handlers:
 
 ```python
 # Good: Let errors propagate
-@route("api")
+@route()
 def create_user(self, data: dict):
     user = self.repository.create(data)  # May raise
     return user
 
 
 # Bad: Swallowing errors
-@route("api")
+@route()
 def create_user(self, data: dict):
     try:
         user = self.repository.create(data)
@@ -240,12 +231,12 @@ Test handler logic independently of routing:
 def test_user_service_list():
     svc = UserService()
     # Test via router
-    result = svc.api.node("list_users")()
+    result = svc.route.node("list_users")()
     assert isinstance(result, list)
 
 def test_user_service_create():
     svc = UserService()
-    result = svc.api.node("create_user")({"name": "Alice"})
+    result = svc.route.node("create_user")({"name": "Alice"})
     assert result["name"] == "Alice"
 ```
 
@@ -258,12 +249,12 @@ def test_application_hierarchy():
     app = Application()
 
     # Verify structure
-    nodes = app.api.nodes()
+    nodes = app.route.nodes()
     assert "users" in nodes["routers"]
     assert "orders" in nodes["routers"]
 
     # Verify access
-    users = app.api.node("users/list_users")()
+    users = app.route.node("users/list_users")()
     assert isinstance(users, list)
 ```
 
@@ -274,7 +265,7 @@ Test that plugins affect handler execution:
 ```python
 def test_logging_plugin_called(caplog):
     svc = LoggedService()
-    svc.api.node("action")()
+    svc.route.node("action")()
 
     assert "action" in caplog.text
 ```
@@ -289,11 +280,9 @@ Attach plugins during router creation for optimal handler wrapping:
 # Good: Plugins attached during construction
 class Service(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api")\
-            .plug("logging")\
-            .plug("pydantic")
+        self.route.plug("logging").plug("pydantic")
 
-    @route("api")
+    @route()
     def action(self):
         return "done"
 ```
@@ -304,13 +293,13 @@ If calling the same handler repeatedly, cache the reference:
 
 ```python
 # Good: Cache for repeated calls
-node = svc.api.node("process")
+node = svc.route.node("process")
 for item in items:
     node(item)
 
 # Less efficient: Lookup every time
 for item in items:
-    svc.api.node("process")(item)
+    svc.route.node("process")(item)
 ```
 
 ## Anti-Patterns
@@ -349,13 +338,11 @@ Avoid circular attachments:
 # Bad: Circular reference
 class A(RoutingClass):
     def __init__(self, b):
-        self.api = Router(self, name="api")
         self.b = b
         self.attach_instance(b, name="b")
 
 class B(RoutingClass):
     def __init__(self, a):
-        self.api = Router(self, name="api")
         self.a = a
         self.attach_instance(a, name="a")  # Circular!
 ```
@@ -366,21 +353,21 @@ Don't configure what doesn't need configuration:
 
 ```python
 # Bad: Over-engineered
-svc.routing.configure("api:logging/handler1", level="info")
-svc.routing.configure("api:logging/handler2", level="info")
-svc.routing.configure("api:logging/handler3", level="info")
+svc.routing.configure("logging/handler1", log=True)
+svc.routing.configure("logging/handler2", log=True)
+svc.routing.configure("logging/handler3", log=True)
 # ... 50 more lines
 
 # Good: Use defaults and override exceptions
-svc.routing.configure("api:logging/_all_", level="info")
-svc.routing.configure("api:logging/debug_*", level="debug")
+svc.routing.configure("logging/_all_", log=True)
+svc.routing.configure("logging/debug_*", print=True)
 ```
 
 ## Summary
 
 | Do | Don't |
 |----|-------|
-| Keep routers focused | Mix unrelated handlers |
+| Keep services focused | Mix unrelated handlers |
 | Use meaningful names | Use vague names |
 | Use `routing.instance()` to retrieve children | Rely on global variables for child access |
 | Apply plugins at right level | Over-apply plugins |

--- a/docs/guide/context.md
+++ b/docs/guide/context.md
@@ -112,7 +112,7 @@ async def dispatch(request, service):
     # Set it — now every RoutingClass in this task sees it
     service.ctx = ctx
     try:
-        result = await service.api.call("some_handler", ...)
+        result = service.route.node("some_handler")(...)
     finally:
         service.ctx = None   # cleanup for this task
 ```
@@ -120,7 +120,7 @@ async def dispatch(request, service):
 After `service.ctx = ctx`, any handler can do:
 
 ```python
-@route("api")
+@route()
 def list_orders(self):
     db = self.ctx.db          # from request_ctx (local)
     user = self.ctx.user      # from request_ctx (local)
@@ -145,7 +145,7 @@ server_ctx.db = db_connection
 svc.ctx = server_ctx
 
 # Handler access — same as before
-@route("api")
+@route()
 def query(self):
     return self.ctx.db.execute("SELECT 1")
 ```

--- a/docs/guide/examples.md
+++ b/docs/guide/examples.md
@@ -69,7 +69,7 @@ Exposes a filesystem repository as a service with `list_dir`, `read_file`, and `
 
 ### 10. Deep Repo Explorer
 
-Maps Python files as routers, introspecting classes and functions at runtime. Combined with MCP Bridge, allows an LLM to **discover API structure without filesystem access**.
+Maps Python files as routing services, introspecting classes and functions at runtime. Combined with MCP Bridge, allows an LLM to **discover API structure without filesystem access**.
 
 - **Source**: [examples/deep_repo_explorer.py](https://github.com/genropy/genro-routes/blob/main/examples/deep_repo_explorer.py)
 

--- a/docs/guide/hierarchies.md
+++ b/docs/guide/hierarchies.md
@@ -6,8 +6,9 @@ Build complex routing structures with nested routers, path-based navigation, and
 
 Genro Routes supports hierarchical router composition where:
 
-- **Parent routers** can have **child routers** attached through explicit instance binding
-- **Path separator** `/` navigates the hierarchy (`root.api.node("users/list")()`)
+- **Every RoutingClass owns exactly one router**, exposed as the read-only `route` property
+- **Parent instances** attach **child instances** through explicit instance binding
+- **Path separator** `/` navigates the hierarchy (`root.route.node("users/list")()`)
 - **Plugins propagate** from parent to children automatically
 - **Each level** maintains independent handler registration
 - **Parent tracking** maintains the relationship between parent and child instances
@@ -31,42 +32,37 @@ Genro Routes provides explicit methods for managing RoutingClass hierarchies:
 Attach a child instance explicitly with an alias:
 
 ```python
-from genro_routes import RoutingClass, Router, route
+from genro_routes import RoutingClass, route
 
 class Child(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="api")
-
-    @route("api")
+    @route()
     def list(self):
         return "child:list"
 
 class Parent(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api")
         # Attach child directly — no need to store as attribute
         self.attach_instance(Child(), name="sales")
 
 parent = Parent()
 
 # Access through hierarchy
-assert parent.api.node("sales/list")() == "child:list"
+assert parent.route.node("sales/list")() == "child:list"
 
-# node() can also resolve to a child router
-child_node = parent.api.node("sales")
-assert child_node.error is None
+# node() can also resolve to a child router (falls back to its default_entry)
+child_node = parent.route.node("sales")
 assert child_node.path == "sales"
 
 # Retrieve the child instance later via routing.instance()
-child = parent.routing.instance("api/sales")
+child = parent.routing.instance("sales")
 assert child._routing_parent is parent
 ```
 
 **Key points**:
 
-- The `name` parameter provides the alias for accessing the child's router (works as a shortcut when the child has a single router)
+- The `name` parameter provides the alias under which the child's router is linked into the parent's router
 - Storing the child as an attribute is **optional** — the router tree keeps a strong reference to the child instance via `router.instance`
-- Use `routing.instance("router/child")` to retrieve a child instance at any time
+- Use `routing.instance("child")` to retrieve a child instance at any time
 - Parent tracking is handled automatically
 
 **`node()` return values**:
@@ -75,226 +71,163 @@ assert child._routing_parent is parent
 - If the path points to a child router, uses that router's `default_entry`
 - Check `node.error` to see if resolution succeeded
 
-## Multiple Routers: Cross-Mapping
+## Multiple Surfaces: Composition
 
-<!-- test: test_router_edge_cases.py::test_attach_instance_multiple_routers_requires_mapping -->
-
-When a child has multiple routers, use explicit cross-mapping via `router_<parent_router>=...` kwargs:
+A RoutingClass owns exactly one router. When a service must expose more than one
+surface (e.g. a public API and an admin area), define **one class per surface**
+and compose them with `attach_instance`. Grouping levels without handlers are
+`Section` instances:
 
 ```python
-class MultiRouterChild(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="api")
-        self.admin = Router(self, name="admin")
+from genro_routes import RoutingClass, Section, route
 
-    @route("api")
+class OrdersApi(RoutingClass):
+    @route()
     def get_data(self):
         return "data"
 
-    @route("admin")
+class OrdersAdmin(RoutingClass):
+    @route()
     def manage(self):
         return "manage"
 
-class Parent(RoutingClass):
+class Application(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api")
-        self.admin = Router(self, name="admin")
-        self.child = MultiRouterChild()
+        api = Section("Public API")
+        admin = Section("Admin area")
+        self.attach_instance(api, name="api")
+        self.attach_instance(admin, name="admin")
+        api.attach_instance(OrdersApi(), name="orders")
+        admin.attach_instance(OrdersAdmin(), name="orders")
 
-parent = Parent()
+app = Application()
 
-# Cross-map child routers to parent routers
-parent.attach_instance(parent.child,
-    router_api="api:sales",
-    router_admin="admin:admin_panel",
-)
-
-assert parent.api.node("sales/get_data")() == "data"
-assert parent.admin.node("admin_panel/manage")() == "manage"
+assert app.route.node("api/orders/get_data")() == "data"
+assert app.route.node("admin/orders/manage")() == "manage"
 ```
 
-**Cross-mapping syntax**:
+**Composition rules**:
 
-- Each kwarg is named `router_<parent_router_name>`
-- Value format: `"child_router:alias"` — comma-separated for multiple child routers on the same parent
-- Unmapped routers are not attached
-- Useful for selective exposure and renaming
+- One class per surface: each `RoutingClass` exposes exactly one router
+- Selective exposure and renaming happen at attach time via `name=`
+- The same alias can be reused under different parents (`api/orders` vs `admin/orders`)
+- Handlers shared by several surfaces belong in a plain (non-routing) collaborator
+  class, or can be exposed as entry aliases via `include()` (see the
+  [Visual Guide](attach-instance-visual-guide.md))
 
-## Parent with Multiple Routers
+## Grouping with Section
 
-<!-- test: test_router_edge_cases.py::test_attach_instance_single_child_requires_alias_when_parent_multi -->
-
-When child has a single router, use `name=` to specify the alias. The child's router is attached to the parent router that matches by name, or to the single parent router if there is only one:
-
-```python
-class MultiRouterParent(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="api")
-        self.admin = Router(self, name="admin")
-        self.child = Child()  # Child has single router named "api"
-
-parent = MultiRouterParent()
-
-# name= shortcut: child's "api" router attaches to parent's "api" router
-parent.attach_instance(parent.child, name="child_alias")
-assert "child_alias" in parent.api._children
-```
-
-When both parent and child have multiple routers, use cross-mapping kwargs instead of `name=` (see previous section).
-
-## Branch Routers
-
-Create pure organizational nodes with branch routers:
+Create pure organizational nodes with `Section` — an empty RoutingClass used as
+a grouping level:
 
 ```python
+from genro_routes import RoutingClass, Section, route
+
 class OrganizedService(RoutingClass):
     def __init__(self):
-        # Branch router: pure container, no handlers
-        self.api = Router(self, name="api", branch=True)
+        # Section: pure container, no handlers
+        api = Section("API surface")
+        self.attach_instance(api, name="api")
 
-        # Add handler routers as children
-        self.users = UserService()
-        self.products = ProductService()
-
-        self.attach_instance(self.users, name="users")
-        self.attach_instance(self.products, name="products")
+        # Attach handler services as children of the section
+        api.attach_instance(UserService(), name="users")
+        api.attach_instance(ProductService(), name="products")
 
 service = OrganizedService()
 
-# Access through branch
-service.api.node("users/list")()
-service.api.node("products/create")()
+# Access through the section
+service.route.node("api/users/list")()
+service.route.node("api/products/create")()
 ```
 
-**Branch router characteristics**:
+**Section characteristics**:
 
-- **Cannot register handlers** - No `@route` methods allowed
-- **Pure containers** - Only for organizing child routers
-- **Useful for** - API namespacing and logical grouping
+- **No handlers of its own** - Just an empty router used as container
+- **Optional description** - `Section("Admin area")` sets the router description
+- **Useful for** - API namespacing and logical grouping without a dedicated class
 
-**When to use branches**:
+**When to use Sections**:
 
 ```python
-# Good: Organize related services under /api namespace
-self.api = Router(self, name="api", branch=True)
-self.attach_instance(self.auth, name="auth")
-self.attach_instance(self.users, name="users")
+# Good: Organize related services under an /api namespace
+api = Section("API")
+self.attach_instance(api, name="api")
+api.attach_instance(self.auth, name="auth")
+api.attach_instance(self.users, name="users")
 # Routes: api/auth/login, api/users/list
-
-# Not needed: Single level with handlers
-self.api = Router(self, name="api")  # Regular router
 ```
 
-**When NOT to use branches**:
+**When NOT to use Sections**:
 
-Branch routers add a level to your URL hierarchy. Use them only when you need pure organizational containers:
+Sections add a level to your URL hierarchy. Use them only when you need pure
+organizational containers:
 
 ```python
-# DON'T: Branch with single child (unnecessary nesting)
-self.api = Router(self, name="api", branch=True)
-self.users = UserService()
-self.attach_instance(self.users, name="users")
+# DON'T: Section with a single child (unnecessary nesting)
+api = Section()
+self.attach_instance(api, name="api")
+api.attach_instance(UserService(), name="users")
 # Result: api/users/list - the "api" level adds nothing
 
-# DO: Regular router with handlers + attached children
-self.api = Router(self, name="api")  # Has its own handlers
-self.users = UserService()
-self.attach_instance(self.users, name="users")
+# DO: attach children directly; root-level handlers live on the class itself
+class Application(RoutingClass):
+    def __init__(self):
+        self.attach_instance(UserService(), name="users")
 
-@route("api")
-def health(self):  # api/health - root level handler
-    return "ok"
-# Result: api/health + api/users/list - "api" has purpose
+    @route()
+    def health(self):  # health - root level handler
+        return "ok"
+# Result: health + users/list - no empty intermediate level
 ```
 
 **Decision guide**:
 
-| Scenario | Use Branch? |
-|----------|-------------|
+| Scenario | Use Section? |
+| -------- | ------------ |
 | Pure namespace (no root handlers) | Yes |
-| Root router with handlers + children | No |
+| Root class with handlers + children | No |
 | Single child service | No (attach directly) |
 | Multiple children, common namespace | Yes |
 
-## Direct Router Hierarchies with parent_router
+## Composing Services
 
-<!-- test: test_router_edge_cases.py::test_parent_router_creates_hierarchy -->
-
-Create router hierarchies directly without separate `RoutingClass` instances using `parent_router`:
+Hierarchies are always built by composing RoutingClass instances — there is no
+way (and no need) to create several routers on the same instance:
 
 ```python
-class Service(RoutingClass):
-    def __init__(self):
-        # Parent branch router
-        self.api = Router(self, name="api", branch=True)
-
-        # Child routers attached via parent_router parameter
-        self.users = Router(self, name="users", parent_router=self.api)
-        self.orders = Router(self, name="orders", parent_router=self.api)
-
-    @route("users")
+class UsersService(RoutingClass):
+    @route()
     def list_users(self):
         return ["alice", "bob"]
 
-    @route("orders")
+class OrdersService(RoutingClass):
+    @route()
     def list_orders(self):
         return ["order1", "order2"]
+
+class Service(RoutingClass):
+    def __init__(self):
+        self.attach_instance(UsersService(), name="users")
+        self.attach_instance(OrdersService(), name="orders")
+
+    @route()
+    def health(self):
+        return "ok"
 
 svc = Service()
 
 # Access through hierarchy
-assert svc.api.node("users/list_users")() == ["alice", "bob"]
-assert svc.api.node("orders/list_orders")() == ["order1", "order2"]
+assert svc.route.node("users/list_users")() == ["alice", "bob"]
+assert svc.route.node("orders/list_orders")() == ["order1", "order2"]
+assert svc.route.node("health")() == "ok"
 ```
 
 **Key characteristics**:
 
-- **Same instance**: All routers share the same owner instance
-- **Automatic attachment**: Child registers itself in parent's `_children` dict
-- **Plugin inheritance**: `_on_attached_to_parent()` is called for plugin propagation
-- **Name required**: Child router must have a `name` (used as the hierarchy key)
-- **Collision detection**: Raises `ValueError` if name already exists in parent
-
-**When to use `parent_router` vs `attach_instance`**:
-
-| Use Case | Method |
-|----------|--------|
-| Same instance, multiple routers | `parent_router` |
-| Different `RoutingClass` instances | `self.attach_instance(child, ...)` |
-| Dynamic attachment/detachment | `self.attach_instance(child, ...)` / `router.detach_instance(child)` |
-| Static hierarchy at init time | `parent_router` |
-
-**Example: Mixed hierarchy**:
-
-```python
-class Application(RoutingClass):
-    def __init__(self):
-        # Root branch
-        self.api = Router(self, name="api", branch=True)
-
-        # Direct children via parent_router
-        self.users = Router(self, name="users", parent_router=self.api)
-        self.products = Router(self, name="products", parent_router=self.api)
-
-        # External service via attach_instance
-        self.auth_service = AuthService()
-        self.attach_instance(self.auth_service, name="auth")
-
-    @route("users")
-    def list_users(self):
-        return ["alice", "bob"]
-
-    @route("products")
-    def list_products(self):
-        return ["widget", "gadget"]
-
-app = Application()
-
-# All accessible through hierarchy
-app.api.node("users/list_users")()      # Direct child
-app.api.node("products/list_products")() # Direct child
-app.api.node("auth/login")()            # Attached instance
-```
+- **One router per instance**: every level of the tree is a RoutingClass instance
+- **Plugin inheritance**: the child router inherits the parent's plugins on attach
+- **Name required**: the `name=` alias is the hierarchy key
+- **Collision detection**: attaching raises `ValueError` if the alias already exists
 
 ## Auto-Detachment
 
@@ -305,19 +238,18 @@ Replacing a child attribute automatically detaches the old instance:
 ```python
 class Parent(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api")
         self.child = Child()
         self.attach_instance(self.child, name="child")
 
 parent = Parent()
 assert parent.child._routing_parent is parent
-assert "child" in parent.api._children
+assert "child" in parent.route._children
 
 # Replacing the attribute triggers auto-detach
 parent.child = None
 
 # Old child is automatically removed from hierarchy
-assert "child" not in parent.api._children
+assert "child" not in parent.route._children
 ```
 
 **Auto-detachment behavior**:
@@ -325,7 +257,7 @@ assert "child" not in parent.api._children
 - Triggered when setting `parent.attribute = new_value`
 - Only detaches if old value's `_routing_parent` is this parent
 - Clears `_routing_parent` on detached instance
-- Removes from all parent routers automatically
+- Removes the child's router (all aliases) from the parent router
 - Best-effort: ignores errors to avoid blocking attribute assignment
 
 **Use cases**:
@@ -346,8 +278,9 @@ Every attached RoutingClass tracks its parent:
 
 ```python
 class Child(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="api")
+    @route()
+    def ping(self):
+        return "pong"
 
     def get_parent_info(self):
         if self._routing_parent:
@@ -355,14 +288,14 @@ class Child(RoutingClass):
         return "No parent"
 
 child = Child()
-assert child._routing_parent is None  # Not attached
+assert getattr(child, "_routing_parent", None) is None  # Not attached
 
 parent = Parent()
 parent.child = child
 parent.attach_instance(parent.child, name="child")
 assert child._routing_parent is parent  # Parent tracked
 
-parent.api.detach_instance(child)
+parent.route.detach_instance(child)
 assert child._routing_parent is None  # Cleared on detach
 ```
 
@@ -383,16 +316,15 @@ Plugins propagate automatically from parent to children:
 class Service(RoutingClass):
     def __init__(self, name: str):
         self.name = name
-        self.api = Router(self, name="api")
 
-    @route("api")
+    @route()
     def process(self):
         return f"{self.name}:process"
 
 class Application(RoutingClass):
     def __init__(self):
-        # Plugin attached to parent
-        self.api = Router(self, name="api").plug("logging")
+        # Plugin attached to the application's router
+        self.route.plug("logging")
         self.service = Service("main")
 
 app = Application()
@@ -401,10 +333,10 @@ app = Application()
 app.attach_instance(app.service, name="service")
 
 # Child router has the logging plugin
-assert hasattr(app.service.api, "logging")
+assert hasattr(app.service.route, "logging")
 
 # Plugin applies to child handlers
-result = app.service.api.node("process")()
+result = app.service.route.node("process")()
 # Logging plugin was active during call
 ```
 
@@ -414,35 +346,39 @@ result = app.service.api.node("process")()
 - Children can add their own plugins
 - Plugin order: parent plugins -> child plugins
 - Configuration inherits but can be overridden
+- Inheritance is triggered by the **primary** attachment (the first parent);
+  linking the same child elsewhere with `include()` is navigational only
 
 ## Path Navigation
 
 <!-- test: test_router_edge_cases.py::test_routed_proxy_get_router_handles_dotted_path -->
 
-Navigate hierarchy with path separator `/` via `routing.get_router()`:
+Navigate the hierarchy with path separator `/` via `routing.get_router()`:
 
 ```python
 class Child(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="api")
+    pass
 
 class Parent(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api")
         self.child = Child()
         self.attach_instance(self.child, name="child")
 
 parent = Parent()
 
+# The instance's own router
+assert parent.routing.get_router() is parent.route
+
 # Get child router directly
-child_router = parent.routing.get_router("api/child")
-assert child_router.name == "api"
+child_router = parent.routing.get_router("child")
+assert child_router.name == "route"
 assert child_router.instance is parent.child
 ```
 
 **Navigation features**:
 
-- `get_router("router/child/grandchild")` traverses hierarchy
+- `get_router()` with no arguments returns the instance's own router
+- `get_router("child/grandchild")` traverses the hierarchy
 - Returns the target router instance
 - Enables programmatic router access
 - Useful for dynamic configuration
@@ -453,7 +389,7 @@ You can also navigate the hierarchy directly from any router using `router_at_pa
 
 ```python
 # From a router, find a child router by path
-child_router = parent.api.router_at_path("child/grandchild")
+child_router = parent.route.router_at_path("child/grandchild")
 if child_router is not None:
     print(child_router.name)
 ```
@@ -461,7 +397,7 @@ if child_router is not None:
 **Differences from `routing.get_router()`**:
 
 - `router_at_path(path)` is called directly on a `Router` instance and navigates its children
-- Returns `None` if the path doesn't resolve (instead of raising `AttributeError`)
+- Returns `None` if the path doesn't resolve (instead of raising `KeyError`)
 - Does not require `RoutingClass` — works on any `BaseRouter`
 
 ## Introspection
@@ -473,31 +409,30 @@ Inspect the full hierarchy structure:
 ```python
 class Inspectable(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api")
         self.service = Service("child")
         self.attach_instance(self.service, name="sub")
 
-    @route("api")
+    @route()
     def action(self):
         pass
 
 insp = Inspectable()
 
 # Get complete hierarchy metadata
-info = insp.api.nodes()
+info = insp.route.nodes()
 assert "action" in info["entries"]
 assert "sub" in info["routers"]
 
 # Child routers included
 child_info = info["routers"]["sub"]
-assert child_info["name"] == "api"
+assert child_info["name"] == "route"
 
 # Get nodes starting from a child
-sub_only = insp.api.nodes(basepath="sub")
-assert "list" in sub_only["entries"]
+sub_only = insp.route.nodes(basepath="sub")
+assert "process" in sub_only["entries"]
 
 # Lazy mode: children are router references
-lazy = insp.api.nodes(lazy=True)
+lazy = insp.route.nodes(lazy=True)
 sub_router = lazy["routers"]["sub"]  # Router reference, not expanded
 sub_expanded = sub_router.nodes()  # Expand on demand
 ```
@@ -510,7 +445,7 @@ sub_expanded = sub_router.nodes()  # Expand on demand
 
 ```python
 # Generate OpenAPI schema for the hierarchy
-schema = insp.api.nodes(mode="openapi")
+schema = insp.route.nodes(mode="openapi")
 ```
 
 **Introspection provides**:
@@ -528,17 +463,14 @@ Routers can handle paths that don't fully resolve by delegating to a `default_en
 
 ```python
 class FileService(RoutingClass):
-    def __init__(self):
-        # default_entry="index" is the default
-        self.api = Router(self, name="api")
+    # default_entry="index" is the router default
 
-    @route("api")
+    @route()
     def index(self, *path_segments):
         return f"File: {'/'.join(path_segments)}"
 
 class Application(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api")
         self.files = FileService()
         self.attach_instance(self.files, name="files")
 
@@ -546,7 +478,7 @@ app = Application()
 
 # Path "files/docs/readme.md" - "files" is a child router,
 # "docs/readme.md" doesn't exist, so best-match resolution uses default_entry
-node = app.api.node("files/docs/readme.md")
+node = app.route.node("files/docs/readme.md")
 # Unconsumed segments passed as args: ["docs", "readme.md"]
 assert node() == "File: docs/readme.md"
 ```
@@ -554,7 +486,7 @@ assert node() == "File: docs/readme.md"
 **Behavior by scenario** (best-match resolution):
 
 | Path | Scenario | Result |
-|------|----------|--------|
+| ---- | -------- | ------ |
 | `/` or `""` | Empty path | Uses this router's `default_entry` |
 | `child/handler` | Handler exists | Returns RouterNode with handler |
 | `child/unknown/path` | Child exists, path unresolved | Uses child's `default_entry` with args |
@@ -567,15 +499,12 @@ When you call `node("/")` or `node("")`, you get a **root node**:
 
 ```python
 class Service(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="api")
-
-    @route("api")
+    @route()
     def index(self):
         return "home"
 
 svc = Service()
-node = svc.api.node("/")
+node = svc.route.node("/")
 
 # Root node properties
 assert node.path == ""
@@ -592,9 +521,9 @@ If no `default_entry` exists, calling raises `NotFound`.
 ```python
 class CustomService(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api", default_entry="catch_all")
+        self.route.default_entry = "catch_all"
 
-    @route("api")
+    @route()
     def catch_all(self, *args):
         return f"Caught: {args}"
 ```
@@ -605,11 +534,10 @@ If `default_entry` handler doesn't exist in the target router, an empty RouterNo
 
 ```python
 class EmptyService(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="api")  # No "index" entry!
+    pass  # No "index" entry!
 
 svc = EmptyService()
-node = svc.api.node("unknown/path")
+node = svc.route.node("unknown/path")
 # node.error will indicate the path couldn't be resolved
 ```
 
@@ -619,120 +547,89 @@ node = svc.api.node("unknown/path")
 
 ```python
 class AuthService(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="api")
-
-    @route("api")
+    @route()
     def login(self, username: str, password: str):
         return {"token": "..."}
 
-    @route("api")
+    @route()
     def logout(self, token: str):
         return {"status": "ok"}
 
 class UserService(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="api")
-
-    @route("api")
+    @route()
     def list_users(self):
         return ["alice", "bob"]
 
-    @route("api")
+    @route()
     def get_user(self, user_id: int):
         return {"id": user_id, "name": "..."}
 
 class Application(RoutingClass):
     def __init__(self):
         # Root router with logging
-        self.api = Router(self, name="api").plug("logging")
+        self.route.plug("logging")
 
-        # Create services
-        self.auth = AuthService()
-        self.users = UserService()
-
-        # Attach to hierarchy
-        self.attach_instance(self.auth, name="auth")
-        self.attach_instance(self.users, name="users")
+        # Create and attach services
+        self.attach_instance(AuthService(), name="auth")
+        self.attach_instance(UserService(), name="users")
 
 app = Application()
 
 # Access through hierarchy
-token = app.api.node("auth/login")("alice", "secret123")
-users = app.api.node("users/list_users")()
+token = app.route.node("auth/login")("alice", "secret123")
+users = app.route.node("users/list_users")()
 
 # Logging applies to all handlers automatically
 ```
 
-### Multi-Level Organization with Branches
+### Multi-Level Organization
 
 ```python
 class ReportsAPI(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="api")
-
-    @route("api")
+    @route()
     def sales_report(self):
         return "sales data"
 
-    @route("api")
+    @route()
     def inventory_report(self):
         return "inventory data"
 
 class AdminAPI(RoutingClass):
     def __init__(self):
-        # Branch for organization
-        self.api = Router(self, name="api", branch=True)
-
-        self.users = UserService()
-        self.reports = ReportsAPI()
-
-        self.attach_instance(self.users, name="users")
-        self.attach_instance(self.reports, name="reports")
+        self.attach_instance(UserService(), name="users")
+        self.attach_instance(ReportsAPI(), name="reports")
 
 class Application(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api", branch=True)
-
-        # Public API
-        self.public = UserService()  # Simplified public interface
+        # Public API (simplified interface)
+        self.attach_instance(UserService(), name="public")
 
         # Admin API (protected, more capabilities)
-        self.admin = AdminAPI()
-
-        self.attach_instance(self.public, name="public")
-        self.attach_instance(self.admin, name="admin")
+        self.attach_instance(AdminAPI(), name="admin")
 
 app = Application()
 
 # Clean hierarchy
-app.api.node("public/list_users")()           # Public access
-app.api.node("admin/users/get_user")(123)     # Admin user access
-app.api.node("admin/reports/sales_report")()  # Admin reports
+app.route.node("public/list_users")()           # Public access
+app.route.node("admin/users/get_user")(123)     # Admin user access
+app.route.node("admin/reports/sales_report")()  # Admin reports
 ```
 
 ### Dynamic Service Replacement
 
 ```python
 class ServiceV1(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="api")
-
-    @route("api")
+    @route()
     def process(self, data: str):
         return f"v1:{data}"
 
 class ServiceV2(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="api")
-
-    @route("api")
+    @route()
     def process(self, data: str):
         return f"v2:{data}"
 
 class Application(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api")
         self.service = ServiceV1()
         self.attach_instance(self.service, name="processor")
 
@@ -742,39 +639,30 @@ class Application(RoutingClass):
         self.attach_instance(self.service, name="processor")
 
 app = Application()
-assert app.api.node("processor/process")("test") == "v1:test"
+assert app.route.node("processor/process")("test") == "v1:test"
 
 app.upgrade_service()  # Seamless replacement
-assert app.api.node("processor/process")("test") == "v2:test"
+assert app.route.node("processor/process")("test") == "v2:test"
 ```
 
 ## Best Practices
 
-### Logical Grouping with Branches
+### Logical Grouping
 
 ```python
-# Use branch routers for pure organization
+# Compose related services under the root class
 class API(RoutingClass):
     def __init__(self):
-        self.root = Router(self, name="root", branch=True)
-
-        # Group related services
-        self.auth = AuthService()
-        self.users = UserService()
-        self.orders = OrderService()
-
-        self.attach_instance(self.auth, name="auth")
-        self.attach_instance(self.users, name="users")
-        self.attach_instance(self.orders, name="orders")
+        self.attach_instance(AuthService(), name="auth")
+        self.attach_instance(UserService(), name="users")
+        self.attach_instance(OrderService(), name="orders")
 ```
 
 ### Shared Plugins at Root
 
 ```python
 # Apply common plugins to entire hierarchy
-self.api = Router(self, name="api")\
-    .plug("logging")\
-    .plug("pydantic")
+self.route.plug("logging").plug("pydantic")
 
 # All children inherit both plugins
 self.attach_instance(self.auth, name="auth")
@@ -785,19 +673,19 @@ self.attach_instance(self.users, name="users")
 
 ```python
 # Organize by domain and subdomain
-app.attach_instance(self.admin, name="admin")
-admin.attach_instance(self.user_admin, name="users")
-admin.attach_instance(self.report_admin, name="reports")
+app.attach_instance(admin, name="admin")
+admin.attach_instance(user_admin, name="users")
+admin.attach_instance(report_admin, name="reports")
 
-# Access: app.api.node("admin/users/create_user")()
-#         app.api.node("admin/reports/sales_report")()
+# Access: app.route.node("admin/users/create_user")()
+#         app.route.node("admin/reports/sales_report")()
 ```
 
 ### Retrieve Child Instances
 
 ```python
 # Retrieve attached child instances via routing.instance()
-child = parent.routing.instance("api/child")  # returns the RoutingClass instance
+child = parent.routing.instance("child")  # returns the RoutingClass instance
 ```
 
 ### Explicit Detachment
@@ -805,7 +693,7 @@ child = parent.routing.instance("api/child")  # returns the RoutingClass instanc
 ```python
 # Explicit detachment for clarity
 if should_remove_service:
-    self.api.detach_instance(self.old_service)
+    self.route.detach_instance(self.old_service)
     self.old_service = None  # Clear reference
 ```
 
@@ -817,8 +705,8 @@ self.attach_instance(self.auth, name="auth_v1")
 self.attach_instance(self.new_auth, name="auth_v2")
 
 # Access both versions
-self.api.node("auth_v1/login")()
-self.api.node("auth_v2/login")()
+self.route.node("auth_v1/login")()
+self.route.node("auth_v2/login")()
 ```
 
 ## Common Patterns
@@ -827,10 +715,7 @@ self.api.node("auth_v2/login")()
 
 ```python
 class ChildService(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="api")
-
-    @route("api")
+    @route()
     def get_config(self):
         # Access parent context
         if self._routing_parent:
@@ -843,39 +728,30 @@ class ChildService(RoutingClass):
 ```python
 class Application(RoutingClass):
     def __init__(self, config):
-        self.api = Router(self, name="api")
-
         # Attach based on configuration
         if config.get("enable_auth"):
-            self.auth = AuthService()
-            self.attach_instance(self.auth, name="auth")
+            self.attach_instance(AuthService(), name="auth")
 
         if config.get("enable_admin"):
-            self.admin = AdminService()
-            self.attach_instance(self.admin, name="admin")
+            self.attach_instance(AdminService(), name="admin")
 ```
 
-### Multi-Router Services
+### Multi-Surface Services
 
 ```python
-class DualInterfaceService(RoutingClass):
-    def __init__(self):
-        self.public = Router(self, name="public")
-        self.admin = Router(self, name="admin")
-
-    @route("public")
+class PublicOrders(RoutingClass):
+    @route()
     def public_endpoint(self):
         return "public data"
 
-    @route("admin")
+class AdminOrders(RoutingClass):
+    @route()
     def admin_endpoint(self):
         return "admin data"
 
-# Cross-map child routers to parent routers
-parent.attach_instance(service,
-    router_api="public:api",
-    router_admin="admin:admin_api",
-)
+# Compose: one class per surface, attached where needed
+app.routing.instance("api").attach_instance(PublicOrders(), name="orders")
+app.routing.instance("admin").attach_instance(AdminOrders(), name="orders")
 ```
 
 ## Next Steps

--- a/docs/guide/plugin-configuration.md
+++ b/docs/guide/plugin-configuration.md
@@ -6,7 +6,7 @@ Configure plugins at runtime through a unified API with support for global setti
 
 Genro Routes provides `routing.configure()` for runtime plugin configuration with:
 
-- **Target syntax**: `<router>:<plugin>/<selector>` format
+- **Target syntax**: `<plugin>/<selector>` format
 - **Global configuration**: Apply to all handlers with `_all_`
 - **Handler-specific overrides**: Target individual handlers
 - **Glob patterns**: Match multiple handlers with wildcards
@@ -17,17 +17,22 @@ Genro Routes provides `routing.configure()` for runtime plugin configuration wit
 
 <!-- test: test_router_edge_cases.py::test_routed_configure_updates_plugins_global_and_local -->
 
-A configuration target has three parts:
+A configuration target has two parts:
 
 ```text
-<router_name>:<plugin_name>/<selector>
+<plugin_name>/<selector>
 ```
+
+The router is implicit: `routing.configure()` always operates on the
+instance's own router (`self.route`). Child routers belong to child
+instances — configure them through the child's own `routing` proxy.
 
 **Examples**:
 
-- `api:logging/_all_` - Apply to all handlers in the logging plugin
-- `api:logging/foo` - Apply only to the `foo` handler
-- `api:logging/b*` - Apply to handlers matching glob pattern `b*`
+- `logging/_all_` - Apply to all handlers in the logging plugin
+- `logging/foo` - Apply only to the `foo` handler
+- `logging/b*` - Apply to handlers matching glob pattern `b*`
+- `logging` - Same as `logging/_all_` (selector defaults to `_all_`)
 
 **Selectors**:
 
@@ -41,52 +46,52 @@ The selector part of the target supports `fnmatch` glob patterns for matching mu
 
 | Pattern | Matches | Example Target |
 |---------|---------|----------------|
-| `*` | Any string | `api:logging/*` (all handlers) |
-| `?` | Any single character | `api:logging/get_?` (get_a, get_b, ...) |
-| `[abc]` | Any char in brackets | `api:logging/get_[123]` |
-| `[!abc]` | Any char NOT in brackets | `api:logging/[!_]*` (not starting with _) |
-| `admin_*` | Prefix match | `api:logging/admin_*` |
-| `*_detail` | Suffix match | `api:logging/*_detail` |
+| `*` | Any string | `logging/*` (all handlers) |
+| `?` | Any single character | `logging/get_?` (get_a, get_b, ...) |
+| `[abc]` | Any char in brackets | `logging/get_[123]` |
+| `[!abc]` | Any char NOT in brackets | `logging/[!_]*` (not starting with _) |
+| `admin_*` | Prefix match | `logging/admin_*` |
+| `*_detail` | Suffix match | `logging/*_detail` |
 
 **Glob pattern examples**:
 
 ```python
 class Service(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("logging")
+        self.route.plug("logging")
 
-    @route("api")
+    @route()
     def admin_list(self): pass
 
-    @route("api")
+    @route()
     def admin_create(self): pass
 
-    @route("api")
+    @route()
     def admin_delete(self): pass
 
-    @route("api")
+    @route()
     def user_profile(self): pass
 
-    @route("api")
+    @route()
     def user_settings(self): pass
 
 svc = Service()
 
 # Disable logging for all admin handlers
-svc.routing.configure("api:logging/admin_*", enabled=False)
+svc.routing.configure("logging/admin_*", enabled=False)
 
-# Set debug level for all user handlers
-svc.routing.configure("api:logging/user_*", level="debug")
+# Print user handlers' log lines to stdout
+svc.routing.configure("logging/user_*", print=True)
 
 # Configure multiple patterns with comma-separated selector
-svc.routing.configure("api:logging/admin_list,admin_create", threshold=5)
+svc.routing.configure("logging/admin_list,admin_create", before=False)
 ```
 
 **Combining patterns**:
 
 ```python
 # Multiple comma-separated patterns in selector
-svc.routing.configure("api:logging/admin_*,user_*", enabled=True)
+svc.routing.configure("logging/admin_*,user_*", enabled=True)
 
 # Each pattern is matched independently:
 # admin_* matches: admin_list, admin_create, admin_delete
@@ -100,40 +105,40 @@ svc.routing.configure("api:logging/admin_*,user_*", enabled=True)
 Configure plugins using keyword arguments:
 
 ```python
-from genro_routes import RoutingClass, Router, route
+from genro_routes import RoutingClass, route
 
 class ConfService(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("logging")
+        self.route.plug("logging")
 
-    @route("api")
+    @route()
     def foo(self):
         return "foo"
 
-    @route("api")
+    @route()
     def bar(self):
         return "bar"
 
 svc = ConfService()
 
 # Global configuration - applies to all handlers
-svc.routing.configure("api:logging/_all_", threshold=10)
-assert svc.api.logging.configuration()["threshold"] == 10
+svc.routing.configure("logging/_all_", print=True)
+assert svc.route.logging.configuration()["print"] is True
 
 # Handler-specific configuration
-svc.routing.configure("api:logging/foo", enabled=False)
-assert svc.api.logging.configuration("foo")["enabled"] is False
+svc.routing.configure("logging/foo", enabled=False)
+assert svc.route.logging.configuration("foo")["enabled"] is False
 
 # Glob pattern configuration
-svc.routing.configure("api:logging/b*", mode="strict")
-assert svc.api.logging.configuration("bar")["mode"] == "strict"
+svc.routing.configure("logging/b*", before=False)
+assert svc.route.logging.configuration("bar")["before"] is False
 ```
 
 **Configuration keys** depend on the plugin. Common keys:
 
 - `enabled` - Enable/disable plugin for handler(s)
-- `flags` - Plugin-specific flags
-- `threshold`, `mode`, `level` - Plugin-specific settings
+- `flags` - Boolean options as comma-separated string
+- `before`, `after`, `print` - Plugin-specific settings (here: LoggingPlugin)
 
 ## Batch Updates
 
@@ -144,13 +149,13 @@ Configure multiple targets with a list of dictionaries:
 ```python
 # JSON-friendly batch configuration
 payload = [
-    {"target": "api:logging/_all_", "flags": "trace"},
-    {"target": "api:logging/foo", "limit": 5},
+    {"target": "logging/_all_", "flags": "print"},
+    {"target": "logging/foo", "after": False},
 ]
 
 result = svc.routing.configure(payload)
 assert len(result) == 2
-assert svc.api.logging.configuration("foo")["limit"] == 5
+assert svc.route.logging.configuration("foo")["after"] is False
 ```
 
 **Each dictionary must have**:
@@ -176,37 +181,38 @@ Query the router and plugin structure with `"?"`:
 ```python
 class Leaf(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("logging")
+        self.route.plug("logging")
 
-    @route("api")
+    @route()
     def ping(self):
         return "leaf"
 
 class Root(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("logging")
+        self.route.plug("logging")
         self.leaf = Leaf()
         self.attach_instance(self.leaf, name="leaf")
 
-    @route("api")
+    @route()
     def root_ping(self):
         return "root"
 
 svc = Root()
 
-# Get full configuration tree
+# Get the router description (recursing into child routers)
 info = svc.routing.configure("?")
-assert "api" in info
-assert info["api"]["plugins"]
-assert "leaf" in info["api"]["routers"]
+assert info["name"] == "route"
+assert info["plugins"]
+assert "root_ping" in info["entries"]
+assert "leaf" in info["routers"]
 ```
 
-**Returns nested dictionary with**:
+**Returns the router description dict with**:
 
-- Router names
-- Attached plugins and their configurations
-- Child routers
-- Registered handlers
+- `name` - The router name (always `"route"`)
+- `plugins` - Attached plugins with their configurations and per-handler overrides
+- `entries` - Registered handler names
+- `routers` - Child routers, each described with the same structure
 
 ## Exposing Configuration API
 
@@ -217,10 +223,9 @@ Create a dedicated configuration endpoint:
 ```python
 class ConfigAPI(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("logging")
-        self.admin = Router(self, name="admin")
+        self.route.plug("logging")
 
-    @route("admin")
+    @route()
     def configure_plugin(self, target: str, **options):
         """Configure plugins via API endpoint."""
         result = self.routing.configure(target, **options)
@@ -229,7 +234,7 @@ class ConfigAPI(RoutingClass):
 config = ConfigAPI()
 
 # Call via router
-result = config.admin.node("configure_plugin")("api:logging/_all_", enabled=True)
+result = config.route.node("configure_plugin")("logging/_all_", enabled=True)
 assert result["status"] == "ok"
 ```
 
@@ -245,27 +250,27 @@ assert result["status"] == "ok"
 **Invalid targets raise exceptions**:
 
 - `ValueError` - Malformed target syntax
-- `AttributeError` - Router or plugin not found
+- `AttributeError` - Plugin not found on the router
 - `KeyError` - Selector matches no handlers
 
 **Validation**:
 
 ```python
-# Router name cannot be empty
+# Plugin name cannot be empty
 try:
-    svc.routing.configure(":logging/_all_", enabled=True)
+    svc.routing.configure("/_all_", enabled=True)
 except ValueError:
     pass  # Expected
 
-# Plugin must exist
+# Plugin must be plugged on the router
 try:
-    svc.routing.configure("api:nonexistent/_all_", enabled=True)
+    svc.routing.configure("nonexistent/_all_", enabled=True)
 except AttributeError:
     pass  # Expected
 
 # Selector must match at least one handler
 try:
-    svc.routing.configure("api:logging/nonexistent", enabled=True)
+    svc.routing.configure("logging/nonexistent", enabled=True)
 except KeyError:
     pass  # Expected
 ```
@@ -276,11 +281,11 @@ except KeyError:
 
 ```python
 # Set defaults for all handlers
-svc.routing.configure("api:logging/_all_", enabled=True, level="info")
+svc.routing.configure("logging/_all_", enabled=True, log=True)
 
 # Override for specific handlers
-svc.routing.configure("api:logging/debug_*", level="debug")
-svc.routing.configure("api:logging/admin_*", enabled=False)
+svc.routing.configure("logging/debug_*", print=True)
+svc.routing.configure("logging/admin_*", enabled=False)
 ```
 
 **Configuration from files**:
@@ -300,10 +305,10 @@ svc.routing.configure(config["plugins"])
 
 ```python
 # Enable new feature for test handlers only
-svc.routing.configure("api:new_feature/test_*", enabled=True)
+svc.routing.configure("new_feature/test_*", enabled=True)
 
 # Expand to all after validation
-svc.routing.configure("api:new_feature/_all_", enabled=True)
+svc.routing.configure("new_feature/_all_", enabled=True)
 ```
 
 ## Next Steps

--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -20,18 +20,18 @@ Genro Routes includes six production-ready plugins:
 **LoggingPlugin** (`logging`):
 
 ```python
-from genro_routes import RoutingClass, Router, route
+from genro_routes import RoutingClass, route
 
 class Service(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("logging")
+        self.route.plug("logging")
 
-    @route("api")
+    @route()
     def process(self, data: str):
         return f"processed:{data}"
 
 svc = Service()
-result = svc.api.node("process")("test")  # Automatically logged
+result = svc.route.node("process")("test")  # Automatically logged
 ```
 
 **PydanticPlugin** (`pydantic`):
@@ -47,22 +47,22 @@ class UserResponse(TypedDict):
 
 class ValidatedService(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("pydantic")
+        self.route.plug("pydantic")
 
-    @route("api")
+    @route()
     def concat(self, text: str, number: int = 1) -> str:
         return f"{text}:{number}"
 
-    @route("api")
+    @route()
     def get_user(self, user_id: int) -> UserResponse:
         return {"id": user_id, "name": "alice"}
 
 svc = ValidatedService()
-svc.api.node("concat")("hello", 3)  # Valid
-# svc.api.node("concat")(123, "oops")  # ValidationError
+svc.route.node("concat")("hello", 3)  # Valid
+# svc.route.node("concat")(123, "oops")  # ValidationError
 
 # Response schema available in metadata
-entry = svc.api._entries["get_user"]
+entry = svc.route._entries["get_user"]
 schema = entry.metadata["pydantic"]["response_schema"]
 # {"type": "object", "properties": {"id": {"type": "integer"}, "name": {"type": "string"}}, ...}
 ```
@@ -72,15 +72,15 @@ schema = entry.metadata["pydantic"]["response_schema"]
 ```python
 class SecureService(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("auth")
+        self.route.plug("auth")
 
-    @route("api", auth_rule="admin")
+    @route(auth_rule="admin")
     def admin_only(self):
         return "secret"
 
 svc = SecureService()
-node = svc.api.node("admin_only", auth_tags="admin")  # Authorized
-node = svc.api.node("admin_only", auth_tags="guest")  # Not authorized
+node = svc.route.node("admin_only", auth_tags="admin")  # Authorized
+node = svc.route.node("admin_only", auth_tags="guest")  # Not authorized
 ```
 
 **EnvPlugin** (`env`):
@@ -95,15 +95,15 @@ class ServerCapabilities(CapabilitiesSet):
 
 class CapabilityService(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("env")
+        self.route.plug("env")
         self.capabilities = ServerCapabilities()
 
-    @route("api", env_requires="redis")
+    @route(env_requires="redis")
     def cached_action(self):
         return "cached"
 
 svc = CapabilityService()
-entries = svc.api.nodes().get("entries", {})  # "cached_action" visible
+entries = svc.route.nodes().get("entries", {})  # "cached_action" visible
 ```
 
 For dynamic capabilities that change at runtime, use `CapabilitiesSet`:
@@ -123,10 +123,10 @@ class ServerCapabilities(CapabilitiesSet):
 
 class DynamicService(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("env")
+        self.route.plug("env")
         self.capabilities = ServerCapabilities()
 
-    @route("api", env_requires="maintenance_window")
+    @route(env_requires="maintenance_window")
     def maintenance_task(self):
         return "maintenance"
 ```
@@ -138,9 +138,9 @@ Capabilities are evaluated dynamically on each `nodes()` call.
 ```python
 class APIService(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("openapi")
+        self.route.plug("openapi")
 
-    @route("api", openapi_method="post", openapi_tags="users")
+    @route(openapi_method="post", openapi_tags="users")
     def create_user(self, name: str) -> dict:
         return {"name": name}
 
@@ -153,24 +153,24 @@ svc = APIService()
 ```python
 class MultiChannelAPI(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("channel")
-        self.api.channel.configure(channels="*")  # default: all channels
+        self.route.plug("channel")
+        self.route.channel.configure(channels="*")  # default: all channels
 
-    @route("api", channel="mcp")  # shorthand for channel_channels="mcp"
+    @route(channel="mcp")  # shorthand for channel_channels="mcp"
     def mcp_only(self):
         return "MCP exclusive"
 
-    @route("api", channel="mcp,bot_.*")  # regex patterns supported
+    @route(channel="mcp,bot_.*")  # regex patterns supported
     def mcp_and_bots(self):
         return "MCP + any bot channel"
 
-    @route("api")  # inherits "*" from router config
+    @route()  # inherits "*" from router config
     def everywhere(self):
         return "all channels"
 
 svc = MultiChannelAPI()
-entries = svc.api.nodes(channel_channel="mcp")["entries"]   # all three
-entries = svc.api.nodes(channel_channel="rest")["entries"]   # only everywhere
+entries = svc.route.nodes(channel_channel="mcp")["entries"]   # all three
+entries = svc.route.nodes(channel_channel="rest")["entries"]   # only everywhere
 ```
 
 See [Quick Start - Plugins](../quickstart.md#adding-plugins) for more examples.
@@ -181,14 +181,14 @@ Plugins that declare a `plugin_default_param` support shorthand syntax in the `@
 
 ```python
 # These are equivalent:
-@route("api", auth_rule="admin")        # longform
-@route("api", auth="admin")             # shorthand
+@route(auth_rule="admin")        # longform
+@route(auth="admin")             # shorthand
 
-@route("api", env_requires="redis")     # longform
-@route("api", env="redis")              # shorthand
+@route(env_requires="redis")     # longform
+@route(env="redis")              # shorthand
 
-@route("api", channel_channels="mcp")   # longform
-@route("api", channel="mcp")            # shorthand
+@route(channel_channels="mcp")   # longform
+@route(channel="mcp")            # shorthand
 ```
 
 The shorthand is opt-in per plugin. Built-in plugins that support it:
@@ -249,48 +249,48 @@ The AuthPlugin provides **tag-based authorization** with boolean rule expression
 **Complete example**:
 
 ```python
-from genro_routes import RoutingClass, Router, route
+from genro_routes import RoutingClass, route
 from genro_routes import NotAuthenticated, NotAuthorized
 
 class SecureAPI(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("auth")
+        self.route.plug("auth")
 
-    @route("api")  # No rule = always accessible
+    @route()  # No rule = always accessible
     def public_info(self):
         return "public"
 
-    @route("api", auth_rule="user")  # Requires "user" tag
+    @route(auth_rule="user")  # Requires "user" tag
     def user_profile(self):
         return "profile"
 
-    @route("api", auth_rule="admin|moderator")  # Requires admin OR moderator
+    @route(auth_rule="admin|moderator")  # Requires admin OR moderator
     def manage_content(self):
         return "content"
 
-    @route("api", auth_rule="admin&!banned")  # Requires admin AND NOT banned
+    @route(auth_rule="admin&!banned")  # Requires admin AND NOT banned
     def admin_panel(self):
         return "admin"
 
 api = SecureAPI()
 
 # No tags - only public entries visible
-public_entries = api.api.nodes()
+public_entries = api.route.nodes()
 assert "public_info" in public_entries["entries"]
 assert "user_profile" not in public_entries["entries"]
 
 # With user tag
-user_entries = api.api.nodes(auth_tags="user")
+user_entries = api.route.nodes(auth_tags="user")
 assert "user_profile" in user_entries["entries"]
 
 # Calling protected handler
-node = api.api.node("admin_panel", auth_tags="admin")
+node = api.route.node("admin_panel", auth_tags="admin")
 assert node.error is None  # Authorized
 
-node = api.api.node("admin_panel", auth_tags="admin,banned")
+node = api.route.node("admin_panel", auth_tags="admin,banned")
 assert node.error == "not_authorized"  # Has admin but also banned
 
-node = api.api.node("admin_panel")  # No tags
+node = api.route.node("admin_panel")  # No tags
 assert node.error == "not_authenticated"
 ```
 
@@ -370,14 +370,14 @@ child.capabilities = ChildCapabilities()     # has "email"
 
 parent.attach_instance(child, name="child")
 
-# child.api.current_capabilities returns {"redis", "email"}
+# child.route.current_capabilities returns {"redis", "email"}
 # (accumulated from parent + child)
 ```
 
 **Complete example**:
 
 ```python
-from genro_routes import RoutingClass, Router, route
+from genro_routes import RoutingClass, route
 from genro_routes.plugins.env import CapabilitiesSet, capability
 
 class AppCapabilities(CapabilitiesSet):
@@ -391,33 +391,33 @@ class AppCapabilities(CapabilitiesSet):
 
 class FeatureAPI(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("env")
+        self.route.plug("env")
         self.capabilities = AppCapabilities()
 
-    @route("api")  # No requirements = always available
+    @route()  # No requirements = always available
     def basic_feature(self):
         return "basic"
 
-    @route("api", env_requires="cache")
+    @route(env_requires="cache")
     def cached_data(self):
         return "cached"
 
-    @route("api", env_requires="premium")
+    @route(env_requires="premium")
     def premium_feature(self):
         return "premium"
 
-    @route("api", env_requires="cache|premium")
+    @route(env_requires="cache|premium")
     def either_feature(self):
         return "either"
 
-    @route("api", env_requires="cache&premium")
+    @route(env_requires="cache&premium")
     def both_features(self):
         return "both"
 
 api = FeatureAPI()
 
 # Based on capabilities (cache=True, premium=False)
-entries = api.api.nodes()["entries"]
+entries = api.route.nodes()["entries"]
 assert "basic_feature" in entries
 assert "cached_data" in entries      # cache is True
 assert "premium_feature" not in entries  # premium is False
@@ -425,7 +425,7 @@ assert "either_feature" in entries   # cache OR premium
 assert "both_features" not in entries    # cache AND premium
 
 # Override with request capabilities
-entries = api.api.nodes(env_capabilities="premium")["entries"]
+entries = api.route.nodes(env_capabilities="premium")["entries"]
 assert "premium_feature" in entries  # Now available
 assert "both_features" in entries    # cache (instance) + premium (request)
 ```
@@ -461,7 +461,7 @@ Supported return types: `TypedDict`, `dict[str, T]`, `list[T]`, `str`, `int`, `b
 
 ```python
 from typing import TypedDict
-from genro_routes import RoutingClass, Router, route
+from genro_routes import RoutingClass, route
 
 class UserResponse(TypedDict):
     id: int
@@ -470,25 +470,25 @@ class UserResponse(TypedDict):
 
 class UserAPI(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("pydantic")
+        self.route.plug("pydantic")
 
-    @route("api")
+    @route()
     def get_user(self, user_id: int) -> UserResponse:
         return {"id": user_id, "name": "alice", "active": True}
 
-    @route("api")
+    @route()
     def list_users(self) -> list[UserResponse]:
         return []
 
 api = UserAPI()
 
 # Response schema in entry metadata
-entry = api.api._entries["get_user"]
+entry = api.route._entries["get_user"]
 schema = entry.metadata["pydantic"]["response_schema"]
 # {"type": "object", "properties": {"id": {...}, "name": {...}, "active": {...}}, ...}
 
 # Also exposed via nodes() introspection
-nodes = api.api.nodes()
+nodes = api.route.nodes()
 pydantic_meta = nodes["entries"]["get_user"]["plugins"]["pydantic"]["metadata"]
 assert "response_schema" in pydantic_meta
 ```
@@ -515,9 +515,8 @@ The OpenAPIPlugin provides **explicit control over OpenAPI schema generation**. 
 
 | Condition | Method |
 |-----------|--------|
-| Has parameters | `POST` |
-| No parameters, returns `None` | `POST` (side effect assumed) |
-| No parameters, returns value | `GET` |
+| All parameters are scalar (str, int, float, bool, Enum) | `GET` |
+| Any parameter is complex (dict, list, TypedDict, model) | `POST` |
 
 **Response schema generation**:
 
@@ -525,7 +524,7 @@ When handlers have return type annotations, the OpenAPI translator automatically
 
 ```python
 from typing import TypedDict
-from genro_routes import RoutingClass, Router, route
+from genro_routes import RoutingClass, route
 
 class ItemResponse(TypedDict):
     id: int
@@ -533,16 +532,16 @@ class ItemResponse(TypedDict):
 
 class ItemAPI(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("pydantic").plug("openapi")
+        self.route.plug("pydantic").plug("openapi")
 
-    @route("api")
+    @route()
     def get_item(self, item_id: int) -> ItemResponse:
         """Get a single item."""
         return {"id": item_id, "name": "widget"}
 
 api = ItemAPI()
-openapi = api.api.nodes(mode="openapi")
-# paths["/get_item"]["post"]["responses"]["200"]["content"]["application/json"]["schema"]
+openapi = api.route.nodes(mode="openapi")
+# paths["/get_item"]["get"]["responses"]["200"]["content"]["application/json"]["schema"]
 # → {"type": "object", "properties": {"id": {"type": "integer"}, "name": {"type": "string"}}, ...}
 ```
 
@@ -554,7 +553,7 @@ The plugin includes `OpenAPITranslator` for converting `nodes()` output to OpenA
 from genro_routes.plugins.openapi import OpenAPITranslator
 
 # Get nodes data
-nodes_data = api.api.nodes()
+nodes_data = api.route.nodes()
 
 # Flat OpenAPI format (all paths merged)
 openapi = OpenAPITranslator.translate_openapi(nodes_data)
@@ -568,35 +567,35 @@ h_openapi = OpenAPITranslator.translate_h_openapi(nodes_data)
 **Complete example**:
 
 ```python
-from genro_routes import RoutingClass, Router, route
+from genro_routes import RoutingClass, route
 from genro_routes.plugins.openapi import OpenAPITranslator
 
 class UserAPI(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("openapi")
+        self.route.plug("openapi")
 
-    @route("api", openapi_tags=["users"])
+    @route(openapi_tags=["users"])
     def list_users(self) -> list:
         """Get all users."""
         return []
 
-    @route("api", openapi_method="post", openapi_tags=["users"])
+    @route(openapi_method="post", openapi_tags=["users"])
     def create_user(self, name: str, email: str) -> dict:
         """Create a new user."""
         return {"name": name, "email": email}
 
-    @route("api", openapi_method="delete", openapi_tags=["users", "admin"])
+    @route(openapi_method="delete", openapi_tags=["users", "admin"])
     def delete_user(self, user_id: int) -> dict:
         """Delete a user (admin only)."""
         return {"deleted": user_id}
 
-    @route("api", openapi_deprecated=True)
+    @route(openapi_deprecated=True)
     def legacy_endpoint(self) -> str:
         """Deprecated endpoint."""
         return "legacy"
 
 api = UserAPI()
-nodes = api.api.nodes()
+nodes = api.route.nodes()
 openapi = OpenAPITranslator.translate_openapi(nodes)
 
 # openapi["paths"] contains:
@@ -650,43 +649,43 @@ The ChannelPlugin provides **channel-based endpoint filtering**. It controls acc
 **Complete example**:
 
 ```python
-from genro_routes import RoutingClass, Router, route
+from genro_routes import RoutingClass, route
 
 class MultiChannelAPI(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("channel")
-        self.api.channel.configure(channels="*")  # default: all channels
+        self.route.plug("channel")
+        self.route.channel.configure(channels="*")  # default: all channels
 
-    @route("api", channel="mcp")  # shorthand syntax
+    @route(channel="mcp")  # shorthand syntax
     def mcp_tool(self):
         return "only via MCP"
 
-    @route("api", channel="mcp,bot_.*")
+    @route(channel="mcp,bot_.*")
     def ai_accessible(self):
         return "MCP + any bot"
 
-    @route("api", channel="rest,web")
+    @route(channel="rest,web")
     def browser_only(self):
         return "REST or web"
 
-    @route("api")  # inherits "*" from router config
+    @route()  # inherits "*" from router config
     def universal(self):
         return "everywhere"
 
 api = MultiChannelAPI()
 
 # MCP client sees: mcp_tool, ai_accessible, universal
-entries = api.api.nodes(channel_channel="mcp")["entries"]
+entries = api.route.nodes(channel_channel="mcp")["entries"]
 assert "mcp_tool" in entries
 assert "browser_only" not in entries
 
 # REST client sees: browser_only, universal
-entries = api.api.nodes(channel_channel="rest")["entries"]
+entries = api.route.nodes(channel_channel="rest")["entries"]
 assert "browser_only" in entries
 assert "mcp_tool" not in entries
 
-# Combined with auth
-api2 = Router(Owner(), name="api").plug("channel").plug("auth")
+# Combined with auth: plug both plugins on the same router
+# self.route.plug("channel").plug("auth")
 # Both filters must pass for entry to be visible
 ```
 
@@ -740,15 +739,15 @@ Router.register_plugin(CapturePlugin)
 # Use in service
 class PluginService(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("capture")
+        self.route.plug("capture")
 
-    @route("api")
+    @route()
     def do_work(self):
         return "ok"
 
 svc = PluginService()
-result = svc.api.node("do_work")()
-assert svc.api.capture.calls == ["do_work"]
+result = svc.route.node("do_work")()
+assert svc.route.capture.calls == ["do_work"]
 ```
 
 ### Constructor Signature
@@ -806,11 +805,9 @@ Response ← [Last Plugin] ← [Middle Plugin] ← [First Plugin] ← Handler
 ```python
 class Service(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api")\
-            .plug("logging")\
-            .plug("pydantic")
+        self.route.plug("logging").plug("pydantic")
 
-    @route("api")
+    @route()
     def process(self, count: int):
         return f"processed:{count}"
 ```
@@ -838,8 +835,7 @@ class Service(RoutingClass):
 **Common pattern for production**:
 
 ```python
-self.api = Router(self, name="api")\
-    .plug("logging")\
+self.route.plug("logging")\
     .plug("auth")\
     .plug("pydantic")\
     .plug("openapi")
@@ -1141,33 +1137,35 @@ This approach gives maximum flexibility:
 
 ### Example: AuthPlugin Inheritance
 
-AuthPlugin has specific inheritance semantics using **union** of tags:
+AuthPlugin follows the default inheritance behavior: a child without its own
+auth configuration inherits the parent's router-level rule:
 
 ```python
-class Parent(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="api").plug("auth", tags="corporate")
-        self.child = Child()
-
 class Child(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="api").plug("auth", tags="internal")
-
-    @route("api", auth_rule="admin")
+    @route(auth_rule="admin")
     def admin_only(self): ...
 
+    @route()
+    def open_action(self): ...
+
+class Parent(RoutingClass):
+    def __init__(self):
+        self.route.plug("auth", rule="corporate")
+        self.child = Child()
+        self.attach_instance(self.child, name="child")
+
 parent = Parent()
-parent.attach_instance(parent.child, name="child")
 
 # Result:
-# - child._all_ tags: "corporate,internal" (union from parent + child)
-# - admin_only tags: "corporate,internal,admin" (union with entry tags)
+# - The child inherits the auth plugin with the parent's router-level
+#   rule ("corporate"): open_action requires the "corporate" tag
+# - admin_only keeps its own entry rule ("admin")
 ```
 
-**Tag semantics**:
+**Rule semantics**:
 
-- Entry without tags → always visible (public)
-- Entry with tags → visible if filter matches at least one tag
+- Entry without a rule (and no router-level rule) → always accessible (public)
+- Entry with a rule → accessible only if the `auth_tags` satisfy the rule expression
 
 See [ARCHITECTURE.md](../ARCHITECTURE.md#plugin-inheritance) for detailed inheritance documentation.
 
@@ -1189,7 +1187,7 @@ Router.register_plugin(CustomPlugin)
 # Now available in all routers
 class Service(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("custom")
+        self.route.plug("custom")
 ```
 
 **Registration rules**:
@@ -1236,9 +1234,9 @@ Router.register_plugin(CapturePlugin)
 svc1 = PluginService()
 svc2 = PluginService()
 
-svc1.api.node("do_work")()
-assert svc1.api.capture.calls == ["do_work"]
-assert svc2.api.capture.calls == []  # Independent state
+svc1.route.node("do_work")()
+assert svc1.route.capture.calls == ["do_work"]
+assert svc2.route.capture.calls == []  # Independent state
 ```
 
 **Benefits**:
@@ -1405,14 +1403,14 @@ Router.register_plugin(AuthPlugin)
 # Use in service
 class API(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("auth")
+        self.route.plug("auth")
 
-    @route("api")
+    @route()
     def public_endpoint(self, request):
         """@roles:guest"""
         return "public data"
 
-    @route("api")
+    @route()
     def admin_endpoint(self, request):
         """@roles:admin"""
         return "admin data"
@@ -1420,7 +1418,7 @@ class API(RoutingClass):
 api = API()
 
 # Configure: disable auth requirement for public endpoints
-api.api.auth.configure(_target="public_endpoint", required=False)
+api.route.auth.configure(_target="public_endpoint", required=False)
 ```
 
 ## Best Practices
@@ -1441,14 +1439,13 @@ class EverythingPlugin(BasePlugin): ...
 
 ```python
 # Good: Multiple simple plugins
-self.api = Router(self, name="api")\
-    .plug("logging")\
+self.route.plug("logging")\
     .plug("pydantic")\
     .plug("caching")\
     .plug("auth")
 
 # Bad: One complex plugin
-self.api = Router(self, name="api").plug("monolith")
+self.route.plug("monolith")
 ```
 
 **Configuration defaults**:
@@ -1490,13 +1487,13 @@ The `Router` class provides methods to enable/disable plugins and store runtime 
 svc = MyService()
 
 # Disable pydantic validation for a specific handler at runtime
-svc.api.set_plugin_enabled("handler_name", "pydantic", enabled=False)
+svc.route.set_plugin_enabled("handler_name", "pydantic", enabled=False)
 
 # Disable globally for all handlers
-svc.api.set_plugin_enabled("_all_", "logging", enabled=False)
+svc.route.set_plugin_enabled("_all_", "logging", enabled=False)
 
 # Check if a plugin is enabled for a handler
-if svc.api.is_plugin_enabled("handler_name", "pydantic"):
+if svc.route.is_plugin_enabled("handler_name", "pydantic"):
     print("Validation active")
 ```
 
@@ -1514,10 +1511,10 @@ Plugins can use `set_runtime_data` / `get_runtime_data` to store handler-specifi
 
 ```python
 # Store runtime data for a plugin/handler combination
-svc.api.set_runtime_data("handler_name", "my_plugin", "call_count", 0)
+svc.route.set_runtime_data("handler_name", "my_plugin", "call_count", 0)
 
 # Retrieve runtime data
-count = svc.api.get_runtime_data("handler_name", "my_plugin", "call_count", default=0)
+count = svc.route.get_runtime_data("handler_name", "my_plugin", "call_count", default=0)
 ```
 
 **Use cases**:

--- a/docs/guide/why-one-name-per-operation.md
+++ b/docs/guide/why-one-name-per-operation.md
@@ -15,7 +15,7 @@ detail, resolved at the bridge layer.
 
 The REST model maps four CRUD verbs to four HTTP methods on a resource path:
 
-```
+```text
 GET    /users      -> list
 POST   /users      -> create
 GET    /users/123  -> retrieve
@@ -61,18 +61,15 @@ In genro-routes, each handler has a unique name that **is** the operation:
 
 ```python
 class OrdersAPI(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="orders")
-
-    @route("orders")
+    @route()
     def list_orders(self):
         return [...]
 
-    @route("orders")
+    @route()
     def create_order(self, payload: dict):
         return {"status": "created"}
 
-    @route("orders")
+    @route()
     def approve_order(self, order_id: str):
         return {"status": "approved"}
 ```
@@ -81,9 +78,10 @@ The HTTP method is inferred automatically when generating OpenAPI schemas:
 handlers with no parameters or only scalar parameters become GET,
 handlers with complex parameters become POST.
 
-When exposed via an HTTP bridge like genro-asgi, the mapping is:
+When exposed via an HTTP bridge like genro-asgi (with the service attached
+under the `orders` alias), the mapping is:
 
-```
+```text
 GET  /orders/list_orders
 POST /orders/create_order
 POST /orders/approve_order

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ The routing logic lives in your application objects - the transport adapter (lik
 
 ## Key Features
 
-- **Instance-scoped routers** - Every object gets an isolated router with its own plugin stack
+- **One class, one router** - Every `RoutingClass` owns exactly one isolated router with its own plugin stack, exposed as the `route` property
 - **Hierarchical organization** - Build router trees with `attach_instance()` and `/` path traversal
 - **Composable plugins** - Hook into decoration and handler execution with `BasePlugin`
 - **Plugin inheritance** - Plugins propagate automatically from parent to child routers
@@ -44,14 +44,13 @@ The routing logic lives in your application objects - the transport adapter (lik
 ## Quick Example
 
 ```python
-from genro_routes import RoutingClass, Router, route
+from genro_routes import RoutingClass, route
 
 class Service(RoutingClass):
     def __init__(self, label: str):
         self.label = label
-        self.api = Router(self, name="api")
 
-    @route("api")
+    @route()
     def describe(self):
         return f"service:{self.label}"
 
@@ -59,8 +58,8 @@ class Service(RoutingClass):
 first = Service("alpha")
 second = Service("beta")
 
-assert first.api.node("describe")() == "service:alpha"
-assert second.api.node("describe")() == "service:beta"
+assert first.route.node("describe")() == "service:alpha"
+assert second.route.node("describe")() == "service:beta"
 ```
 
 ## Documentation Sections

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,14 +15,13 @@ pip install genro-routes
 Create a service with instance-scoped routing:
 
 ```python
-from genro_routes import RoutingClass, Router, route
+from genro_routes import RoutingClass, route
 
 class Service(RoutingClass):
     def __init__(self, label: str):
         self.label = label
-        self.api = Router(self, name="api")
 
-    @route("api")
+    @route()
     def describe(self):
         return f"service:{self.label}"
 
@@ -30,17 +29,17 @@ class Service(RoutingClass):
 first = Service("alpha")
 second = Service("beta")
 
-assert first.api.node("describe")() == "service:alpha"
-assert second.api.node("describe")() == "service:beta"
+assert first.route.node("describe")() == "service:alpha"
+assert second.route.node("describe")() == "service:beta"
 ```
 
-**Key concept**: Routers are instantiated in `__init__` with `Router(self, ...)` - each instance gets its own isolated router.
+**Key concept**: Every `RoutingClass` owns exactly one router, created automatically and exposed as the `route` property - each instance gets its own isolated router. You never instantiate `Router` yourself.
 
 ## Custom Entry Names
 
 <!-- test: test_router_basic.py::test_prefix_and_name_override -->
 
-[From test](https://github.com/genropy/genro-routes/blob/main/tests/test_router_basic.py#L151-L156)
+[From test](https://github.com/genropy/genro-routes/blob/main/tests/test_router_basic.py#L150-L154)
 
 Use prefixes and explicit names for cleaner method registration:
 
@@ -48,45 +47,44 @@ Use prefixes and explicit names for cleaner method registration:
 class SubService(RoutingClass):
     def __init__(self, prefix: str):
         self.prefix = prefix
-        self.routes = Router(self, name="routes", prefix="handle_")
+        self.route.prefix = "handle_"
 
-    @route("routes")
+    @route()
     def handle_list(self):
         return f"{self.prefix}:list"
 
-    @route("routes", name="detail")
+    @route(name="detail")
     def handle_detail(self, ident: int):
         return f"{self.prefix}:detail:{ident}"
 
 sub = SubService("users")
 
 # Prefix stripped: "handle_list" → "list"
-assert sub.routes.node("list")() == "users:list"
+assert sub.route.node("list")() == "users:list"
 
 # Custom name used: "handle_detail" → "detail"
-assert sub.routes.node("detail")(10) == "users:detail:10"
+assert sub.route.node("detail")(10) == "users:detail:10"
 ```
 
-## Single Router Default
+Router options like `prefix` and `description` are set on the existing router in `__init__` (binding is lazy, so this is race-free).
+
+## One Class, One Router
 
 <!-- test: test_router_basic.py::TestSingleRouterDefault::test_route_without_args_uses_single_router -->
 
-When a class has exactly one router, `@route()` without arguments uses it automatically:
+`@route()` always registers the method on the class's single router. A class with no plugins or router options needs no `__init__` at all:
 
 ```python
 class Table(RoutingClass):
-    def __init__(self):
-        self.table = Router(self, name="table")
-
-    @route()  # Uses the only router automatically
+    @route()
     def add(self, data):
         return f"added:{data}"
 
 t = Table()
-assert t.table.node("add")("x") == "added:x"
+assert t.route.node("add")("x") == "added:x"
 ```
 
-If the class has multiple routers, you must specify the router name explicitly.
+Need more than one routing surface (e.g. `api` and `admin`)? Compose separate `RoutingClass` instances with `attach_instance()` - see [Building Hierarchies](#building-hierarchies) below.
 
 ## Building Hierarchies
 
@@ -95,7 +93,6 @@ Create nested router structures:
 ```python
 class RootAPI(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api")
         self.users = SubService("users")
         self.products = SubService("products")
 
@@ -105,56 +102,56 @@ class RootAPI(RoutingClass):
 root = RootAPI()
 
 # Access with path separator
-assert root.api.node("users/list")() == "users:list"
-assert root.api.node("products/detail")(5) == "products:detail:5"
+assert root.route.node("users/list")() == "users:list"
+assert root.route.node("products/detail")(5) == "products:detail:5"
 ```
 
 ## Adding Plugins
 
 <!-- test: test_router_basic.py::test_plugins_are_per_instance_and_accessible -->
 
-[From test](https://github.com/genropy/genro-routes/blob/main/tests/test_router_basic.py#L159-L167)
+[From test](https://github.com/genropy/genro-routes/blob/main/tests/test_router_basic.py#L157-L165)
 
 Extend behavior with plugins. Built-in plugins (`logging`, `pydantic`, `auth`, `env`, `openapi`) are pre-registered.
 
 ```python
 class PluginService(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("logging")
+        self.route.plug("logging")
 
-    @route("api")
+    @route()
     def do_work(self):
         return "ok"
 
 svc = PluginService()
-result = svc.api.node("do_work")()  # Automatically logged
+result = svc.route.node("do_work")()  # Automatically logged
 ```
 
 ## Validating Arguments
 
 <!-- test: test_pydantic_plugin.py::test_pydantic_plugin_accepts_valid_input -->
 
-[From test](https://github.com/genropy/genro-routes/blob/main/tests/test_pydantic_plugin.py#L22-L27)
+[From test](https://github.com/genropy/genro-routes/blob/main/tests/test_pydantic_plugin.py#L36-L41)
 
 Use Pydantic for automatic validation:
 
 ```python
 class ValidateService(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("pydantic")
+        self.route.plug("pydantic")
 
-    @route("api")
+    @route()
     def concat(self, text: str, number: int = 1) -> str:
         return f"{text}:{number}"
 
 svc = ValidateService()
 
 # Valid inputs
-assert svc.api.node("concat")("hello", 3) == "hello:3"
-assert svc.api.node("concat")("hi") == "hi:1"
+assert svc.route.node("concat")("hello", 3) == "hello:3"
+assert svc.route.node("concat")("hi") == "hi:1"
 
 # Invalid inputs raise ValidationError
-# svc.api.node("concat")(123, "oops")  # ValidationError!
+# svc.route.node("concat")(123, "oops")  # ValidationError!
 ```
 
 ## Response Schemas
@@ -170,16 +167,16 @@ class StatusResponse(TypedDict):
 
 class HealthService(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("pydantic")
+        self.route.plug("pydantic")
 
-    @route("api")
+    @route()
     def health(self) -> StatusResponse:
         return {"ok": True, "message": "running"}
 
 svc = HealthService()
 
 # Response schema is generated automatically
-entry = svc.api._entries["health"]
+entry = svc.route._entries["health"]
 schema = entry.metadata["pydantic"]["response_schema"]
 # {"type": "object", "properties": {"ok": {"type": "boolean"}, "message": {"type": "string"}}, ...}
 ```
@@ -192,13 +189,10 @@ Handlers need access to shared state (database, user, session) without
 knowing which adapter provides it. Use `RoutingContext`:
 
 ```python
-from genro_routes import RoutingClass, RoutingContext, Router, route
+from genro_routes import RoutingClass, RoutingContext, route
 
 class OrderService(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="api")
-
-    @route("api")
+    @route()
     def list_orders(self):
         return self.ctx.db.query("SELECT * FROM orders")
 
@@ -208,7 +202,7 @@ ctx.db = my_database
 
 svc = OrderService()
 svc.ctx = ctx
-svc.api.node("list_orders")()  # handler reads self.ctx.db
+svc.route.node("list_orders")()  # handler reads self.ctx.db
 ```
 
 Contexts can be layered with `RoutingContext(parent=parent_ctx)` — missing

--- a/examples/WHY_GENRO_ROUTES.md
+++ b/examples/WHY_GENRO_ROUTES.md
@@ -18,7 +18,7 @@ The utility of `genro-routes` emerges when you look at the **system architecture
 
 ## 4. Automatic Documentation (OpenAPI)
 *   **Pure Library**: To know what the library does, developers must read its source code or external documentation.
-*   **With Genro-Routes**: Calling `service.api.nodes(mode="openapi")` instantly generates technical documentation (Swagger/OpenAPI). Your colleagues will know exactly which methods are available and what parameters they require without ever seeing your Python code.
+*   **With Genro-Routes**: Calling `service.route.nodes(mode="openapi")` instantly generates technical documentation (Swagger/OpenAPI). Your colleagues will know exactly which methods are available and what parameters they require without ever seeing your Python code.
 
 ## 5. Technical Decoupling (The Contract)
 If you decide to switch the underlying implementation (e.g., swapping `Pygments` for a faster Rust-based highlighter), you only change the internal code of your handler. For everyone else in the organization, the endpoint `api/highlighter/html` remains identical. **You have created a stable contract, not just a function call.**

--- a/examples/auth_roles.py
+++ b/examples/auth_roles.py
@@ -1,25 +1,25 @@
 from __future__ import annotations
-from genro_routes import Router, RoutingClass, route
+from genro_routes import RoutingClass, route
 from genro_routes.exceptions import NotAuthenticated, NotAuthorized
 
 class SecureService(RoutingClass):
     def __init__(self):
         # We plug the 'auth' plugin to enable role-based access control
-        self.api = Router(self, name="api").plug("auth")
+        self.route.plug("auth")
 
-    @route("api")
+    @route()
     def public_info(self):
         """Available to everyone."""
         return {"status": "online", "access": "public"}
 
     # This node requires 'user' tag
-    @route("api", auth_tags="user")
+    @route(auth_tags="user")
     def user_profile(self):
         """Requires a valid user role."""
         return {"profile": "User Data", "access": "restricted"}
 
     # This node requires 'admin' tag
-    @route("api", auth_tags="admin")
+    @route(auth_tags="admin")
     def admin_settings(self):
         """Requires administrative privileges."""
         return {"settings": "System Config", "access": "admin_only"}
@@ -28,28 +28,28 @@ if __name__ == "__main__":
     service = SecureService()
 
     print("--- 1. Public Access ---")
-    node = service.api.node("public_info")
+    node = service.route.node("public_info")
     print(f"Result: {node()}")
 
     print("\n--- 2. Accessing User Data WITHOUT roles ---")
     try:
         # Calling without providing auth_tags in kwargs
-        service.api.node("user_profile")()
+        service.route.node("user_profile")()
     except NotAuthenticated:
         print("Caught expected: NotAuthenticated (401)")
 
     print("\n--- 3. Accessing User Data WITH 'user' role ---")
     # We pass current user capabilities to the node resolution
-    user_node = service.api.node("user_profile", auth_tags="user")
+    user_node = service.route.node("user_profile", auth_tags="user")
     print(f"Result: {user_node()}")
 
     print("\n--- 4. Accessing Admin Data WITH 'user' role ---")
     try:
         # Providing 'user' tag for an 'admin' required node
-        service.api.node("admin_settings", auth_tags="user")()
+        service.route.node("admin_settings", auth_tags="user")()
     except NotAuthorized:
         print("Caught expected: NotAuthorized (403)")
 
     print("\n--- 5. Accessing Admin Data WITH 'admin' role ---")
-    admin_node = service.api.node("admin_settings", auth_tags="admin")
+    admin_node = service.route.node("admin_settings", auth_tags="admin")
     print(f"Result: {admin_node()}")

--- a/examples/auth_roles.py
+++ b/examples/auth_roles.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
+
 from genro_routes import RoutingClass, route
 from genro_routes.exceptions import NotAuthenticated, NotAuthorized
+
 
 class SecureService(RoutingClass):
     def __init__(self):

--- a/examples/deep_repo_explorer.py
+++ b/examples/deep_repo_explorer.py
@@ -2,16 +2,13 @@ from __future__ import annotations
 import os
 import inspect
 import importlib.util
-from typing import Any
-from genro_routes import Router, RoutingClass, route
+from genro_routes import Router, RoutingClass, Section
 
 class MagicClassRouter(RoutingClass):
     """Maps all public methods of a class as routes."""
-    def __init__(self, name: str, cls: type, parent_router: Router):
-        # Plugins are inherited from parent, no need to plug again
-        self.router = Router(self, name=name, parent_router=parent_router)
+    def __init__(self, cls: type):
         self._cls = cls
-        
+
         # We need an instance to bind methods, or we treat them as static
         # For a "repo explorer", we might just map the signatures
         for attr_name in dir(cls):
@@ -19,12 +16,12 @@ class MagicClassRouter(RoutingClass):
                 continue
             attr = getattr(cls, attr_name)
             if inspect.isfunction(attr) or inspect.ismethod(attr):
-                self.router.add_entry(attr, name=attr_name)
+                self.route.add_entry(attr, name=attr_name)
 
 class PythonModuleService(RoutingClass):
     """Exposes internal functions and classes of a Python module as routes."""
-    def __init__(self, name: str, file_path: str, parent_router: Router):
-        self.router = Router(self, name=name, parent_router=parent_router).plug("pydantic")
+    def __init__(self, name: str, file_path: str):
+        self.route.plug("pydantic")
         self.file_path = os.path.abspath(file_path)
         self._module_name = name
         self._module = self._import_file(name, file_path)
@@ -55,25 +52,25 @@ class PythonModuleService(RoutingClass):
                 try:
                     attr_file = inspect.getsourcefile(attr)
                     if attr_file and os.path.samefile(os.path.abspath(attr_file), self.file_path):
-                        self.router.add_entry(attr, name=attr_name)
+                        self.route.add_entry(attr, name=attr_name)
                 except (TypeError, ValueError, OSError):
                     pass
             elif inspect.isclass(attr):
                 # Check if class belongs to this module via __module__
                 if getattr(attr, "__module__", None) == self._module_name:
-                    MagicClassRouter(attr_name, attr, self.router)
+                    self.route.include(MagicClassRouter(attr).route, name=attr_name)
 
 class CodeInspector(RoutingClass):
     """Orchestrates the discovery of Python modules as functional routers."""
     def __init__(self, root_path: str):
         self.root = os.path.abspath(root_path)
-        self.api = Router(self, name="inspector")
-        self._discover_modules(self.api, self.root, depth=1)
+        self.route.description = "Repository inspector"
+        self._discover_modules(self.route, self.root, depth=1)
 
     def _discover_modules(self, parent_router: Router, current_path: str, depth: int):
         if depth < 0:
             return
-            
+
         try:
             items = os.listdir(current_path)
         except PermissionError:
@@ -83,13 +80,15 @@ class CodeInspector(RoutingClass):
             if item.startswith('.') or item == "__pycache__":
                 continue
             full_path = os.path.join(current_path, item)
-            
+
             if os.path.isdir(full_path):
-                branch = Router(self, name=item, branch=True, parent_router=parent_router)
-                self._discover_modules(branch, full_path, depth - 1)
-            
+                section = Section()
+                parent_router.include(section.route, name=item)
+                self._discover_modules(section.route, full_path, depth - 1)
+
             elif item.endswith('.py'):
-                PythonModuleService(item[:-3], full_path, parent_router)
+                module_service = PythonModuleService(item[:-3], full_path)
+                parent_router.include(module_service.route, name=item[:-3])
 
 if __name__ == "__main__":
     # Explore the mcp_bridge example folder
@@ -97,13 +96,13 @@ if __name__ == "__main__":
     inspector = CodeInspector(target)
 
     print(f"--- Deep Repo Explorer (Enhanced) ---")
-    
+
     # Introspect result
-    info = inspector.api.nodes()
+    info = inspector.route.nodes()
     routers = info.get("routers", {})
-    
+
     print(f"Discovered items in bridge folder: {list(routers.keys())}")
-    
+
     # Check bridge.py (containing classes)
     if "bridge" in routers:
         content = routers["bridge"]
@@ -111,7 +110,7 @@ if __name__ == "__main__":
         # Now we should see classes as child routers
         classes = content.get("routers", {})
         print(f" - Classes discovered: {list(classes.keys())}")
-        
+
         if "GenroMCPBridge" in classes:
             methods = list(classes["GenroMCPBridge"].get("entries", {}).keys())
             print(f" - Methods in GenroMCPBridge: {methods}")

--- a/examples/deep_repo_explorer.py
+++ b/examples/deep_repo_explorer.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
-import os
-import inspect
+
 import importlib.util
+import inspect
+import os
+
 from genro_routes import Router, RoutingClass, Section
+
 
 class MagicClassRouter(RoutingClass):
     """Maps all public methods of a class as routes."""
@@ -55,10 +58,9 @@ class PythonModuleService(RoutingClass):
                         self.route.add_entry(attr, name=attr_name)
                 except (TypeError, ValueError, OSError):
                     pass
-            elif inspect.isclass(attr):
-                # Check if class belongs to this module via __module__
-                if getattr(attr, "__module__", None) == self._module_name:
-                    self.route.include(MagicClassRouter(attr).route, name=attr_name)
+            elif inspect.isclass(attr) and getattr(attr, "__module__", None) == self._module_name:
+                # Class belongs to this module via __module__
+                self.route.include(MagicClassRouter(attr).route, name=attr_name)
 
 class CodeInspector(RoutingClass):
     """Orchestrates the discovery of Python modules as functional routers."""
@@ -95,7 +97,7 @@ if __name__ == "__main__":
     target = os.path.join(os.path.dirname(os.path.abspath(__file__)), "mcp_bridge")
     inspector = CodeInspector(target)
 
-    print(f"--- Deep Repo Explorer (Enhanced) ---")
+    print("--- Deep Repo Explorer (Enhanced) ---")
 
     # Introspect result
     info = inspector.route.nodes()
@@ -106,7 +108,7 @@ if __name__ == "__main__":
     # Check bridge.py (containing classes)
     if "bridge" in routers:
         content = routers["bridge"]
-        print(f"\nContents of 'bridge.py':")
+        print("\nContents of 'bridge.py':")
         # Now we should see classes as child routers
         classes = content.get("routers", {})
         print(f" - Classes discovered: {list(classes.keys())}")

--- a/examples/faker_magic.py
+++ b/examples/faker_magic.py
@@ -2,15 +2,15 @@ from __future__ import annotations
 import inspect
 from typing import Any
 from faker import Faker
-from genro_routes import Router, RoutingClass
+from genro_routes import RoutingClass
 
 # -----------------------------------------------------------------------------
 # MAGIC Wrapper: Automatically maps all methods of an object as routes
 # -----------------------------------------------------------------------------
 
 class MagicFakerRouter(RoutingClass):
-    def __init__(self, name: str, provider_obj: Any):
-        self.router = Router(self, name=name).plug("pydantic")
+    def __init__(self, provider_obj: Any):
+        self.route.plug("pydantic")
         self._provider = provider_obj
         
         # Magic introspection: map all public methods of the provider
@@ -22,7 +22,7 @@ class MagicFakerRouter(RoutingClass):
             if inspect.ismethod(attr) or inspect.isfunction(attr):
                 # Dynamically register the entry in the router
                 # This is the core of genro-routes' power
-                self.router.add_entry(attr, name=attr_name)
+                self.route.add_entry(attr, name=attr_name)
 
 # -----------------------------------------------------------------------------
 # Service exposing ALL of Faker hierarchically
@@ -31,13 +31,12 @@ class MagicFakerRouter(RoutingClass):
 class FullFakerService(RoutingClass):
     def __init__(self, locale: str = "en_US"):
         self.fake = Faker(locale=locale)
-        self.api = Router(self, name="api")
-        
+
         # Map entire functionality blocks automatically
         # (Faker organizes methods internally; here we choose main providers)
-        self.person = MagicFakerRouter("person", self.fake)
-        self.address = MagicFakerRouter("address", self.fake)
-        self.company = MagicFakerRouter("company", self.fake)
+        self.person = MagicFakerRouter(self.fake)
+        self.address = MagicFakerRouter(self.fake)
+        self.company = MagicFakerRouter(self.fake)
         
         self.attach_instance(self.person, name="person")
         self.attach_instance(self.address, name="address")
@@ -49,13 +48,13 @@ if __name__ == "__main__":
     print(f"--- FULL DYNAMIC MAPPING ACTIVE ---")
     
     # Now we can call ANYTHING, even if not explicitly defined!
-    print(f"Name: {service.api.node('person/name')()}")
-    print(f"Last Name: {service.api.node('person/last_name')()}")
-    print(f"SSN: {service.api.node('person/ssn')()}")
-    print(f"Company: {service.api.node('company/company')()}")
-    print(f"Catch Phrase: {service.api.node('company/catch_phrase')()}")
+    print(f"Name: {service.route.node('person/name')()}")
+    print(f"Last Name: {service.route.node('person/last_name')()}")
+    print(f"SSN: {service.route.node('person/ssn')()}")
+    print(f"Company: {service.route.node('company/company')()}")
+    print(f"Catch Phrase: {service.route.node('company/catch_phrase')()}")
 
     # And OpenAPI will reflect ALL discovered methods
-    nodes = service.api.nodes()
+    nodes = service.route.nodes()
     count = len(nodes['routers']['person']['entries'])
     print(f"\nThe 'person' router automatically exposed {count} Faker methods.")

--- a/examples/faker_magic.py
+++ b/examples/faker_magic.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
+
 import inspect
 from typing import Any
+
 from faker import Faker
+
 from genro_routes import RoutingClass
 
 # -----------------------------------------------------------------------------
@@ -12,12 +15,12 @@ class MagicFakerRouter(RoutingClass):
     def __init__(self, provider_obj: Any):
         self.route.plug("pydantic")
         self._provider = provider_obj
-        
+
         # Magic introspection: map all public methods of the provider
         for attr_name in dir(provider_obj):
             if attr_name.startswith("_"):
                 continue
-            
+
             attr = getattr(provider_obj, attr_name)
             if inspect.ismethod(attr) or inspect.isfunction(attr):
                 # Dynamically register the entry in the router
@@ -37,7 +40,7 @@ class FullFakerService(RoutingClass):
         self.person = MagicFakerRouter(self.fake)
         self.address = MagicFakerRouter(self.fake)
         self.company = MagicFakerRouter(self.fake)
-        
+
         self.attach_instance(self.person, name="person")
         self.attach_instance(self.address, name="address")
         self.attach_instance(self.company, name="company")
@@ -45,8 +48,8 @@ class FullFakerService(RoutingClass):
 if __name__ == "__main__":
     service = FullFakerService()
 
-    print(f"--- FULL DYNAMIC MAPPING ACTIVE ---")
-    
+    print("--- FULL DYNAMIC MAPPING ACTIVE ---")
+
     # Now we can call ANYTHING, even if not explicitly defined!
     print(f"Name: {service.route.node('person/name')()}")
     print(f"Last Name: {service.route.node('person/last_name')()}")

--- a/examples/faker_standard.py
+++ b/examples/faker_standard.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
-from typing import Any
 from faker import Faker
-from genro_routes import Router, RoutingClass, route
+from genro_routes import RoutingClass, route
 
 # -----------------------------------------------------------------------------
 # 1. Child routers focused on specific domains
@@ -11,14 +10,14 @@ class PersonService(RoutingClass):
     def __init__(self, fake: Faker):
         self.fake = fake
         # Plug the pydantic plugin for automatic validation
-        self.router = Router(self, name="person").plug("pydantic")
+        self.route.plug("pydantic")
 
-    @route("person")
+    @route()
     def name(self) -> str:
         """Returns a full name."""
         return self.fake.name()
 
-    @route("person")
+    @route()
     def email(self, domain: str | None = None) -> str:
         """Returns an email address, optionally for a specific domain."""
         return self.fake.email(domain=domain)
@@ -26,9 +25,9 @@ class PersonService(RoutingClass):
 class AddressService(RoutingClass):
     def __init__(self, fake: Faker):
         self.fake = fake
-        self.router = Router(self, name="address").plug("pydantic")
+        self.route.plug("pydantic")
 
-    @route("address")
+    @route()
     def city(self) -> str:
         """Returns a city name."""
         return self.fake.city()
@@ -40,10 +39,7 @@ class AddressService(RoutingClass):
 class FakerService(RoutingClass):
     def __init__(self, locale: str = "en_US"):
         self.fake = Faker(locale=locale)
-        
-        # Main router
-        self.api = Router(self, name="api")
-        
+
         # Mount child services as branches of the main router
         self.person = PersonService(self.fake)
         self.address = AddressService(self.fake)
@@ -60,17 +56,17 @@ if __name__ == "__main__":
     service = FakerService()
 
     # 1. Access via hierarchical path
-    print(f"English Name: {service.api.node('person/name')()}")
+    print(f"English Name: {service.route.node('person/name')()}")
 
     # 2. Introspection (OpenAPI)
     # genro-routes automatically generates schema for all children
-    openapi = service.api.nodes(mode="openapi")
+    openapi = service.route.nodes(mode="openapi")
     print(f"Generated Endpoints: {list(openapi['paths'].keys())}")
 
     # 3. Automatic Pydantic Validation
     # If we pass a domain that is not a string, the pydantic plugin
     # intercepts the error before even calling Faker.
     try:
-        service.api.node('person/email')(domain=123)
+        service.route.node('person/email')(domain=123)
     except Exception as e:
         print(f"Validation failed as expected: {e}")

--- a/examples/faker_standard.py
+++ b/examples/faker_standard.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
+
 from faker import Faker
+
 from genro_routes import RoutingClass, route
 
 # -----------------------------------------------------------------------------
@@ -43,7 +45,7 @@ class FakerService(RoutingClass):
         # Mount child services as branches of the main router
         self.person = PersonService(self.fake)
         self.address = AddressService(self.fake)
-        
+
         # Different instances are mounted under the main router
         self.attach_instance(self.person, name="person")
         self.attach_instance(self.address, name="address")

--- a/examples/mcp_bridge/agent_sim.py
+++ b/examples/mcp_bridge/agent_sim.py
@@ -2,21 +2,21 @@ from __future__ import annotations
 import os
 import json
 import anthropic
-from genro_routes import Router, RoutingClass, route
+from genro_routes import RoutingClass, route
 from bridge import GenroMCPBridge
 
 # 1. Define the Services (Tools for the LLM)
 class MathService(RoutingClass):
     def __init__(self):
-        self.router = Router(self, name="math").plug("pydantic")
+        self.route.plug("pydantic")
 
-    @route("math")
+    @route()
     def add(self, a: int, b: int) -> int:
         """Adds two integers together."""
         print(f"[EXECUTING] math/add({a}, {b})")
         return a + b
 
-    @route("math")
+    @route()
     def multiply(self, a: float, b: float) -> float:
         """Multiplies two floating point numbers."""
         print(f"[EXECUTING] math/multiply({a}, {b})")
@@ -24,7 +24,6 @@ class MathService(RoutingClass):
 
 class RootApp(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api")
         self.math = MathService()
         self.attach_instance(self.math, name="math")
 
@@ -38,7 +37,7 @@ def run_agent_demo():
 
     client = anthropic.Anthropic(api_key=api_key)
     app = RootApp()
-    bridge = GenroMCPBridge(app.api)
+    bridge = GenroMCPBridge(app.route)
     
     # Get tools from Genro-Routes
     mcp_tools = bridge.get_mcp_tools()
@@ -81,7 +80,7 @@ def run_agent_demo():
                 genro_path = tool_map[tool_name]
                 print(f"[AGENT] Calling {genro_path} with {tool_input}")
                 
-                result = app.api.node(genro_path)(**tool_input)
+                result = app.route.node(genro_path)(**tool_input)
                 
                 tool_results.append({
                     "type": "tool_result",

--- a/examples/mcp_bridge/agent_sim.py
+++ b/examples/mcp_bridge/agent_sim.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
+
 import os
-import json
+
 import anthropic
-from genro_routes import RoutingClass, route
 from bridge import GenroMCPBridge
+
+from genro_routes import RoutingClass, route
+
 
 # 1. Define the Services (Tools for the LLM)
 class MathService(RoutingClass):
@@ -38,10 +41,10 @@ def run_agent_demo():
     client = anthropic.Anthropic(api_key=api_key)
     app = RootApp()
     bridge = GenroMCPBridge(app.route)
-    
+
     # Get tools from Genro-Routes
     mcp_tools = bridge.get_mcp_tools()
-    
+
     # Standardize names for the LLM (internal mapping)
     # MCP bridge uses underscores for tool names, we need to map them back to /
     tool_map = {t['name']: t['name'].replace("_", "/") for t in mcp_tools}
@@ -64,30 +67,30 @@ def run_agent_demo():
 
     # Process Tool Calls (Loop for multi-step reasoning)
     current_messages = [{"role": "user", "content": prompt}]
-    
+
     while message.stop_reason == "tool_use":
         # Add the assistant message with tool_use to history
         current_messages.append({"role": "assistant", "content": message.content})
-        
+
         tool_results = []
         for block in message.content:
             if block.type == "tool_use":
                 tool_id = block.id
                 tool_name = block.name
                 tool_input = block.input
-                
+
                 # ROUTE the call back to Genro-Routes!
                 genro_path = tool_map[tool_name]
                 print(f"[AGENT] Calling {genro_path} with {tool_input}")
-                
+
                 result = app.route.node(genro_path)(**tool_input)
-                
+
                 tool_results.append({
                     "type": "tool_result",
                     "tool_use_id": tool_id,
                     "content": str(result)
                 })
-        
+
         # Send results back to the LLM
         current_messages.append({"role": "user", "content": tool_results})
         message = client.messages.create(

--- a/examples/mcp_bridge/bridge.py
+++ b/examples/mcp_bridge/bridge.py
@@ -1,22 +1,25 @@
 from __future__ import annotations
-from typing import Any, Dict, List
+
+from typing import Any
+
 from genro_routes import Router
+
 
 class GenroMCPBridge:
     """Helper to bridge Genro-Routes to Model Context Protocol (MCP)."""
-    
+
     def __init__(self, router: Router):
         self.router = router
 
-    def get_mcp_tools(self) -> List[Dict[str, Any]]:
+    def get_mcp_tools(self) -> list[dict[str, Any]]:
         """Returns a list of tools formatted for the Model Context Protocol."""
         # We use the internal introspection to harvest all entries
         nodes = self.router.nodes()
         return self._harvest_tools(nodes)
 
-    def _harvest_tools(self, nodes: Dict[str, Any], path_prefix: str = "") -> List[Dict[str, Any]]:
+    def _harvest_tools(self, nodes: dict[str, Any], path_prefix: str = "") -> list[dict[str, Any]]:
         tools = []
-        
+
         # Process entries in the current node
         entries = nodes.get("entries", {})
         for name, info in entries.items():
@@ -24,7 +27,7 @@ class GenroMCPBridge:
             metadata = info.get("metadata", {})
             pydantic_meta = metadata.get("pydantic", {})
             model = pydantic_meta.get("model")
-            
+
             # Build MCP tool definition
             tool = {
                 "name": tool_name.replace("/", "_"), # MCP likes flat names with underscores
@@ -38,15 +41,15 @@ class GenroMCPBridge:
                 tool["outputSchema"] = response_schema
 
             tools.append(tool)
-            
+
         # Recurse into child routers
         routers = nodes.get("routers", {})
         for r_name, r_nodes in routers.items():
             tools.extend(self._harvest_tools(r_nodes, f"{path_prefix}{r_name}/"))
-            
+
         return tools
 
-    def _get_schema_from_model(self, model: Any) -> Dict[str, Any]:
+    def _get_schema_from_model(self, model: Any) -> dict[str, Any]:
         """Extracts JSON Schema from a Pydantic model (if available)."""
         if model and hasattr(model, "model_json_schema"):
             return model.model_json_schema()

--- a/examples/mcp_bridge/demo.py
+++ b/examples/mcp_bridge/demo.py
@@ -1,34 +1,33 @@
 from __future__ import annotations
 import json
-from genro_routes import Router, RoutingClass, route
+from genro_routes import RoutingClass, route
 from bridge import GenroMCPBridge
 
 # 1. Define a sample library (e.g., a simple calculator)
 class MathService(RoutingClass):
     def __init__(self):
         # We use Pydantic for the bridge to see the type hints
-        self.router = Router(self, name="math").plug("pydantic")
+        self.route.plug("pydantic")
 
-    @route("math")
+    @route()
     def add(self, a: int, b: int) -> int:
         """Adds two integers together."""
         return a + b
 
-    @route("math")
+    @route()
     def multiply(self, a: float, b: float) -> float:
         """Multiplies two floating point numbers."""
         return a * b
 
 class RootApp(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api")
         self.math = MathService()
         self.attach_instance(self.math, name="math")
 
 # 2. Run the Demo
 if __name__ == "__main__":
     app = RootApp()
-    bridge = GenroMCPBridge(app.api)
+    bridge = GenroMCPBridge(app.route)
     
     print("--- Genro-Routes to MCP Bridge Demo ---")
     

--- a/examples/mcp_bridge/demo.py
+++ b/examples/mcp_bridge/demo.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
+
 import json
-from genro_routes import RoutingClass, route
+
 from bridge import GenroMCPBridge
+
+from genro_routes import RoutingClass, route
+
 
 # 1. Define a sample library (e.g., a simple calculator)
 class MathService(RoutingClass):
@@ -28,14 +32,14 @@ class RootApp(RoutingClass):
 if __name__ == "__main__":
     app = RootApp()
     bridge = GenroMCPBridge(app.route)
-    
+
     print("--- Genro-Routes to MCP Bridge Demo ---")
-    
+
     # Generate the MCP tools
     tools = bridge.get_mcp_tools()
-    
+
     print(f"\nDiscovered {len(tools)} tools for the LLM:")
-    
+
     for tool in tools:
         print(f"\n[Tool: {tool['name']}]")
         print(f"Description: {tool['description']}")

--- a/examples/pygments_highlighting.py
+++ b/examples/pygments_highlighting.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
+
 from pygments import highlight
-from pygments.lexers import get_lexer_by_name
 from pygments.formatters import HtmlFormatter, TerminalFormatter
+from pygments.lexers import get_lexer_by_name
+
 from genro_routes import RoutingClass, route
+
 
 class HighlightingService(RoutingClass):
     """Wraps the Pygments library to provide syntax highlighting as a service."""
-    
+
     def __init__(self):
         # We use Pydantic for robust input validation of code and options
         self.route.plug("pydantic")
@@ -27,7 +30,7 @@ class HighlightingService(RoutingClass):
 
 if __name__ == "__main__":
     service = HighlightingService()
-    
+
     sample_code = "def hello(): print('Hello Genro!')"
 
     print("--- 1. Terminal Highlighting ---")

--- a/examples/pygments_highlighting.py
+++ b/examples/pygments_highlighting.py
@@ -2,23 +2,23 @@ from __future__ import annotations
 from pygments import highlight
 from pygments.lexers import get_lexer_by_name
 from pygments.formatters import HtmlFormatter, TerminalFormatter
-from genro_routes import Router, RoutingClass, route
+from genro_routes import RoutingClass, route
 
 class HighlightingService(RoutingClass):
     """Wraps the Pygments library to provide syntax highlighting as a service."""
     
     def __init__(self):
         # We use Pydantic for robust input validation of code and options
-        self.api = Router(self, name="highlighter").plug("pydantic")
+        self.route.plug("pydantic")
 
-    @route("highlighter")
+    @route()
     def html(self, code: str, language: str = "python", linenos: bool = False) -> str:
         """Generates HTML highlighted code."""
         lexer = get_lexer_by_name(language)
         formatter = HtmlFormatter(linenos=linenos)
         return highlight(code, lexer, formatter)
 
-    @route("highlighter")
+    @route()
     def terminal(self, code: str, language: str = "python") -> str:
         """Generates ANSI terminal highlighted code."""
         lexer = get_lexer_by_name(language)
@@ -32,17 +32,17 @@ if __name__ == "__main__":
 
     print("--- 1. Terminal Highlighting ---")
     # Resolution via paths
-    node = service.api.node("terminal")
+    node = service.route.node("terminal")
     print(node(code=sample_code, language="python"))
 
     print("\n--- 2. HTML Highlighting ---")
-    html_node = service.api.node("html")
+    html_node = service.route.node("html")
     html_output = html_node(code=sample_code, language="python", linenos=True)
     print(f"Generated HTML (first 50 chars): {html_output[:50]}...")
 
     print("\n--- 3. Pydantic Validation in action ---")
     try:
         # Pydantic will complain if 'linenos' is not a boolean
-        service.api.node("html")(code=sample_code, linenos="not-a-boolean")
+        service.route.node("html")(code=sample_code, linenos="not-a-boolean")
     except Exception as e:
         print(f"Caught expected validation error: {e}")

--- a/examples/qrcode_generator.py
+++ b/examples/qrcode_generator.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
-import io
+
 import base64
+import io
+
 try:
     import qrcode
 except ImportError:
@@ -8,9 +10,10 @@ except ImportError:
 
 from genro_routes import RoutingClass, route
 
+
 class QRCodeService(RoutingClass):
     """Wraps the qrcode library to generate QR code assets."""
-    
+
     def __init__(self):
         self.route.plug("pydantic")
 
@@ -19,13 +22,13 @@ class QRCodeService(RoutingClass):
         """Generates a QR code and returns it as a Base64 encoded PNG string."""
         if qrcode is None:
             return "Error: 'qrcode' library not installed. Run 'pip install qrcode[pil]'"
-            
+
         qr = qrcode.QRCode(version=1, box_size=box_size, border=border)
         qr.add_data(data)
         qr.make(fit=True)
 
         img = qr.make_image(fill_color="black", back_color="white")
-        
+
         buffered = io.BytesIO()
         img.save(buffered, format="PNG")
         return base64.b64encode(buffered.getvalue()).decode()
@@ -36,7 +39,7 @@ if __name__ == "__main__":
     print("--- Generating QR Code ---")
     # Path resolution
     node = service.route.node("generate_base64")
-    
+
     try:
         b64_result = node(data="https://genropy.org", box_size=5)
         print(f"Success! Base64 length: {len(b64_result)}")

--- a/examples/qrcode_generator.py
+++ b/examples/qrcode_generator.py
@@ -6,15 +6,15 @@ try:
 except ImportError:
     qrcode = None
 
-from genro_routes import Router, RoutingClass, route
+from genro_routes import RoutingClass, route
 
 class QRCodeService(RoutingClass):
     """Wraps the qrcode library to generate QR code assets."""
     
     def __init__(self):
-        self.api = Router(self, name="qrcode").plug("pydantic")
+        self.route.plug("pydantic")
 
-    @route("qrcode")
+    @route()
     def generate_base64(self, data: str, box_size: int = 10, border: int = 4) -> str:
         """Generates a QR code and returns it as a Base64 encoded PNG string."""
         if qrcode is None:
@@ -35,7 +35,7 @@ if __name__ == "__main__":
 
     print("--- Generating QR Code ---")
     # Path resolution
-    node = service.api.node("generate_base64")
+    node = service.route.node("generate_base64")
     
     try:
         b64_result = node(data="https://genropy.org", box_size=5)
@@ -47,6 +47,6 @@ if __name__ == "__main__":
     print("\n--- Automatic Validation ---")
     try:
         # box_size must be an integer
-        service.api.node("generate_base64")(data="test", box_size="extra-large")
+        service.route.node("generate_base64")(data="test", box_size="extra-large")
     except Exception as e:
         print(f"Caught validation error: {e}")

--- a/examples/repo_explorer.py
+++ b/examples/repo_explorer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import os
 from typing import List, Dict, Any
-from genro_routes import Router, RoutingClass, route
+from genro_routes import RoutingClass, route
 
 class RepositoryService(RoutingClass):
     """
@@ -14,15 +14,15 @@ class RepositoryService(RoutingClass):
     def __init__(self, root_path: str):
         self.root = os.path.abspath(root_path)
         # Use Pydantic for path validation
-        self.api = Router(self, name="repo").plug("pydantic")
+        self.route.plug("pydantic")
 
-    @route("repo")
+    @route()
     def list_dir(self, path: str = ".") -> List[str]:
         """Lists files and directories in a given path."""
         target = self._secure_path(path)
         return os.listdir(target)
 
-    @route("repo")
+    @route()
     def read_file(self, path: str) -> str:
         """Reads the content of a file."""
         target = self._secure_path(path)
@@ -31,7 +31,7 @@ class RepositoryService(RoutingClass):
         with open(target, 'r', encoding='utf-8', errors='ignore') as f:
             return f.read()
 
-    @route("repo")
+    @route()
     def get_info(self, path: str) -> Dict[str, Any]:
         """Returns metadata for a file or directory."""
         target = self._secure_path(path)
@@ -59,16 +59,16 @@ if __name__ == "__main__":
     
     # List root
     print(f"\n1. Listing root:")
-    print(service.api.node("list_dir")(path="."))
+    print(service.route.node("list_dir")(path="."))
 
     # Read README.md
     print(f"\n2. Reading README.md (first 100 chars):")
     try:
-        content = service.api.node("read_file")(path="README.md")
+        content = service.route.node("read_file")(path="README.md")
         print(content[:100] + "...")
     except Exception as e:
         print(f"Error: {e}")
 
     # Inspect a folder
     print(f"\n3. Info for 'src':")
-    print(service.api.node("get_info")(path="src"))
+    print(service.route.node("get_info")(path="src"))

--- a/examples/repo_explorer.py
+++ b/examples/repo_explorer.py
@@ -1,23 +1,26 @@
 from __future__ import annotations
+
 import os
-from typing import List, Dict, Any
+from typing import Any
+
 from genro_routes import RoutingClass, route
+
 
 class RepositoryService(RoutingClass):
     """
     Exposes a repository as a Service.
-    
-    Instead of mapping every file to a Router (anti-pattern), 
+
+    Instead of mapping every file to a Router (anti-pattern),
     we provide methods that take paths as arguments.
     """
-    
+
     def __init__(self, root_path: str):
         self.root = os.path.abspath(root_path)
         # Use Pydantic for path validation
         self.route.plug("pydantic")
 
     @route()
-    def list_dir(self, path: str = ".") -> List[str]:
+    def list_dir(self, path: str = ".") -> list[str]:
         """Lists files and directories in a given path."""
         target = self._secure_path(path)
         return os.listdir(target)
@@ -28,11 +31,11 @@ class RepositoryService(RoutingClass):
         target = self._secure_path(path)
         if not os.path.isfile(target):
             raise ValueError(f"Path is not a file: {path}")
-        with open(target, 'r', encoding='utf-8', errors='ignore') as f:
+        with open(target, encoding='utf-8', errors='ignore') as f:
             return f.read()
 
     @route()
-    def get_info(self, path: str) -> Dict[str, Any]:
+    def get_info(self, path: str) -> dict[str, Any]:
         """Returns metadata for a file or directory."""
         target = self._secure_path(path)
         stats = os.stat(target)
@@ -56,13 +59,13 @@ if __name__ == "__main__":
     service = RepositoryService(repo_root)
 
     print(f"--- Repository Service Demo: {repo_root} ---")
-    
+
     # List root
-    print(f"\n1. Listing root:")
+    print("\n1. Listing root:")
     print(service.route.node("list_dir")(path="."))
 
     # Read README.md
-    print(f"\n2. Reading README.md (first 100 chars):")
+    print("\n2. Reading README.md (first 100 chars):")
     try:
         content = service.route.node("read_file")(path="README.md")
         print(content[:100] + "...")
@@ -70,5 +73,5 @@ if __name__ == "__main__":
         print(f"Error: {e}")
 
     # Inspect a folder
-    print(f"\n3. Info for 'src':")
+    print("\n3. Info for 'src':")
     print(service.route.node("get_info")(path="src"))

--- a/examples/self_documentation.py
+++ b/examples/self_documentation.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
+
 import inspect
 from typing import Any
+
 from genro_routes import RoutingClass
 
 # -----------------------------------------------------------------------------
@@ -16,7 +18,7 @@ class MagicRouter(RoutingClass):
         for attr_name in dir(target):
             if attr_name.startswith("_"):
                 continue
-            
+
             attr = getattr(target, attr_name)
             if inspect.ismethod(attr) or inspect.isfunction(attr):
                 # Dynamically register the entry
@@ -43,7 +45,7 @@ if __name__ == "__main__":
     service = GenroInternalService()
 
     print("--- Genro-Routes Self-Documentation Demo ---")
-    
+
     # We can now call 'nodes()' on the router, THROUGH the router itself!
     # Path: router_inspector/nodes
     print("\n1. Querying the router's nodes via the API:")
@@ -54,7 +56,7 @@ if __name__ == "__main__":
     # We can see the OpenAPI schema of the Router class itself
     print("\n2. Generating OpenAPI for the internal Router API:")
     openapi = service.route.node("router_inspector/nodes")(mode="openapi")
-    
+
     print("\nAvailable internal 'Router' methods in OpenAPI:")
     for path in openapi['paths']:
         if "router_inspector" in path:

--- a/examples/self_documentation.py
+++ b/examples/self_documentation.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import inspect
 from typing import Any
-from genro_routes import Router, RoutingClass
+from genro_routes import RoutingClass
 
 # -----------------------------------------------------------------------------
 # 1. The Magic Mapper (Generalized)
@@ -9,10 +9,9 @@ from genro_routes import Router, RoutingClass
 
 class MagicRouter(RoutingClass):
     """Dynamically maps any Python object's public methods into a router."""
-    def __init__(self, name: str, target: Any):
-        self.router = Router(self, name=name)
+    def __init__(self, target: Any):
         self._target = target
-        
+
         # Introspection: collect all public methods
         for attr_name in dir(target):
             if attr_name.startswith("_"):
@@ -21,7 +20,7 @@ class MagicRouter(RoutingClass):
             attr = getattr(target, attr_name)
             if inspect.ismethod(attr) or inspect.isfunction(attr):
                 # Dynamically register the entry
-                self.router.add_entry(attr, name=attr_name)
+                self.route.add_entry(attr, name=attr_name)
 
 # -----------------------------------------------------------------------------
 # 2. Self-Documentation Service
@@ -30,13 +29,10 @@ class MagicRouter(RoutingClass):
 class GenroInternalService(RoutingClass):
     """A service that exposes Genro-Routes' own internal API as a route."""
     def __init__(self):
-        # We create a router for this service
-        self.api = Router(self, name="api")
-        
         # META: We take our own Router instance and expose it!
         # This allows us to "remote control" or "query" the router through itself.
-        self.router_ctrl = MagicRouter("router_inspector", self.api)
-        
+        self.router_ctrl = MagicRouter(self.route)
+
         self.attach_instance(self.router_ctrl, name="router_inspector")
 
 # -----------------------------------------------------------------------------
@@ -49,14 +45,15 @@ if __name__ == "__main__":
     print("--- Genro-Routes Self-Documentation Demo ---")
     
     # We can now call 'nodes()' on the router, THROUGH the router itself!
-    # Path: api/router_inspector/nodes
+    # Path: router_inspector/nodes
     print("\n1. Querying the router's nodes via the API:")
-    nodes_info = service.api.node("router_inspector/nodes")()
-    print(f"Discovered entries in the inspector: {list(nodes_info['entries'].keys())}")
+    nodes_info = service.route.node("router_inspector/nodes")()
+    inspector_info = nodes_info["routers"]["router_inspector"]
+    print(f"Discovered entries in the inspector: {list(inspector_info['entries'].keys())}")
 
     # We can see the OpenAPI schema of the Router class itself
     print("\n2. Generating OpenAPI for the internal Router API:")
-    openapi = service.api.node("router_inspector/nodes")(mode="openapi")
+    openapi = service.route.node("router_inspector/nodes")(mode="openapi")
     
     print("\nAvailable internal 'Router' methods in OpenAPI:")
     for path in openapi['paths']:

--- a/examples/service_composition.py
+++ b/examples/service_composition.py
@@ -1,27 +1,19 @@
 from __future__ import annotations
-from genro_routes import Router, RoutingClass, route
+from genro_routes import RoutingClass, route
 
 class BillingModule(RoutingClass):
-    def __init__(self):
-        self.router = Router(self, name="billing")
-    
-    @route("billing")
+    @route()
     def invoice_list(self):
         return ["Inv-001", "Inv-002"]
 
 class InventoryModule(RoutingClass):
-    def __init__(self):
-        self.router = Router(self, name="inventory")
-    
-    @route("inventory")
+    @route()
     def stock_level(self, item_id: str):
         return {"item": item_id, "qty": 42}
 
 class EnterpriseApp(RoutingClass):
     """A main application that composes multiple modules."""
     def __init__(self):
-        self.api = Router(self, name="api")
-        
         # Instantiate separate modules
         self.billing = BillingModule()
         self.inventory = InventoryModule()
@@ -36,16 +28,16 @@ if __name__ == "__main__":
     print("--- Service Composition Demo ---")
     
     # Accessing Billing via the main app
-    print(f"Invoices: {app.api.node('billing/invoice_list')()}")
+    print(f"Invoices: {app.route.node('billing/invoice_list')()}")
     
     # Accessing Inventory via the main app
-    print(f"Stock: {app.api.node('inventory/stock_level')(item_id='part-123')}")
+    print(f"Stock: {app.route.node('inventory/stock_level')(item_id='part-123')}")
     
     # Introspection shows the merged structure
-    nodes = app.api.nodes()
+    nodes = app.route.nodes()
     print(f"\nMain API contains {len(nodes['routers'])} child routers: {list(nodes['routers'].keys())}")
     
     print("\nFull paths discovered:")
-    openapi = app.api.nodes(mode="openapi")
+    openapi = app.route.nodes(mode="openapi")
     for path in openapi['paths']:
         print(f" - {path}")

--- a/examples/service_composition.py
+++ b/examples/service_composition.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
+
 from genro_routes import RoutingClass, route
+
 
 class BillingModule(RoutingClass):
     @route()
@@ -17,7 +19,7 @@ class EnterpriseApp(RoutingClass):
         # Instantiate separate modules
         self.billing = BillingModule()
         self.inventory = InventoryModule()
-        
+
         # COMPOSITION: attach their routers to our main API
         self.attach_instance(self.billing, name="billing")
         self.attach_instance(self.inventory, name="inventory")
@@ -26,17 +28,17 @@ if __name__ == "__main__":
     app = EnterpriseApp()
 
     print("--- Service Composition Demo ---")
-    
+
     # Accessing Billing via the main app
     print(f"Invoices: {app.route.node('billing/invoice_list')()}")
-    
+
     # Accessing Inventory via the main app
     print(f"Stock: {app.route.node('inventory/stock_level')(item_id='part-123')}")
-    
+
     # Introspection shows the merged structure
     nodes = app.route.nodes()
     print(f"\nMain API contains {len(nodes['routers'])} child routers: {list(nodes['routers'].keys())}")
-    
+
     print("\nFull paths discovered:")
     openapi = app.route.nodes(mode="openapi")
     for path in openapi['paths']:

--- a/src/genro_routes/__init__.py
+++ b/src/genro_routes/__init__.py
@@ -1,13 +1,21 @@
 """Genro Routes - Instance-scoped routing engine for Python.
 
 Public API surface providing hierarchical handler organization, per-instance
-plugin application, and complex service composition through descriptors.
+plugin application, and service composition by attaching instances. Every
+``RoutingClass`` owns exactly one ``Router``, exposed as the lazy ``route``
+property.
 
 Public exports:
-    - ``Router``: Main router class for binding methods to selectors
+    - ``Router``: Router class (created by RoutingClass, not by user code)
+    - ``RouterInterface``: Abstract interface shared by routers
     - ``RouterNode``: Wrapper returned by node() for handler access
-    - ``RoutingClass``: Mixin for classes that expose routers
+    - ``RoutingClass``: Mixin binding a class to its single router
+    - ``RoutingContext``: Execution context with parent-chain lookup
+    - ``Section``: Empty RoutingClass used as grouping node
     - ``route``: Decorator for marking methods as route handlers
+    - ``is_result_wrapper``: Predicate for ResultWrapper instances
+    - Exceptions: ``NotFound``, ``NotAuthorized``, ``NotAuthenticated``,
+      ``NotAvailable``
 
 Plugin registration happens lazily via ``import_module`` to avoid cycles.
 Built-in plugins (logging, pydantic, auth, env, openapi, channel) are
@@ -15,13 +23,10 @@ auto-registered on first import.
 
 Example::
 
-    from genro_routes import Router, RoutingClass, route
+    from genro_routes import RoutingClass, route
 
     class MyService(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def hello(self):
             return "Hello, World!"
 """
@@ -36,6 +41,7 @@ from .core import (
     RouterInterface,
     RoutingClass,
     RoutingContext,
+    Section,
     is_result_wrapper,
     route,
 )
@@ -58,6 +64,7 @@ __all__ = [
     "RouterNode",
     "RoutingClass",
     "RoutingContext",
+    "Section",
     "is_result_wrapper",
     "route",
     "NotFound",

--- a/src/genro_routes/cli/_builder.py
+++ b/src/genro_routes/cli/_builder.py
@@ -28,31 +28,14 @@ class CliBuilder:
         self._converter = ParamConverter()
 
     def build(self, name: str | None = None) -> click.Group:
-        """Build the root click.Group from all registered routers."""
-        routers = dict(self._instance._iter_registered_routers())
+        """Build the root click.Group from the instance's router."""
         root_name = name or self._instance.__class__.__name__.lower()
         root_doc = inspect.getdoc(self._instance) or ""
 
         root = click.Group(name=root_name, help=root_doc)
-
-        if len(routers) == 1:
-            # Single router: entries become direct commands on root
-            router = next(iter(routers.values()))
-            nodes_data = router.nodes()
+        nodes_data = self._instance.route.nodes()
+        if nodes_data:
             self._populate_group(root, nodes_data)
-        else:
-            # Multiple routers: each becomes a sub-group
-            for router_name, router in routers.items():
-                nodes_data = router.nodes()
-                if not nodes_data:
-                    continue
-                sub_group = click.Group(
-                    name=router_name,
-                    help=nodes_data.get("description") or "",
-                )
-                self._populate_group(sub_group, nodes_data)
-                root.add_command(sub_group)
-
         return root
 
     def _populate_group(self, group: click.Group, nodes_data: dict[str, Any]) -> None:

--- a/src/genro_routes/core/__init__.py
+++ b/src/genro_routes/core/__init__.py
@@ -1,13 +1,16 @@
 """Core runtime aggregator for Genro Routes.
 
-Exposes the runtime building blocks from a single module:
-``BaseRouter``, ``Router``, ``route``, ``RoutingClass``.
+Exposes the runtime building blocks from a single module.
 
 Public API:
     - ``BaseRouter``: Plugin-free routing engine
     - ``Router``: Plugin-enabled router with middleware support
+    - ``RouterInterface``: Abstract interface shared by routers
+    - ``RoutingClass``: Mixin binding a class to its single router
+    - ``RoutingContext``: Execution context with parent-chain lookup
+    - ``Section``: Empty RoutingClass used as grouping node
     - ``route``: Decorator for marking handler methods
-    - ``RoutingClass``: Mixin for classes exposing routers
+    - ``is_result_wrapper``: Predicate for ResultWrapper instances
 
 Importing this module performs only imports; it does not register plugins
 or instantiate routers.
@@ -18,7 +21,7 @@ from .context import RoutingContext
 from .decorators import route
 from .router import Router
 from .router_interface import RouterInterface
-from .routing import RoutingClass, is_result_wrapper
+from .routing import RoutingClass, Section, is_result_wrapper
 
 __all__ = [
     "BaseRouter",
@@ -26,6 +29,7 @@ __all__ = [
     "RouterInterface",
     "RoutingClass",
     "RoutingContext",
+    "Section",
     "is_result_wrapper",
     "route",
 ]

--- a/src/genro_routes/core/base_router.py
+++ b/src/genro_routes/core/base_router.py
@@ -9,21 +9,22 @@ Constructor and slots
 ---------------------
 Constructor signature::
 
-    BaseRouter(owner, name=None, prefix=None, *, description=None,
-               default_entry="index", branch=False, parent_router=None)
+    BaseRouter(owner, *, prefix=None, description=None,
+               default_entry="index", get_default_handler=None,
+               get_kwargs=None)
 
 - ``owner`` is required; ``None`` raises ``ValueError``. Routers are bound to
-  this instance and never re-bound.
+  this instance and never re-bound. Every router is created by its owning
+  RoutingClass (lazy ``route`` property) and registers itself with the owner;
+  its ``name`` is always ``"route"``.
 - ``description``: optional human-readable description of this router's purpose.
   Included in ``nodes()`` output for documentation/introspection.
 - ``default_entry``: the fallback entry name (default: "index") used when a path
   cannot be fully resolved. The router returns this entry with any unconsumed
   path segments passed as positional arguments when invoked.
-- ``parent_router``: optional parent router. When provided, this router is
-  automatically attached as a child using ``name`` as the alias. Requires
-  ``name`` to be set; raises ``ValueError`` on name collision.
-- Slots: ``instance``, ``name``, ``prefix``, ``description`` (optional router description),
-  ``_entries`` (logical name → MethodEntry with handler), ``_children`` (name → child router).
+- Slots: ``instance``, ``name``, ``prefix``, ``description``, ``default_entry``,
+  ``__entries_raw`` (logical name → MethodEntry with handler), ``_children``
+  (alias → child router), ``_get_defaults``, ``_bound``.
 
 Lazy binding
 ------------
@@ -33,9 +34,9 @@ is needed.
 
 Marker discovery
 ----------------
-``_iter_marked_methods`` walks the reversed MRO of ``type(owner)`` (child first
-wins), scans ``__dict__`` for plain functions carrying ``_route_decorator_kw``
-markers. Only markers whose ``name`` matches this router's ``name`` are used.
+``_iter_marked_methods`` walks the MRO of ``type(owner)`` (child classes
+first, so derived overrides win), scans ``__dict__`` for plain functions
+carrying ``_route_decorator_kw`` markers. All markers belong to this router.
 
 Handler table and wrapping
 --------------------------
@@ -58,8 +59,10 @@ Accepts a Router (child hierarchy) or RouterNode (entry alias).
 ``detach_instance(child)`` removes all routers belonging to a child instance.
 
 Instance attachment is handled by ``RoutingClass.attach_instance()``, which
-sets ``_routing_parent`` and links child routers into parent routers.
-Attached child routers inherit plugins via ``_on_attached_to_parent``.
+sets ``_routing_parent`` and delegates the routing link to ``include()``.
+On the first (primary) attachment ``include()`` triggers plugin inheritance
+via ``_on_attached_to_parent``; subsequent includes of the same router are
+navigational shortcuts only.
 
 Introspection
 -------------
@@ -118,22 +121,18 @@ class BaseRouter(RouterInterface):
         "__entries_raw",
         "_children",
         "_get_defaults",
-        "_is_branch",
         "_bound",
     )
 
     def __init__(
         self,
         owner: Any,
-        name: str | None = None,
-        prefix: str | None = None,
         *,
+        prefix: str | None = None,
         description: str | None = None,
         default_entry: str = "index",
         get_default_handler: Callable | None = None,
         get_kwargs: dict[str, Any] | None = None,
-        branch: bool = False,
-        parent_router: BaseRouter | None = None,
     ) -> None:
         if owner is None:
             raise ValueError("Router requires a parent instance")
@@ -143,11 +142,10 @@ class BaseRouter(RouterInterface):
                 "Inherit from RoutingClass to use Router."
             )
         self.instance = owner
-        self.name = name
+        self.name = "route"
         self.prefix = prefix or ""
         self.description = description
         self.default_entry = default_entry
-        self._is_branch = bool(branch)
         self._bound = False
         self.__entries_raw: dict[str, MethodEntry] = {}
         self._children: dict[str, BaseRouter] = {}
@@ -155,21 +153,7 @@ class BaseRouter(RouterInterface):
         if get_default_handler is not None:
             defaults.setdefault("default_handler", get_default_handler)
         self._get_defaults: dict[str, Any] = defaults
-        # Register with owner only if this is a root router
-        if parent_router is None:
-            hook = getattr(self.instance, "_register_router", None)
-            if callable(hook):
-                hook(self)
-
-        # Attach to parent router if specified
-        if parent_router is not None:
-            alias = name
-            if not alias:
-                raise ValueError("Child router must have a name when using parent_router")
-            if alias in parent_router._children and parent_router._children[alias] is not self:
-                raise ValueError(f"Child name collision: {alias!r}")
-            parent_router._children[alias] = self
-            self._on_attached_to_parent(parent_router)
+        self.instance._register_router(self)
 
     # ------------------------------------------------------------------
     # Lazy binding property
@@ -256,8 +240,6 @@ class BaseRouter(RouterInterface):
             AttributeError: when resolving missing attributes on owner.
             TypeError: on unsupported target type.
         """
-        if self._is_branch:
-            raise ValueError("Branch routers cannot register handlers")
         entry_name = name
         # Split plugin-scoped options (<plugin>_<key>) and meta_* from core options
         plugin_options: dict[str, dict[str, Any]] = {}
@@ -434,19 +416,13 @@ class BaseRouter(RouterInterface):
             )
 
     def _iter_marked_methods(self) -> Iterator[tuple[Callable, dict[str, Any]]]:
-        """Yield (func, marker_dict) for methods decorated with @route for this router.
+        """Yield (func, marker_dict) for methods decorated with @route.
 
         Walks the MRO (child classes first) and scans __dict__ for functions
-        carrying _route_decorator_kw markers. Only yields markers where the
-        router name matches this router's name.
+        carrying _route_decorator_kw markers. All markers belong to this
+        router (one router per class).
         """
         cls = type(self.instance)
-        # Check if instance has exactly one router (default_router)
-        default_router_name: str | None = None
-        if hasattr(self.instance, "default_router"):
-            default = self.instance.default_router
-            if default is not None:
-                default_router_name = default.name
         # Track seen method names to respect MRO (derived class wins)
         # Track seen function ids to avoid duplicate registration of aliases (alias = original)
         seen_names: set[str] = set()
@@ -469,15 +445,7 @@ class BaseRouter(RouterInterface):
                 if not markers:
                     continue
                 for marker in markers:
-                    marker_name = marker.get("name")
-                    # If marker_name is None, use default_router (only if single router)
-                    if marker_name is None:
-                        marker_name = default_router_name
-                    if marker_name != self.name:
-                        continue
-                    payload = dict(marker)
-                    payload.pop("name", None)
-                    yield value, payload
+                    yield value, dict(marker)
 
     def _resolve_name(self, func_name: str, *, name_override: str | None) -> str:
         """Compute the logical entry name from the function name.
@@ -524,8 +492,7 @@ class BaseRouter(RouterInterface):
         if self._bound:
             return  # Already bound, no-op
         self._bound = True  # Set BEFORE work to avoid recursion via properties
-        if not self._is_branch:
-            self.add_entry("*")
+        self.add_entry("*")
 
     def _require_bound(self, operation: str) -> None:
         """Ensure the router is bound, auto-binding if needed.
@@ -576,11 +543,11 @@ class BaseRouter(RouterInterface):
         Examples::
 
             # Include a router
-            self._sys.include(swagger.api, name="swagger")
+            self._sys.include(swagger.route, name="swagger")
 
             # Include an entry as alias
-            fatture.api.include(
-                pagamenti.api.node("collega_a_fattura"),
+            fatture.route.include(
+                pagamenti.route.node("collega_a_fattura"),
                 name="collega_pagamento",
             )
         """
@@ -682,7 +649,7 @@ class BaseRouter(RouterInterface):
 
         Example::
 
-            # Given: @route("api", endpoint_id="invoice.detail")
+            # Given: @route(endpoint_id="invoice.detail")
             #        def detail(self, invoice_id): ...
             # Mounted at: billing/detail
 

--- a/src/genro_routes/core/decorators.py
+++ b/src/genro_routes/core/decorators.py
@@ -3,14 +3,17 @@
 This module contains only marker helpers; no router mutation happens at
 decoration time.
 
-``route(router, *, name=None, **kwargs)``
-    Returns a decorator storing metadata on the function under ``_route_decorator_kw``
-    as a list of dicts. Each payload starts with ``{"name": router}``.
+``route(*, name=None, endpoint_id=None, **kwargs)``
+    Returns a decorator storing metadata on the function under
+    ``_route_decorator_kw`` as a list of dicts. All markers belong to the
+    class's single router (one router per RoutingClass).
 
-    - Explicit logical name: if ``name`` is provided, the payload sets ``entry_name``
-      to that value. Otherwise the handler name defaults to the function name.
+    - Explicit logical name: if ``name`` is provided, the payload sets
+      ``entry_name`` to that value. Otherwise the handler name defaults to
+      the function name.
     - Extra ``**kwargs`` are copied verbatim into the payload (e.g. plugin flags).
-    - Multiple routers can target the same function by stacking decorators.
+    - Stacking the decorator registers the same function under multiple
+      entry names (aliases).
     - The decorator returns the original function unchanged aside from the marker.
 
 Re-exports
@@ -31,58 +34,37 @@ __all__ = ["route", "RoutingClass", "Router"]
 
 
 def route(
-    router: str | None = None,
     *,
     name: str | None = None,
     endpoint_id: str | None = None,
     **kwargs: Any,
 ) -> Callable[[Callable], Callable]:
-    """Mark a bound method for inclusion in the given router.
+    """Mark a bound method for inclusion in the class's router.
 
     Args:
-        router: Router identifier (e.g. ``"api"``). If None, uses the default
-            router (only works if the class has exactly one router).
         name: Optional explicit entry name (overrides function name/prefix stripping).
         endpoint_id: Optional globally unique identifier for reverse lookup.
             When set, the handler can be resolved via ``router.node("@endpoint_id")``.
         **kwargs: Extra metadata merged into handler entry (e.g. plugin flags).
 
     Returns:
-        Decorator that marks the function for the specified router.
+        Decorator that marks the function for the router.
 
     Example::
 
-        @route("api")
-        def list_users(self):
-            return ["alice", "bob"]
-
-        @route("api", name="custom_name", logging_enabled=False)
-        def get_user(self, user_id):
-            return {"id": user_id}
-
-        # With single router - @route() works without arguments:
         class Table(RoutingClass):
-            def __init__(self):
-                self.api = Router(self, name="api")  # single router
+            @route()
+            def list_users(self):
+                return ["alice", "bob"]
 
-            @route()  # Uses the only router automatically
-            def add(self, data):
-                ...
-
-        # With multiple routers - must specify:
-        class Service(RoutingClass):
-            def __init__(self):
-                self.api = Router(self, name="api")
-                self.admin = Router(self, name="admin")
-
-            @route("api")  # Must specify router name
-            def public(self):
-                ...
+            @route(name="custom_name", logging_enabled=False)
+            def get_user(self, user_id):
+                return {"id": user_id}
     """
 
     def decorator(func: Callable) -> Callable:
         markers = list(getattr(func, "_route_decorator_kw", []))
-        payload: dict[str, Any] = {"name": router}  # None means "use default_router"
+        payload: dict[str, Any] = {}
         if name is not None:
             payload["entry_name"] = name
         if endpoint_id is not None:

--- a/src/genro_routes/core/router.py
+++ b/src/genro_routes/core/router.py
@@ -41,9 +41,9 @@ Example::
 
     class MyService(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("logging")
+            self.route.plug("logging")
 
-        @route("api")
+        @route()
         def hello(self):
             return "Hello!"
 """

--- a/src/genro_routes/core/routing.py
+++ b/src/genro_routes/core/routing.py
@@ -1,78 +1,89 @@
 """RoutingClass mixin and router proxy for Genro Routes.
 
-The mixin keeps router state off user instances via slots and offers a proxy
-for configuration/lookup.
+One class, one router: every ``RoutingClass`` owns exactly one ``Router``,
+exposed as the lazy read-only property ``route``. The router is created on
+first access and stored in a slot; users never call ``Router(...)`` directly.
+Grouping and hierarchy are expressed by composing RoutingClass instances.
 
 RoutingClass
 ------------
 A mixin class providing:
-    - ``_register_router(router)``: Lazily creates a registry dict on the instance
-      and stores the router under ``router.name`` if truthy.
-    - ``_iter_registered_routers``: Yields ``(name, router)`` for registry entries.
-    - ``attach_instance(child, ...)``: Attaches a child RoutingClass instance,
-      sets ``_routing_parent``, and links child routers into parent routers.
-    - ``routing`` property: Returns cached ``_RoutingProxy`` bound to the owner.
+    - ``route`` property: the instance's Router, created lazily on first
+      access. Assigning to it raises ``AttributeError`` (read-only).
+    - ``attach_instance(child, name=...)``: attaches a child RoutingClass
+      instance. Sets ``child._routing_parent = self`` and, when ``name`` is
+      given, links ``child.route`` into ``self.route`` under that alias.
+    - ``routing`` property: cached ``_RoutingProxy`` for configuration/lookup.
+    - ``ctx`` property: execution context, walking up the parent chain.
+    - ``capabilities`` property: CapabilitiesSet for runtime feature flags.
 
-Instance attachment
--------------------
-``attach_instance`` lives on RoutingClass (not on Router) because it manages
-the parent-child relationship at the instance level:
+Router configuration happens on the existing router in ``__init__`` (binding
+is lazy, so this is race-free)::
 
-    - Sets ``child._routing_parent = self``
-    - Links child routers into parent routers via ``_children`` dict
-    - Triggers plugin inheritance via ``_on_attached_to_parent``
+    class MyService(RoutingClass):
+        def __init__(self):
+            self.route.description = "My service API"
+            self.route.plug("logging")
 
-Two calling styles::
+        @route()
+        def hello(self):
+            return "Hello!"
 
-    # 1:1 shortcut (child has single router, parent has single router)
-    self.attach_instance(child, name="sales")
+Section
+-------
+Minimal concrete RoutingClass used as a grouping node. A Section carries an
+empty router; children are attached under it to build intermediate levels of
+a routing tree (including dynamically discovered trees)::
 
-    # Explicit cross-mapping (any number of routers)
-    self.attach_instance(child,
-        router_api="orders:sales,billing:invoices",
-        router_admin="mgmt:management",
-    )
+    svc.attach_instance(Section("Admin area"), name="admin")
 
 _RoutingProxy
 -------------
 Bound to the owning ``RoutingClass`` instance.
 
 Router lookup:
-    - ``get_router(name, path=None)`` splits combined specs (``foo/bar``) into
-      base router + child path. Raises ``AttributeError`` if no router is found.
+    - ``get_router(path=None)`` returns the owner's router, optionally
+      navigating child routers along ``path`` (e.g. ``"users/detail"``).
+      Raises ``KeyError`` if a path segment does not resolve.
 
 Configuration entrypoint:
     - ``configure(target, **options)`` accepts string, dict, or list targets.
-    - ``"?"`` shortcut returns ``_describe_all()``.
+      String targets are ``"plugin"`` or ``"plugin/selector"`` where selector
+      is a handler name or comma-separated glob patterns.
+    - ``"?"`` shortcut returns the router description dict.
+    - Child routers belong to child instances: configure them through the
+      child's own ``routing`` proxy.
 
 Example::
 
-    from genro_routes import Router, RoutingClass, route
+    from genro_routes import RoutingClass, route
 
     class MyService(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api")
+            self.route.plug("logging")
 
-        @route("api")
+        @route()
         def hello(self):
             return "Hello!"
 
     svc = MyService()
-    svc.routing.configure("api:logging/_all_", enabled=False)
+    svc.routing.configure("logging/_all_", enabled=False)
 """
 
 from __future__ import annotations
 
+import contextlib
 from fnmatch import fnmatchcase
 from typing import TYPE_CHECKING, Any
 
 from genro_toolbox.typeutils import safe_is_instance
 
+from .router import Router
+
 if TYPE_CHECKING:  # pragma: no cover - import for typing only
     from .context import RoutingContext
-    from .router import Router
 
-__all__ = ["RoutingClass", "ResultWrapper", "is_routing_class", "is_result_wrapper"]
+__all__ = ["RoutingClass", "Section", "ResultWrapper", "is_routing_class", "is_result_wrapper"]
 
 
 class ResultWrapper:
@@ -92,18 +103,19 @@ class ResultWrapper:
         self.metadata = metadata
 
 _PROXY_ATTR_NAME = "__routing_proxy__"
+_ROUTER_ATTR_NAME = "__genro_routes_router__"
 
 
 class RoutingClass:
-    """Mixin providing helper proxies for runtime routers.
+    """Mixin binding the instance to its single router.
 
-    Subclass this to enable automatic router registration and configuration
-    via the ``routing`` property.
+    Subclass this to get the ``route`` router (created lazily) and the
+    ``routing`` configuration proxy.
     """
 
     __slots__ = (
         _PROXY_ATTR_NAME,
-        "__genro_routes_router_registry__",
+        _ROUTER_ATTR_NAME,
         "_routing_parent",
         "_ctx",
         "_capabilities",
@@ -127,68 +139,54 @@ class RoutingClass:
             return None  # pragma: no cover - only detach if bound to this parent
         return current
 
-    @property
-    def _routers(self) -> dict:
-        """Lazy-initialized router registry."""
-        registry = getattr(self, "__genro_routes_router_registry__", None)
-        if registry is None:
-            registry = {}
-            self.__genro_routes_router_registry__ = registry
-        return registry
-
     def _auto_detach_child(self, current: Any) -> None:
-        import contextlib
-
-        for router in self._routers.values():
+        router = getattr(self, _ROUTER_ATTR_NAME, None)
+        if router is not None:
             with contextlib.suppress(Exception):  # best-effort; avoid blocking setattr
-                router.detach_instance(current)  # type: ignore[attr-defined]
+                router.detach_instance(current)
+
+    @property
+    def route(self) -> Router:
+        """Return the instance's router, creating it on first access."""
+        router = getattr(self, _ROUTER_ATTR_NAME, None)
+        if router is None:
+            router = Router(self)
+        return router
 
     def _register_router(self, router: Router) -> None:
-        """Register a router with this instance.
+        """Register the router with this instance.
 
-        Called automatically by Router during initialization.
+        Called automatically by Router during initialization. Raises
+        ValueError if a different router is already registered.
         """
         if not hasattr(self, "_routing_parent"):
             object.__setattr__(self, "_routing_parent", None)
-        if router.name:
-            self._routers[router.name] = router
+        existing = getattr(self, _ROUTER_ATTR_NAME, None)
+        if existing is not None and existing is not router:
+            raise ValueError(f"{type(self).__name__} already has a router")
+        object.__setattr__(self, _ROUTER_ATTR_NAME, router)
 
-    def _iter_registered_routers(self):
-        """Yield (name, router) pairs for all registered routers."""
-        yield from self._routers.items()
+    def attach_instance(self, child: RoutingClass, *, name: str | None = None) -> None:
+        """Attach a child RoutingClass instance.
 
-    def attach_instance(self, child: RoutingClass, *, name: str | None = None, **router_specs: str) -> None:
-        """Attach a child RoutingClass instance and optionally link its routers.
-
-        Sets ``child._routing_parent = self`` and links child routers to
-        parent routers according to the provided mapping.
+        Sets ``child._routing_parent = self``. When ``name`` is given,
+        ``child.route`` is linked into ``self.route`` under that alias
+        (plugin inheritance is triggered by the link).
 
         Args:
             child: The RoutingClass instance to attach.
-            name: Shortcut for the 1:1 case (child has a single router).
-                The child's default router is linked to this instance's
-                default router under the given alias.
-            **router_specs: Explicit mapping with ``router_<parent_router>``
-                keys. Values are comma-separated ``"child_router:alias"``
-                pairs.
+            name: Alias under which the child's router is reachable from
+                this instance's router. If omitted, only the parent
+                relationship is set (no routing link).
 
         Raises:
             TypeError: If child is not a RoutingClass instance.
-            ValueError: If name and router_* specs are both provided.
-            ValueError: If name is used but child or parent has multiple routers.
-            ValueError: If a referenced router does not exist.
-            ValueError: If there is an alias collision in _children.
+            ValueError: If child is already bound to another parent.
+            ValueError: If the alias collides with an existing child.
 
-        Examples::
+        Example::
 
-            # 1:1 shortcut
             self.attach_instance(child, name="sales")
-
-            # Explicit cross-mapping
-            self.attach_instance(child,
-                router_api="orders:sales,billing:invoices",
-                router_admin="mgmt:management",
-            )
         """
         if not safe_is_instance(child, "genro_routes.core.routing.RoutingClass"):
             raise TypeError("attach_instance() requires a RoutingClass instance")
@@ -196,76 +194,11 @@ class RoutingClass:
         if existing_parent is not None and existing_parent is not self:
             raise ValueError("attach_instance() rejected: child already bound to another parent")
 
-        # Parse router_* kwargs
-        router_mappings = {
-            k[len("router_"):]: v
-            for k, v in router_specs.items()
-            if k.startswith("router_")
-        }
-        unknown = set(router_specs) - {f"router_{k}" for k in router_mappings}
-        if unknown:
-            raise ValueError(f"Unknown keyword arguments: {', '.join(sorted(unknown))}")
-
-        if name is not None and router_mappings:
-            raise ValueError("Cannot use 'name' together with router_* specs")
-
         if name is not None:
-            child_default = child.default_router
-            if child_default is None:
-                raise ValueError(
-                    f"name= shortcut requires child to have exactly one router; "
-                    f"{type(child).__name__} has {len(child._routers)}"
-                )
-            parent_default = self.default_router
-            if parent_default is None:
-                raise ValueError(
-                    f"name= shortcut requires parent to have exactly one router; "
-                    f"{type(self).__name__} has {len(self._routers)}"
-                )
-            self._link_router(parent_default, child, child_default.name, name)
-
-        for parent_router_name, spec_string in router_mappings.items():
-            parent_router = self._routers.get(parent_router_name)
-            if parent_router is None:
-                raise ValueError(
-                    f"No router named '{parent_router_name}' on {type(self).__name__}"
-                )
-            pairs = self._parse_router_spec(spec_string)
-            for child_router_name, alias in pairs:
-                self._link_router(parent_router, child, child_router_name, alias)
+            self.route.include(child.route, name=name)
 
         if getattr(child, "_routing_parent", None) is not self:
             object.__setattr__(child, "_routing_parent", self)
-
-    def _link_router(self, parent_router: Any, child: RoutingClass, child_router_name: str, alias: str) -> None:
-        """Link a single child router into a parent router via include()."""
-        child_router = child._routers.get(child_router_name)
-        if child_router is None:
-            raise ValueError(
-                f"No router named '{child_router_name}' on {type(child).__name__}"
-            )
-        parent_router.include(child_router, name=alias)
-
-    def _parse_router_spec(self, spec: str) -> list[tuple[str, str]]:
-        """Parse 'child_router:alias,child_router2:alias2' into pairs."""
-        pairs: list[tuple[str, str]] = []
-        for token in spec.split(","):
-            token = token.strip()
-            if not token:
-                continue
-            if ":" not in token:
-                raise ValueError(
-                    f"Invalid router spec '{token}': expected 'child_router:alias'"
-                )
-            child_router_name, alias = token.split(":", 1)
-            child_router_name = child_router_name.strip()
-            alias = alias.strip()
-            if not child_router_name or not alias:
-                raise ValueError(
-                    f"Invalid router spec '{token}': both router name and alias are required"
-                )
-            pairs.append((child_router_name, alias))
-        return pairs
 
     @property
     def routing(self) -> _RoutingProxy:
@@ -291,25 +224,6 @@ class RoutingClass:
     def ctx(self, value: RoutingContext | None) -> None:
         """Set the execution context on this instance."""
         object.__setattr__(self, "_ctx", value)
-
-    @property
-    def default_router(self) -> Any:
-        """Return the default router for this instance.
-
-        Returns the router only if exactly one router is registered.
-        This allows ``@route()`` without arguments to work when there's
-        an unambiguous single router.
-
-        If multiple routers are registered, returns None and ``@route()``
-        requires an explicit router name argument.
-
-        Returns:
-            Router | None: The single router or None if zero or multiple.
-        """
-        routers = self._routers
-        if len(routers) == 1:
-            return next(iter(routers.values()))
-        return None
 
     @property
     def capabilities(self):
@@ -344,7 +258,7 @@ class RoutingClass:
 
             class PaymentService(RoutingClass):
                 def __init__(self):
-                    self.api = Router(self, name="api").plug("env")
+                    self.route.plug("env")
                     self._stripe_configured = True
                     self._paypal_configured = False
                     self.capabilities = PaymentCapabilities(self)
@@ -382,7 +296,7 @@ class RoutingClass:
             A ResultWrapper instance containing value and metadata.
 
         Example:
-            @route("root")
+            @route()
             def _resource(self, name: str):
                 content, mime_type = self.load_resource(name)
                 return self.result_wrapper(content, mime_type=mime_type)
@@ -390,26 +304,41 @@ class RoutingClass:
         return ResultWrapper(value, metadata)
 
 
+class Section(RoutingClass):
+    """Empty routing node for grouping children.
+
+    Use a Section to build intermediate levels of a routing tree without
+    defining a dedicated class — e.g. namespacing or dynamically discovered
+    hierarchies::
+
+        svc.attach_instance(Section("Admin area"), name="admin")
+    """
+
+    def __init__(self, description: str | None = None) -> None:
+        if description is not None:
+            self.route.description = description
+
+
 class _RoutingProxy:
-    """Proxy for accessing and configuring routers on a RoutingClass instance.
+    """Proxy for accessing and configuring the router of a RoutingClass instance.
 
     Provides a unified interface for router lookup and plugin configuration.
     Access via the ``routing`` property on any RoutingClass instance.
 
     Main operations:
-        - ``get_router(name)``: Look up a router by name
+        - ``get_router(path=None)``: The owner's router, or a child at path
         - ``configure(target, **options)``: Configure plugin settings
-        - ``attach_instance(child, ...)``: Delegates to owner's attach_instance
+        - ``attach_instance(child, name=...)``: Delegates to owner's attach_instance
 
     Target syntax for configure():
-        - ``"router:plugin"`` - Global plugin config
-        - ``"router:plugin/handler"`` - Per-handler config
-        - ``"router:plugin/pattern*"`` - Glob pattern matching
-        - ``"?"`` - Describe all routers and their configuration
+        - ``"plugin"`` - Global plugin config
+        - ``"plugin/handler"`` - Per-handler config
+        - ``"plugin/pattern*"`` - Glob pattern matching
+        - ``"?"`` - Describe the router and its configuration
 
     Example:
-        >>> svc.routing.configure("api:logging", before=False)
-        >>> svc.routing.configure("api:auth/admin_*", rule="admin")
+        >>> svc.routing.configure("logging", before=False)
+        >>> svc.routing.configure("auth/admin_*", rule="admin")
         >>> svc.routing.configure("?")  # introspection
     """
 
@@ -418,74 +347,48 @@ class _RoutingProxy:
     def __init__(self, owner: RoutingClass):
         object.__setattr__(self, "_owner", owner)
 
-    def get_router(self, name: str, path: str | None = None):
-        """Look up a router by name, optionally navigating child routers.
+    def get_router(self, path: str | None = None):
+        """Return the owner's router, optionally navigating child routers.
 
         Args:
-            name: Router name, or "name/child/grandchild" path notation.
-            path: Optional additional path to navigate after finding router.
+            path: Optional "child/grandchild" path to navigate.
 
         Returns:
-            The resolved Router (or child router if path provided).
+            The owner's Router, or the child router at path.
 
         Raises:
-            AttributeError: If no router with that name exists.
             KeyError: If child path navigation fails.
 
         Example:
-            >>> svc.routing.get_router("api")
-            >>> svc.routing.get_router("api/users")  # child router
-            >>> svc.routing.get_router("api", "users/detail")
+            >>> svc.routing.get_router()
+            >>> svc.routing.get_router("users")  # child router
+            >>> svc.routing.get_router("users/detail")
         """
-        owner = self._owner
-        base_name, extra_path = self._split_router_spec(name, path)
-        router = self._lookup_router(owner, base_name)
-        if router is None:
-            raise AttributeError(f"No Router named '{base_name}' on {type(owner).__name__}")
-        if not extra_path:
+        router = self._owner.route
+        if not path:
             return router
-        return self._navigate_router(router, extra_path)
+        return self._navigate_router(router, path)
 
     def instance(self, path: str) -> RoutingClass:
         """Return the RoutingClass instance that owns the child router at path.
 
         Args:
-            path: Router path in "router/child" or "router/child/grandchild" notation.
+            path: Router path in "child" or "child/grandchild" notation.
 
         Returns:
             The RoutingClass instance owning the resolved child router.
 
         Raises:
-            AttributeError: If the base router is not found.
             KeyError: If child path navigation fails.
 
         Example:
-            >>> svc.routing.instance("api/users")  # → UsersModule instance
-            >>> svc.routing.instance("api/users/detail")  # → nested child instance
+            >>> svc.routing.instance("users")  # → UsersModule instance
+            >>> svc.routing.instance("users/detail")  # → nested child instance
         """
         router = self.get_router(path)
         return router.instance  # type: ignore[no-any-return]
 
-    def _lookup_router(self, owner: RoutingClass, name: str) -> Router | None:
-        """Find a router by name in the owner's registry or as attribute."""
-        router = owner._routers.get(name)
-        if router:
-            return router  # type: ignore[no-any-return]
-        candidate = getattr(owner, name, None)
-        if safe_is_instance(candidate, "genro_routes.core.base_router.BaseRouter"):
-            owner._routers[name] = candidate
-            return candidate
-        return None
-
     # Helpers -------------------------------------------------
-    def _split_router_spec(self, name: str, path: str | None) -> tuple[str, str | None]:
-        """Split 'router/path' into (router, path) components."""
-        extra_path = path
-        base_name = name
-        if not path and "/" in name:
-            base_name, extra_path = name.split("/", 1)
-        return base_name, extra_path
-
     def _navigate_router(self, root, path: str):
         """Walk child routers following the path segments."""
         node = root
@@ -496,23 +399,17 @@ class _RoutingProxy:
             node = node._children[segment]
         return node
 
-    def _parse_target(self, target: str) -> tuple[str, str, str]:
-        """Parse 'router:plugin/selector' into (router, plugin, selector)."""
-        if ":" not in target:
-            raise ValueError("Target must include router:plugin")
-        router_part, rest = target.split(":", 1)
-        router_part = router_part.strip()
-        if not router_part:
-            raise ValueError("Router name cannot be empty")
-        if "/" in rest:
-            plugin_part, selector = rest.split("/", 1)
+    def _parse_target(self, target: str) -> tuple[str, str]:
+        """Parse 'plugin/selector' into (plugin, selector)."""
+        if "/" in target:
+            plugin_part, selector = target.split("/", 1)
         else:
-            plugin_part, selector = rest, "_all_"
+            plugin_part, selector = target, "_all_"
         plugin_part = plugin_part.strip()
         selector = selector.strip() or "_all_"
         if not plugin_part:
             raise ValueError("Plugin name cannot be empty")
-        return router_part, plugin_part, selector
+        return plugin_part, selector
 
     def _match_handlers(self, router, selector: str) -> set[str]:
         """Match handler names against glob patterns (comma-separated)."""
@@ -525,16 +422,8 @@ class _RoutingProxy:
                     matched.add(handler_name)
         return matched
 
-    def _describe_all(self) -> dict[str, Any]:
-        """Build introspection dict for all routers on the owner."""
-        owner = self._owner
-        result: dict[str, Any] = {}
-        for attr_name, router in owner._routers.items():
-            result[attr_name] = self._describe_router(router)
-        return result
-
     def _describe_router(self, router) -> dict[str, Any]:
-        """Build introspection dict for a single router."""
+        """Build introspection dict for a router (recursing into children)."""
         return {
             "name": router.name,
             "plugins": [
@@ -555,34 +444,26 @@ class _RoutingProxy:
             },
         }
 
-    def attach_instance(
-        self,
-        child: RoutingClass,
-        *,
-        name: str | None = None,
-        **router_specs: str,
-    ) -> None:
+    def attach_instance(self, child: RoutingClass, *, name: str | None = None) -> None:
         """Attach a child instance. Delegates to owner's attach_instance.
 
         Args:
             child: The RoutingClass instance to attach.
-            name: Shortcut for 1:1 case (child with single router).
-            **router_specs: Explicit mapping with ``router_<parent_router>`` keys.
+            name: Alias under which the child's router is linked.
 
         Example:
             >>> svc.routing.attach_instance(child, name="sales")
-            >>> svc.routing.attach_instance(child, router_api="orders:sales")
         """
-        self._owner.attach_instance(child, name=name, **router_specs)
+        self._owner.attach_instance(child, name=name)
 
     def configure(self, target: Any, **options: Any):
         """Configure router plugins.
 
         Args:
             target: Configuration target. Can be:
-                - ``"?"`` to describe all routers
-                - ``"router:plugin"`` for global plugin config
-                - ``"router:plugin/selector"`` for handler-specific config
+                - ``"?"`` to describe the router
+                - ``"plugin"`` for global plugin config
+                - ``"plugin/selector"`` for handler-specific config
                 - A dict with ``"target"`` key and options
                 - A list of targets
             **options: Configuration options for the plugin.
@@ -607,12 +488,12 @@ class _RoutingProxy:
         if target == "?":
             if options:
                 raise ValueError("Options are not allowed with '?' ")
-            return self._describe_all()
-        router_spec, plugin_name, selector = self._parse_target(target)
-        bound_router = self.get_router(router_spec)
+            return self._describe_router(self._owner.route)
+        plugin_name, selector = self._parse_target(target)
+        bound_router = self._owner.route
         plugin = getattr(bound_router, plugin_name, None)
         if plugin is None:
-            raise AttributeError(f"No plugin named '{plugin_name}' on router '{router_spec}'")
+            raise AttributeError(f"No plugin named '{plugin_name}' on router")
         if not options:
             raise ValueError("No configuration options provided")
         selector = selector or "_all_"
@@ -621,7 +502,7 @@ class _RoutingProxy:
             return {"target": target, "updated": ["_all_"]}
         matches = self._match_handlers(bound_router, selector)
         if not matches:
-            raise KeyError(f"No handlers matching '{selector}' on router '{router_spec}'")
+            raise KeyError(f"No handlers matching '{selector}'")
         for handler in matches:
             plugin.configure(_target=handler, **options)
         return {"target": target, "updated": sorted(matches)}

--- a/src/genro_routes/plugins/auth.py
+++ b/src/genro_routes/plugins/auth.py
@@ -8,25 +8,25 @@ authorization rules defined on endpoints against user tags.
 
 Usage::
 
-    from genro_routes import Router, RoutingClass, route
+    from genro_routes import RoutingClass, route
 
     class MyAPI(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api")
+            self.route.plug("auth")
 
-        @route("api", auth_rule="admin&internal")
+        @route(auth_rule="admin&internal")
         def admin_action(self):
             return "admin only"
 
-        @route("api", auth_rule="public")
+        @route(auth_rule="public")
         def public_action(self):
             return "public"
 
     # Query with user's tags (comma-separated list of tags the user has)
     obj = MyAPI()
-    obj.api.node("admin_action", auth_tags="admin,internal")  # user has both tags
-    obj.api.nodes(auth_tags="admin")           # user has admin tag
-    obj.api.nodes(auth_tags="admin,public")    # user has admin AND public tags
+    obj.route.node("admin_action", auth_tags="admin,internal")  # user has both tags
+    obj.route.nodes(auth_tags="admin")           # user has admin tag
+    obj.route.nodes(auth_tags="admin,public")    # user has admin AND public tags
 
 Rule syntax (on entry auth_rule):
     - ``|`` : OR (user must have at least one)
@@ -79,10 +79,10 @@ class AuthPlugin(BasePlugin):
     Example:
         Entry definition::
 
-            @route("api", auth_rule="admin|manager")  # OR
+            @route(auth_rule="admin|manager")  # OR
             def sensitive_action(self): ...
 
-            @route("api", auth_rule="admin&!guest")   # AND + NOT
+            @route(auth_rule="admin&!guest")   # AND + NOT
             def admin_only(self): ...
 
         Query with user tags::

--- a/src/genro_routes/plugins/channel.py
+++ b/src/genro_routes/plugins/channel.py
@@ -13,26 +13,26 @@ Usage::
 
     class MyAPI(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("channel")
-            self.api.channel.configure(channels="*")  # default: all channels
+            self.route.plug("channel")
+            self.route.channel.configure(channels="*")  # default: all channels
 
-        @route("api", channel_channels="mcp")
+        @route(channel_channels="mcp")
         def mcp_only(self):
             return "only accessible from MCP channel"
 
-        @route("api", channel_channels="mcp,bot_.*")
+        @route(channel_channels="mcp,bot_.*")
         def mcp_and_bots(self):
             return "MCP + any bot channel"
 
-        @route("api")
+        @route()
         def everywhere(self):
             return "inherits * from router config"
 
     obj = MyAPI()
-    obj.api.nodes(channel_channel="mcp")     # sees all three
-    obj.api.nodes(channel_channel="rest")    # sees only everywhere
-    obj.api.node("mcp_only", channel_channel="mcp")  # OK
-    obj.api.node("mcp_only", channel_channel="rest")  # NotAvailable
+    obj.route.nodes(channel_channel="mcp")     # sees all three
+    obj.route.nodes(channel_channel="rest")    # sees only everywhere
+    obj.route.node("mcp_only", channel_channel="mcp")  # OK
+    obj.route.node("mcp_only", channel_channel="rest")  # NotAvailable
 
 Channel patterns:
     - Comma-separated list of patterns: ``"mcp,bot_.*,rest"``

--- a/src/genro_routes/plugins/env.py
+++ b/src/genro_routes/plugins/env.py
@@ -32,21 +32,21 @@ Usage::
 
     class MyAPI(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("env")
+            self.route.plug("env")
             self.capabilities = MyCapabilities()
 
-        @route("api", env_requires="pyjwt&redis")
+        @route(env_requires="pyjwt&redis")
         def create_jwt(self):
             return "jwt created"
 
-        @route("api", env_requires="paypal|stripe")
+        @route(env_requires="paypal|stripe")
         def process_payment(self):
             return "payment processed"
 
     # Query with additional request capabilities
     obj = MyAPI()
-    obj.api.node("create_jwt", env_capabilities="pyjwt")  # OK: pyjwt from request + redis from instance
-    obj.api.node("create_jwt")  # not_available: only redis from instance, missing pyjwt
+    obj.route.node("create_jwt", env_capabilities="pyjwt")  # OK: pyjwt from request + redis from instance
+    obj.route.node("create_jwt")  # not_available: only redis from instance, missing pyjwt
 
     # Dynamic capabilities via CapabilitiesSet
     class PaymentCapabilities(CapabilitiesSet):
@@ -63,7 +63,7 @@ Usage::
 
     class PaymentService(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("env")
+            self.route.plug("env")
             self._stripe_configured = True
             self._paypal_configured = False
             self.capabilities = PaymentCapabilities(self)
@@ -118,10 +118,10 @@ class EnvPlugin(BasePlugin):
     Example:
         Entry definition::
 
-            @route("api", env_requires="redis&pyjwt")  # requires both
+            @route(env_requires="redis&pyjwt")  # requires both
             def create_session(self): ...
 
-            @route("api", env_requires="stripe|paypal")  # requires one
+            @route(env_requires="stripe|paypal")  # requires one
             def process_payment(self): ...
 
         Dynamic capabilities via CapabilitiesSet::
@@ -133,7 +133,7 @@ class EnvPlugin(BasePlugin):
 
             class MyService(RoutingClass):
                 def __init__(self):
-                    self.api = Router(self, name="api").plug("env")
+                    self.route.plug("env")
                     self.capabilities = ServerCaps()
 
         Query with additional request capabilities::
@@ -279,7 +279,7 @@ class CapabilitiesSet:
 
         class MyService(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("env")
+                self.route.plug("env")
                 self.capabilities = ServerCapabilities()
     """
 

--- a/src/genro_routes/plugins/logging.py
+++ b/src/genro_routes/plugins/logging.py
@@ -17,14 +17,14 @@ Example::
 
     class MyService(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("logging")
+            self.route.plug("logging")
 
-        @route("api")
+        @route()
         def hello(self):
             return "Hello!"
 
     # Or configure per-handler:
-    @route("api", logging_after=False)
+    @route(logging_after=False)
     def fast_handler(self):
         return "fast"
 """
@@ -66,22 +66,22 @@ class LoggingPlugin(BasePlugin):
 
             class MyService(RoutingClass):
                 def __init__(self):
-                    self.api = Router(self, name="api").plug("logging")
+                    self.route.plug("logging")
 
-                @route("api")
+                @route()
                 def hello(self):
                     return "Hello!"
 
         Per-handler configuration::
 
-            @route("api", logging_after=False)  # disable end message
+            @route(logging_after=False)  # disable end message
             def fast_handler(self):
                 return "fast"
 
         Runtime configuration::
 
-            svc.api.logging.configure(before=False)  # disable globally
-            svc.api.logging.configure(_target="slow_handler", after=True)
+            svc.route.logging.configure(before=False)  # disable globally
+            svc.route.logging.configure(_target="slow_handler", after=True)
     """
 
     plugin_code = "logging"

--- a/src/genro_routes/plugins/openapi.py
+++ b/src/genro_routes/plugins/openapi.py
@@ -28,21 +28,21 @@ Example::
 
     class MyService(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("openapi").plug("auth")
+            self.route.plug("openapi").plug("auth")
 
-        @route("api", openapi_method="delete")
+        @route(openapi_method="delete")
         def delete_item(self, item_id: int) -> dict:
             return {"deleted": item_id}
 
-        @route("api", openapi_tags=["users"], openapi_deprecated=True)
+        @route(openapi_tags=["users"], openapi_deprecated=True)
         def old_list(self) -> list:
             return []
 
-        @route("api", auth_rule="admin")
+        @route(auth_rule="admin")
         def admin_only(self) -> dict:
             return {}
 
-        @route("api", openapi_security=[])
+        @route(openapi_security=[])
         def force_public(self) -> dict:
             return {}
 """
@@ -91,13 +91,13 @@ class OpenAPIPlugin(BasePlugin):
     Example:
         Override HTTP method::
 
-            @route("api", openapi_method="delete")
+            @route(openapi_method="delete")
             def remove_item(self, item_id: int) -> dict:
                 return {"deleted": item_id}
 
         Add tags and mark deprecated::
 
-            @route("api", openapi_tags=["users", "admin"], openapi_deprecated=True)
+            @route(openapi_tags=["users", "admin"], openapi_deprecated=True)
             def old_list_users(self) -> list:
                 return []
 

--- a/src/genro_routes/plugins/pydantic.py
+++ b/src/genro_routes/plugins/pydantic.py
@@ -22,25 +22,25 @@ Example::
 
     class MyService(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("pydantic")
+            self.route.plug("pydantic")
 
-        @route("api")
+        @route()
         def get_user(self, user_id: int) -> UserResponse:
             return {"id": user_id, "name": "alice"}
 
     svc = MyService()
-    svc.api.node("get_user")(user_id=123)  # OK, validated
-    svc.api.node("get_user")(user_id="not_an_int")  # ValidationError
+    svc.route.node("get_user")(user_id=123)  # OK, validated
+    svc.route.node("get_user")(user_id="not_an_int")  # ValidationError
 
     # Response schema available in metadata
-    entry = svc.api._entries["get_user"]
+    entry = svc.route._entries["get_user"]
     entry.metadata["pydantic"]["response_schema"]
     # {"type": "object", "properties": {"id": ..., "name": ...}, ...}
 
 Configuration::
 
     # Disable validation for a specific handler
-    @route("api", pydantic_disabled=True)
+    @route(pydantic_disabled=True)
     def unvalidated_handler(self):
         pass
 """
@@ -91,22 +91,22 @@ class PydanticPlugin(BasePlugin):
 
             class MyService(RoutingClass):
                 def __init__(self):
-                    self.api = Router(self, name="api").plug("pydantic")
+                    self.route.plug("pydantic")
 
-                @route("api")
+                @route()
                 def get_user(self, user_id: int) -> dict[str, int]:
                     return {"id": user_id}
 
             svc = MyService()
-            svc.api.node("get_user")(user_id=123)           # OK
-            svc.api.node("get_user")(user_id="not_an_int")  # ValidationError
+            svc.route.node("get_user")(user_id=123)           # OK
+            svc.route.node("get_user")(user_id="not_an_int")  # ValidationError
 
             # Response schema in metadata
-            svc.api._entries["get_user"].metadata["pydantic"]["response_schema"]
+            svc.route._entries["get_user"].metadata["pydantic"]["response_schema"]
 
         Disable validation::
 
-            @route("api", pydantic_disabled=True)
+            @route(pydantic_disabled=True)
             def unvalidated(self, data):
                 return data  # no validation
     """

--- a/tests/test_auth_plugin.py
+++ b/tests/test_auth_plugin.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import pytest
 
-from genro_routes import RoutingClass
+from genro_routes import RoutingClass, route
 
 
 class Owner(RoutingClass):
@@ -149,7 +149,6 @@ class TestAuthPluginIntegration:
 
     def test_auth_with_child_routers(self):
         """Test that authorization works with hierarchical routers."""
-        from genro_routes import RoutingClass, route
 
         class Parent(RoutingClass):
             def __init__(self):
@@ -183,7 +182,6 @@ class TestAuthPluginIntegration:
 
     def test_auth_removes_empty_child_routers(self):
         """Child routers with no matching entries should be pruned."""
-        from genro_routes import RoutingClass, route
 
         class Parent(RoutingClass):
             def __init__(self):
@@ -211,7 +209,6 @@ class TestAuth401vs403:
 
     def test_nodes_filters_out_both_401_and_403(self):
         """nodes() silently filters out entries that would be 401 or 403."""
-        from genro_routes import RoutingClass, route
 
         class Svc(RoutingClass):
             def __init__(self):
@@ -251,7 +248,6 @@ class TestAuth401vs403:
 
     def test_custom_exception_classes(self):
         """Test that custom exception classes are used for 401 and 403."""
-        from genro_routes import RoutingClass, route
 
         class Custom401(Exception):
             def __init__(self, path):
@@ -293,7 +289,6 @@ class TestAuthRuleValidation:
 
     def test_comma_in_auth_rule_raises_error(self):
         """Using comma in auth_rule should raise ValueError in configure()."""
-        from genro_routes import RoutingClass, route
 
         class MyService(RoutingClass):
             def __init__(self):
@@ -309,7 +304,6 @@ class TestAuthRuleValidation:
 
     def test_pipe_in_auth_rule_works(self):
         """Using pipe for OR in auth_rule should work."""
-        from genro_routes import RoutingClass, route
 
         class GoodService(RoutingClass):
             def __init__(self):
@@ -331,7 +325,6 @@ class TestAuthRuleValidation:
 
     def test_comma_in_auth_tags_still_works(self):
         """Comma in auth_tags (user credentials) should still work."""
-        from genro_routes import RoutingClass, route
 
         class StrictService(RoutingClass):
             def __init__(self):

--- a/tests/test_auth_plugin.py
+++ b/tests/test_auth_plugin.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import pytest
 
-from genro_routes import RoutingClass, Router
+from genro_routes import RoutingClass
 
 
 class Owner(RoutingClass):
@@ -15,7 +15,7 @@ class Owner(RoutingClass):
 
 
 def _make_router():
-    return Router(Owner(), name="api")
+    return Owner().route
 
 
 class TestAuthPluginIntegration:
@@ -153,29 +153,26 @@ class TestAuthPluginIntegration:
 
         class Parent(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("auth")
+                self.route.plug("auth")
 
         class Child(RoutingClass):
-            def __init__(self):
-                self.api = Router(self, name="api")
-
-            @route("api", auth_rule="admin")
+            @route(auth_rule="admin")
             def child_admin(self):
                 return "child_admin"
 
-            @route("api", auth_rule="public")
+            @route(auth_rule="public")
             def child_public(self):
                 return "child_public"
 
         parent = Parent()
-        parent.api.add_entry(lambda: "parent_admin", name="parent_admin", auth_rule="admin")
+        parent.route.add_entry(lambda: "parent_admin", name="parent_admin", auth_rule="admin")
 
         child = Child()
         # Attach child - plugin is inherited from parent
         parent.attach_instance(child, name="child")
 
         # Filter should apply to both parent and child
-        result = parent.api.nodes(auth_tags="admin")
+        result = parent.route.nodes(auth_tags="admin")
         assert "parent_admin" in result.get("entries", {})
         # Child router should be present if it has matching entries
         assert "child" in result.get("routers", {})
@@ -190,24 +187,21 @@ class TestAuthPluginIntegration:
 
         class Parent(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("auth")
+                self.route.plug("auth")
 
         class Child(RoutingClass):
-            def __init__(self):
-                self.api = Router(self, name="api")
-
-            @route("api", auth_rule="public")
+            @route(auth_rule="public")
             def only_public(self):
                 return "public"
 
         parent = Parent()
-        parent.api.add_entry(lambda: "admin", name="admin_action", auth_rule="admin")
+        parent.route.add_entry(lambda: "admin", name="admin_action", auth_rule="admin")
 
         child = Child()
         parent.attach_instance(child, name="child")
 
         # Filter for admin - child has no admin entries
-        result = parent.api.nodes(auth_tags="admin")
+        result = parent.route.nodes(auth_tags="admin")
         assert "admin_action" in result.get("entries", {})
         # Child should be pruned (empty after filter)
         assert "child" not in result.get("routers", {})
@@ -221,36 +215,36 @@ class TestAuth401vs403:
 
         class Svc(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("auth")
+                self.route.plug("auth")
 
-            @route("api", auth_rule="admin")
+            @route(auth_rule="admin")
             def admin_action(self):
                 return "admin"
 
-            @route("api", auth_rule="public")
+            @route(auth_rule="public")
             def public_action(self):
                 return "public"
 
-            @route("api")  # No tags
+            @route()  # No tags
             def open_action(self):
                 return "open"
 
         svc = Svc()
 
         # With admin tags - sees admin and open, not public
-        entries = svc.api.nodes(auth_tags="admin").get("entries", {})
+        entries = svc.route.nodes(auth_tags="admin").get("entries", {})
         assert "admin_action" in entries
         assert "open_action" in entries
         assert "public_action" not in entries
 
         # With public tags - sees public and open, not admin
-        entries = svc.api.nodes(auth_tags="public").get("entries", {})
+        entries = svc.route.nodes(auth_tags="public").get("entries", {})
         assert "public_action" in entries
         assert "open_action" in entries
         assert "admin_action" not in entries
 
         # Without any tags - only sees entries without rules (401 filtered out)
-        entries = svc.api.nodes().get("entries", {})
+        entries = svc.route.nodes().get("entries", {})
         assert "admin_action" not in entries  # Has rule, no tags → 401
         assert "public_action" not in entries  # Has rule, no tags → 401
         assert "open_action" in entries  # No rule → always visible
@@ -269,29 +263,29 @@ class TestAuth401vs403:
 
         class Svc(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("auth")
+                self.route.plug("auth")
 
-            @route("api", auth_rule="admin")
+            @route(auth_rule="admin")
             def admin_action(self):
                 return "admin"
 
         svc = Svc()
 
         # Test 401 with custom exception
-        node = svc.api.node("admin_action", errors={
+        node = svc.route.node("admin_action", errors={
             "not_authenticated": Custom401
         })
         with pytest.raises(Custom401) as exc_info:
             node()
-        assert exc_info.value.path == "api:admin_action"
+        assert exc_info.value.path == "route:admin_action"
 
         # Test 403 with custom exception
-        node = svc.api.node("admin_action", auth_tags="public", errors={
+        node = svc.route.node("admin_action", auth_tags="public", errors={
             "not_authorized": Custom403
         })
         with pytest.raises(Custom403) as exc_info:
             node()
-        assert exc_info.value.path == "api:admin_action"
+        assert exc_info.value.path == "route:admin_action"
 
 
 class TestAuthRuleValidation:
@@ -303,15 +297,15 @@ class TestAuthRuleValidation:
 
         class MyService(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("auth")
+                self.route.plug("auth")
 
-            @route("api")
+            @route()
             def action(self):
                 return "ok"
 
         svc = MyService()
         with pytest.raises(ValueError, match="Comma not allowed"):
-            svc.api.auth.configure(rule="admin,manager")
+            svc.route.auth.configure(rule="admin,manager")
 
     def test_pipe_in_auth_rule_works(self):
         """Using pipe for OR in auth_rule should work."""
@@ -319,20 +313,20 @@ class TestAuthRuleValidation:
 
         class GoodService(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("auth")
+                self.route.plug("auth")
 
-            @route("api", auth_rule="admin|manager")
+            @route(auth_rule="admin|manager")
             def good_action(self):
                 return "good"
 
         svc = GoodService()
 
         # User with admin can access
-        entries = svc.api.nodes(auth_tags="admin").get("entries", {})
+        entries = svc.route.nodes(auth_tags="admin").get("entries", {})
         assert "good_action" in entries
 
         # User with manager can access
-        entries = svc.api.nodes(auth_tags="manager").get("entries", {})
+        entries = svc.route.nodes(auth_tags="manager").get("entries", {})
         assert "good_action" in entries
 
     def test_comma_in_auth_tags_still_works(self):
@@ -341,14 +335,14 @@ class TestAuthRuleValidation:
 
         class StrictService(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("auth")
+                self.route.plug("auth")
 
-            @route("api", auth_rule="admin&internal")
+            @route(auth_rule="admin&internal")
             def strict_action(self):
                 return "strict"
 
         svc = StrictService()
 
         # User passes multiple tags with comma - should work
-        entries = svc.api.nodes(auth_tags="admin,internal").get("entries", {})
+        entries = svc.route.nodes(auth_tags="admin,internal").get("entries", {})
         assert "strict_action" in entries

--- a/tests/test_capabilities_set.py
+++ b/tests/test_capabilities_set.py
@@ -5,8 +5,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from genro_routes import RoutingClass, route
 from genro_routes.plugins.env import CapabilitiesSet, capability
 

--- a/tests/test_capabilities_set.py
+++ b/tests/test_capabilities_set.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import pytest
 
-from genro_routes import Router, RoutingClass, route
+from genro_routes import RoutingClass, route
 from genro_routes.plugins.env import CapabilitiesSet, capability
 
 
@@ -155,21 +155,21 @@ class TestCapabilitiesSetWithRouting:
 
         class Service(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("env")
+                self.route.plug("env")
                 self.capabilities = ServerCaps()
 
-            @route("api", env_requires="redis")
+            @route(env_requires="redis")
             def needs_redis(self):
                 return "ok"
 
-            @route("api", env_requires="postgres")
+            @route(env_requires="postgres")
             def needs_postgres(self):
                 return "ok"
 
         svc = Service()
 
         # redis is active - entry visible in nodes()
-        entries = svc.api.nodes().get("entries", {})
+        entries = svc.route.nodes().get("entries", {})
         assert "needs_redis" in entries
 
         # postgres is inactive - entry not visible
@@ -188,26 +188,26 @@ class TestCapabilitiesSetWithRouting:
 
         class Service(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("env")
+                self.route.plug("env")
                 self._caps = DynamicCaps()
                 self.capabilities = self._caps
 
-            @route("api", env_requires="online")
+            @route(env_requires="online")
             def process(self):
                 return "processed"
 
         svc = Service()
 
         # Initially online - entry visible
-        entries = svc.api.nodes().get("entries", {})
+        entries = svc.route.nodes().get("entries", {})
         assert "process" in entries
 
         # Enter maintenance mode - entry not visible
         svc._caps._maintenance = True
-        entries = svc.api.nodes().get("entries", {})
+        entries = svc.route.nodes().get("entries", {})
         assert "process" not in entries
 
         # Exit maintenance mode - entry visible again
         svc._caps._maintenance = False
-        entries = svc.api.nodes().get("entries", {})
+        entries = svc.route.nodes().get("entries", {})
         assert "process" in entries

--- a/tests/test_channel_plugin.py
+++ b/tests/test_channel_plugin.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import pytest
 
-from genro_routes import Router, RoutingClass, route
+from genro_routes import RoutingClass, route
 from genro_routes.exceptions import NotAvailable
 
 
@@ -16,7 +16,7 @@ class Owner(RoutingClass):
 
 
 def _make_router():
-    return Router(Owner(), name="api").plug("channel")
+    return Owner().route.plug("channel")
 
 
 class TestChannelPluginBasic:
@@ -95,23 +95,23 @@ class TestChannelPluginWithDecorator:
 
         class Svc(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("channel")
-                self.api.channel.configure(channels="*")
+                self.route.plug("channel")
+                self.route.channel.configure(channels="*")
 
-            @route("api", channel_channels="mcp")
+            @route(channel_channels="mcp")
             def mcp_only(self):
                 return "mcp"
 
-            @route("api")
+            @route()
             def everywhere(self):
                 return "all"
 
         svc = Svc()
-        entries = svc.api.nodes(channel_channel="mcp").get("entries", {})
+        entries = svc.route.nodes(channel_channel="mcp").get("entries", {})
         assert "mcp_only" in entries
         assert "everywhere" in entries
 
-        entries = svc.api.nodes(channel_channel="rest").get("entries", {})
+        entries = svc.route.nodes(channel_channel="rest").get("entries", {})
         assert "mcp_only" not in entries
         assert "everywhere" in entries
 
@@ -120,16 +120,16 @@ class TestChannelPluginWithDecorator:
 
         class Svc(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("channel")
+                self.route.plug("channel")
 
-            @route("api", channel="mcp")
+            @route(channel="mcp")
             def mcp_only(self):
                 return "mcp"
 
         svc = Svc()
-        entries = svc.api.nodes(channel_channel="mcp").get("entries", {})
+        entries = svc.route.nodes(channel_channel="mcp").get("entries", {})
         assert "mcp_only" in entries
-        entries = svc.api.nodes(channel_channel="rest").get("entries", {})
+        entries = svc.route.nodes(channel_channel="rest").get("entries", {})
         assert "mcp_only" not in entries
 
 
@@ -162,19 +162,19 @@ class TestChannelPluginGlobalConfig:
 
         class Svc(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("channel")
-                self.api.channel.configure(channels="*")
+                self.route.plug("channel")
+                self.route.channel.configure(channels="*")
 
-            @route("api")
+            @route()
             def open_handler(self):
                 return "open"
 
-            @route("api", channel_channels="mcp")
+            @route(channel_channels="mcp")
             def restricted(self):
                 return "mcp only"
 
         svc = Svc()
-        entries = svc.api.nodes(channel_channel="rest").get("entries", {})
+        entries = svc.route.nodes(channel_channel="rest").get("entries", {})
         assert "open_handler" in entries
         assert "restricted" not in entries
 
@@ -199,21 +199,21 @@ class TestChannelWithAuthPlugin:
 
         class Svc(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("channel").plug("auth")
+                self.route.plug("channel").plug("auth")
 
-            @route("api", channel_channels="mcp", auth_rule="admin")
+            @route(channel_channels="mcp", auth_rule="admin")
             def admin_mcp(self):
                 return "admin via mcp"
 
         svc = Svc()
         # Both match
-        entries = svc.api.nodes(channel_channel="mcp", auth_tags="admin").get("entries", {})
+        entries = svc.route.nodes(channel_channel="mcp", auth_tags="admin").get("entries", {})
         assert "admin_mcp" in entries
 
         # Channel matches, auth doesn't
-        entries = svc.api.nodes(channel_channel="mcp", auth_tags="guest").get("entries", {})
+        entries = svc.route.nodes(channel_channel="mcp", auth_tags="guest").get("entries", {})
         assert "admin_mcp" not in entries
 
         # Auth matches, channel doesn't
-        entries = svc.api.nodes(channel_channel="rest", auth_tags="admin").get("entries", {})
+        entries = svc.route.nodes(channel_channel="rest", auth_tags="admin").get("entries", {})
         assert "admin_mcp" not in entries

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,13 +16,12 @@
 
 import json
 from enum import Enum
-from typing import Literal, Optional
+from typing import Literal
 
 from click.testing import CliRunner
 
 from genro_routes import RoutingClass, route
 from genro_routes.cli import RoutingCli
-
 
 # ---------------------------------------------------------------------------
 # Test fixtures: RoutingClass examples
@@ -58,7 +57,7 @@ class TypedService(RoutingClass):
         return f"verbose={verbose}"
 
     @route()
-    def with_optional(self, name: Optional[str] = None):
+    def with_optional(self, name: str | None = None):
         return f"name={name}"
 
     @route()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,10 +18,9 @@ import json
 from enum import Enum
 from typing import Literal, Optional
 
-import pytest
 from click.testing import CliRunner
 
-from genro_routes import Router, RoutingClass, route
+from genro_routes import RoutingClass, route
 from genro_routes.cli import RoutingCli
 
 
@@ -32,59 +31,41 @@ from genro_routes.cli import RoutingCli
 class SimpleService(RoutingClass):
     """A simple test service."""
 
-    def __init__(self):
-        self.api = Router(self, name="api")
-
-    @route("api")
+    @route()
     def hello(self, name: str = "world"):
         return f"Hello {name}"
 
-    @route("api")
+    @route()
     def add(self, a: int, b: int):
         """Add two numbers."""
         return a + b
 
-    @route("api")
+    @route()
     def greet(self, name: str):
         """Greet someone by name."""
         return f"Hi {name}!"
 
-
-class MultiRouterService(RoutingClass):
-    """Service with multiple routers."""
-
-    def __init__(self):
-        self.api = Router(self, name="api")
-        self.admin = Router(self, name="admin")
-
-    @route("api")
+    @route()
     def status(self):
         return {"status": "ok"}
-
-    @route("admin")
-    def reset(self):
-        return "reset done"
 
 
 class TypedService(RoutingClass):
     """Service with various parameter types."""
 
-    def __init__(self):
-        self.api = Router(self, name="api")
-
-    @route("api")
+    @route()
     def with_flag(self, verbose: bool = False):
         return f"verbose={verbose}"
 
-    @route("api")
+    @route()
     def with_optional(self, name: Optional[str] = None):
         return f"name={name}"
 
-    @route("api")
+    @route()
     def with_literal(self, mode: Literal["fast", "slow"] = "fast"):
         return f"mode={mode}"
 
-    @route("api")
+    @route()
     def with_list(self, items: list[str] = ()):
         return f"items={list(items)}"
 
@@ -96,19 +77,13 @@ class Color(Enum):
 
 
 class EnumService(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="api")
-
-    @route("api")
+    @route()
     def paint(self, color: Color = Color.RED):
         return f"color={color.name}"
 
 
 class ChildService(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="api")
-
-    @route("api")
+    @route()
     def detail(self, item_id: int):
         return f"item={item_id}"
 
@@ -117,11 +92,10 @@ class ParentService(RoutingClass):
     """Service with child hierarchy."""
 
     def __init__(self):
-        self.api = Router(self, name="api")
         self.child = ChildService()
         self.attach_instance(self.child, name="items")
 
-    @route("api")
+    @route()
     def index(self):
         return "parent index"
 
@@ -162,17 +136,6 @@ class TestCommandStructure:
         assert "hello" in cmd_names
         assert "add" in cmd_names
         assert "greet" in cmd_names
-
-    def test_multi_router_creates_subgroups(self):
-        cli = RoutingCli(MultiRouterService)
-        cmd_names = set(cli.click_group.commands.keys())
-        assert "api" in cmd_names
-        assert "admin" in cmd_names
-
-    def test_multi_router_subgroup_has_commands(self):
-        cli = RoutingCli(MultiRouterService)
-        api_group = cli.click_group.commands["api"]
-        assert "status" in api_group.commands
 
     def test_child_hierarchy(self):
         cli = RoutingCli(ParentService)
@@ -217,17 +180,11 @@ class TestInvocation:
         assert "7" in result.output
 
     def test_dict_output_is_json(self):
-        cli = RoutingCli(MultiRouterService)
-        result = self.runner.invoke(cli.click_group, ["api", "status"])
+        cli = RoutingCli(SimpleService)
+        result = self.runner.invoke(cli.click_group, ["status"])
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data == {"status": "ok"}
-
-    def test_multi_router_command(self):
-        cli = RoutingCli(MultiRouterService)
-        result = self.runner.invoke(cli.click_group, ["admin", "reset"])
-        assert result.exit_code == 0
-        assert "reset done" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -315,13 +272,6 @@ class TestHelp:
         assert result.exit_code == 0
         assert "Add two numbers" in result.output
 
-    def test_multi_router_help(self):
-        cli = RoutingCli(MultiRouterService)
-        result = self.runner.invoke(cli.click_group, ["--help"])
-        assert result.exit_code == 0
-        assert "api" in result.output
-        assert "admin" in result.output
-
 
 # ---------------------------------------------------------------------------
 # Tests: child hierarchy invocation
@@ -352,25 +302,22 @@ class TestOutputFormat:
 
     def test_json_format(self):
         runner = CliRunner()
-        cli = RoutingCli(MultiRouterService, output_format="json")
-        result = runner.invoke(cli.click_group, ["api", "status"])
+        cli = RoutingCli(SimpleService, output_format="json")
+        result = runner.invoke(cli.click_group, ["status"])
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data == {"status": "ok"}
 
     def test_raw_format(self):
         runner = CliRunner()
-        cli = RoutingCli(MultiRouterService, output_format="raw")
-        result = runner.invoke(cli.click_group, ["admin", "reset"])
+        cli = RoutingCli(SimpleService, output_format="raw")
+        result = runner.invoke(cli.click_group, ["hello"])
         assert result.exit_code == 0
-        assert "'reset done'" in result.output
+        assert "'Hello world'" in result.output
 
     def test_none_return_no_output(self):
         class NoneService(RoutingClass):
-            def __init__(self):
-                self.api = Router(self, name="api")
-
-            @route("api")
+            @route()
             def noop(self):
                 return None
 

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -18,11 +18,24 @@ import sys
 from typing import TypedDict
 
 import pytest
+from pydantic import BaseModel
 
 import genro_routes.plugins.logging  # noqa: F401
 import genro_routes.plugins.pydantic  # noqa: F401
 from genro_routes import Router, RoutingClass, route
+from genro_routes.core.base_router import BaseRouter
+from genro_routes.core.context import RoutingContext
+from genro_routes.core.router import _PluginSpec
+from genro_routes.core.router_node import RouterNode
+from genro_routes.core.routing import ResultWrapper, is_result_wrapper
+from genro_routes.exceptions import (
+    NotAuthenticated,
+    NotAuthorized,
+    NotAvailable,
+    NotFound,
+)
 from genro_routes.plugins._base_plugin import BasePlugin
+from genro_routes.plugins.openapi import OpenAPITranslator
 
 # TypedDict classes at module level for cross-Python-version compatibility
 # (pydantic handles nested TypedDict differently when defined inside functions
@@ -71,7 +84,6 @@ def test_nodes_with_plugin_returns_extra_info():
 
 def test_plugin_spec_clone():
     """Test _PluginSpec.clone() method."""
-    from genro_routes.core.router import _PluginSpec
 
     class DummyPlugin(BasePlugin):
         plugin_code = "dummy_clone"
@@ -633,7 +645,6 @@ def test_child_ignores_parent_config_no_cascade():
 
 def test_not_found_selector():
     """Test NotFound exception with selector."""
-    from genro_routes.exceptions import NotFound
 
     exc = NotFound("my_router:my_path")
     assert exc.selector == "my_router:my_path"
@@ -642,7 +653,6 @@ def test_not_found_selector():
 
 def test_not_authorized_selector():
     """Test NotAuthorized exception with selector."""
-    from genro_routes.exceptions import NotAuthorized
 
     exc = NotAuthorized("my_router:my_path")
     assert exc.selector == "my_router:my_path"
@@ -651,7 +661,6 @@ def test_not_authorized_selector():
 
 def test_not_authenticated_selector():
     """Test NotAuthenticated exception with selector."""
-    from genro_routes.exceptions import NotAuthenticated
 
     exc = NotAuthenticated("my_router:my_path")
     assert exc.selector == "my_router:my_path"
@@ -660,7 +669,6 @@ def test_not_authenticated_selector():
 
 def test_not_available_selector():
     """Test NotAvailable exception with selector."""
-    from genro_routes.exceptions import NotAvailable
 
     exc = NotAvailable("my_router:my_path")
     assert exc.selector == "my_router:my_path"
@@ -740,7 +748,6 @@ def test_auth_deny_reason_router_empty():
 
 def test_openapi_translator_schema_to_parameters_empty():
     """Test schema_to_parameters with empty schema."""
-    from genro_routes.plugins.openapi import OpenAPITranslator
 
     result = OpenAPITranslator.schema_to_parameters({})
     assert result == []
@@ -751,7 +758,6 @@ def test_openapi_translator_schema_to_parameters_empty():
 
 def test_openapi_translator_entry_without_callable():
     """Test entry_info_to_openapi when callable is None."""
-    from genro_routes.plugins.openapi import OpenAPITranslator
 
     entry_info = {
         "callable": None,
@@ -767,7 +773,6 @@ def test_openapi_translator_entry_without_callable():
 
 def test_openapi_translator_create_model_no_fields():
     """Test create_pydantic_model_for_func returns None when no fields."""
-    from genro_routes.plugins.openapi import OpenAPITranslator
 
     def no_params() -> str:
         return "ok"
@@ -779,7 +784,6 @@ def test_openapi_translator_create_model_no_fields():
 
 def test_openapi_h_openapi_child_included():
     """Test h_openapi includes child routers with metadata."""
-    from genro_routes.plugins.openapi import OpenAPITranslator
 
     nodes_data = {
         "entries": {},
@@ -812,7 +816,6 @@ def test_openapi_nested_typeddict_defs_at_root():
 
     Fixes: https://github.com/softwellsrl/genro-routes/issues/15
     """
-    from genro_routes.plugins.openapi import OpenAPITranslator
 
     class Svc(RoutingClass):
         @route()
@@ -839,7 +842,6 @@ def test_openapi_nested_typeddict_defs_at_root():
 )
 def test_openapi_nested_typeddict_h_openapi_defs_at_root():
     """Test that h_openapi also collects $defs at root level."""
-    from genro_routes.plugins.openapi import OpenAPITranslator
 
     class Svc(RoutingClass):
         @route()
@@ -925,7 +927,6 @@ def test_base_router_entry_invalid_reason():
     BaseRouter provides a default implementation that returns "not_found"
     for None entries. Router overrides this, so we test BaseRouter directly.
     """
-    from genro_routes.core.base_router import BaseRouter
 
     class Svc(RoutingClass):
         @route()
@@ -1027,7 +1028,6 @@ def test_add_entry_unknown_plugin_option_as_metadata():
 
 def test_router_node_custom_exceptions_in_init():
     """Test RouterNode with custom exceptions passed to constructor."""
-    from genro_routes.core.router_node import RouterNode
 
     class CustomNotFound(Exception):
         pass
@@ -1053,7 +1053,6 @@ def test_router_node_custom_exceptions_in_init():
 
 def test_router_node_doc_and_metadata_when_entry_none():
     """Test doc and metadata properties return empty when entry is None."""
-    from genro_routes.core.router_node import RouterNode
 
     class Svc(RoutingClass):
         @route()
@@ -1080,7 +1079,6 @@ def test_router_node_custom_validation_error_exception():
         @route()
         def handler(self):
             # Raise a pydantic ValidationError
-            from pydantic import BaseModel
 
             class Model(BaseModel):
                 value: int
@@ -1100,7 +1098,6 @@ def test_router_node_custom_validation_error_exception():
 
 def test_auth_deny_reason_router_with_accessible_child():
     """Test auth deny_reason returns empty when at least one child is accessible."""
-    import genro_routes.plugins.auth  # noqa: F401
 
     class Child(RoutingClass):
         @route(auth_rule="public")
@@ -1133,7 +1130,6 @@ def test_auth_deny_reason_router_with_accessible_child():
 
 def test_result_wrapper():
     """Test ResultWrapper class."""
-    from genro_routes.core.routing import ResultWrapper, is_result_wrapper
 
     wrapper = ResultWrapper("test_value", {"mime": "text/plain"})
     assert wrapper.value == "test_value"
@@ -1151,7 +1147,6 @@ def test_routing_class_result_wrapper_method():
     svc = Svc()
     result = svc.result_wrapper("content", mime_type="application/json")
 
-    from genro_routes.core.routing import ResultWrapper
 
     assert isinstance(result, ResultWrapper)
     assert result.value == "content"
@@ -1160,7 +1155,6 @@ def test_routing_class_result_wrapper_method():
 
 def test_routing_class_ctx_property():
     """Test RoutingClass.ctx getter and setter via slot + parent chain."""
-    from genro_routes.core.context import RoutingContext
 
     class Svc(RoutingClass):
         pass
@@ -1184,7 +1178,6 @@ def test_routing_class_ctx_property():
 
 def test_routing_class_ctx_parent_chain():
     """Child walks up _routing_parent chain for ctx."""
-    from genro_routes.core.context import RoutingContext
 
     class Parent(RoutingClass):
         pass
@@ -1615,7 +1608,6 @@ def test_describe_entry_extra_with_plugin_data():
 
 def test_router_node_default_exceptions_without_pydantic():
     """Test DEFAULT_EXCEPTIONS when ValidationError import fails."""
-    from genro_routes.core.router_node import RouterNode
 
     # Just verify the class loads correctly and has default exceptions
     assert "not_found" in RouterNode.DEFAULT_EXCEPTIONS
@@ -1650,7 +1642,6 @@ def test_add_entry_star_with_plugin_options():
     passed to add_entry (e.g., logging_before=False) and merged in
     _register_marked.
     """
-    from genro_routes.core.base_router import BaseRouter
 
     # Create a fresh class for this test
     class SvcForPluginOpts(RoutingClass):
@@ -1686,7 +1677,6 @@ def test_bind_when_already_bound():
 
     Covers the early-return statement when self._bound is True.
     """
-    from genro_routes.core.base_router import BaseRouter
 
     class Svc(RoutingClass):
         @route()

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -21,9 +21,8 @@ import pytest
 
 import genro_routes.plugins.logging  # noqa: F401
 import genro_routes.plugins.pydantic  # noqa: F401
-from genro_routes import RoutingClass, Router, route
+from genro_routes import Router, RoutingClass, route
 from genro_routes.plugins._base_plugin import BasePlugin
-
 
 # TypedDict classes at module level for cross-Python-version compatibility
 # (pydantic handles nested TypedDict differently when defined inside functions
@@ -46,7 +45,7 @@ class _Inner(TypedDict):
 class _Outer(TypedDict):
     inner: _Inner
 
-# --- base_router.py:682 - _describe_entry_extra returns extra ---
+# --- base_router.py - _describe_entry_extra returns extra ---
 
 
 def test_nodes_with_plugin_returns_extra_info():
@@ -54,20 +53,20 @@ def test_nodes_with_plugin_returns_extra_info():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("pydantic")
+            self.route.plug("pydantic")
 
-        @route("api")
+        @route()
         def handler(self, text: str) -> str:
             return text
 
     svc = Svc()
-    tree = svc.api.nodes()
+    tree = svc.route.nodes()
     # Should have plugins info in entry
     entry_info = tree["entries"]["handler"]
     assert "plugins" in entry_info
 
 
-# --- router.py:130 - _PluginSpec.clone ---
+# --- router.py - _PluginSpec.clone ---
 
 
 def test_plugin_spec_clone():
@@ -85,7 +84,7 @@ def test_plugin_spec_clone():
     assert cloned.kwargs is not spec.kwargs  # Should be a copy
 
 
-# --- router.py:175 - empty plugin name error ---
+# --- router.py - empty plugin name error ---
 
 
 def test_register_plugin_empty_name_raises():
@@ -100,49 +99,46 @@ def test_register_plugin_empty_name_raises():
         Router.register_plugin(NoCodePlugin)
 
 
-# --- router.py:335-341, 353-355 - inherited plugin config lookup ---
+# --- router.py - inherited plugin config lookup ---
 
 
 def test_inherited_plugin_config_lookup():
     """Test that child router inherits parent plugin config."""
 
     class ChildSvc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def child_handler(self):
             return "child"
 
     class ParentSvc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("logging")
+            self.route.plug("logging")
             self.child = ChildSvc()  # Child must be an attribute of parent
 
-        @route("api")
+        @route()
         def parent_handler(self):
             return "parent"
 
     parent = ParentSvc()
 
     # Set config on parent
-    parent.api.logging.configure(before=False, after=True)
+    parent.route.logging.configure(before=False, after=True)
 
     # Attach child to parent
     parent.attach_instance(parent.child, name="child")
 
     # Child should inherit the plugin and config
-    assert "logging" in parent.child.api._plugins_by_name
+    assert "logging" in parent.child.route._plugins_by_name
 
     # The config lookup should work (callable resolution)
-    child_logging = parent.child.api._plugins_by_name["logging"]
+    child_logging = parent.child.route._plugins_by_name["logging"]
     cfg = child_logging.configuration("child_handler")
     # Should have inherited config (before=False, after=True from parent)
     assert cfg.get("after") is True
     assert cfg.get("before") is False
 
 
-# --- _base_plugin.py:119-122 - multi-target configure ---
+# --- _base_plugin.py - multi-target configure ---
 
 
 def test_configure_multi_target():
@@ -150,28 +146,28 @@ def test_configure_multi_target():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("logging")
+            self.route.plug("logging")
 
-        @route("api")
+        @route()
         def handler_a(self):
             return "a"
 
-        @route("api")
+        @route()
         def handler_b(self):
             return "b"
 
-        @route("api")
+        @route()
         def handler_c(self):
             return "c"
 
     svc = Svc()
     # Configure multiple targets at once
-    svc.api.logging.configure(_target="handler_a,handler_b", before=False)
+    svc.route.logging.configure(_target="handler_a,handler_b", before=False)
 
     # Both should have before=False
-    cfg_a = svc.api.logging.configuration("handler_a")
-    cfg_b = svc.api.logging.configuration("handler_b")
-    cfg_c = svc.api.logging.configuration("handler_c")
+    cfg_a = svc.route.logging.configuration("handler_a")
+    cfg_b = svc.route.logging.configuration("handler_b")
+    cfg_c = svc.route.logging.configuration("handler_c")
 
     assert cfg_a.get("before") is False
     assert cfg_b.get("before") is False
@@ -179,7 +175,7 @@ def test_configure_multi_target():
     assert cfg_c.get("before") is not False or "before" not in cfg_c
 
 
-# --- _base_plugin.py:240-241 - base configure with flags ---
+# --- _base_plugin.py - base configure with flags ---
 
 
 def test_base_plugin_configure_with_flags():
@@ -195,22 +191,22 @@ def test_base_plugin_configure_with_flags():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("flags_test")
+            self.route.plug("flags_test")
 
-        @route("api")
+        @route()
         def handler(self):
             return "ok"
 
     svc = Svc()
     # Call configure with flags - should use base implementation
-    svc.api.flags_test.configure(flags="enabled,verbose:off")
+    svc.route.flags_test.configure(flags="enabled,verbose:off")
 
-    cfg = svc.api.flags_test.configuration("handler")
+    cfg = svc.route.flags_test.configuration("handler")
     assert cfg.get("enabled") is True
     assert cfg.get("verbose") is False
 
 
-# --- pydantic.py:100 - no parameter hints ---
+# --- pydantic.py - no parameter hints ---
 
 
 def test_pydantic_handler_without_param_hints():
@@ -218,15 +214,15 @@ def test_pydantic_handler_without_param_hints():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("pydantic")
+            self.route.plug("pydantic")
 
-        @route("api")
+        @route()
         def no_hints(self, x, y):  # No type hints on parameters
             return f"{x}:{y}"
 
     svc = Svc()
     # Should work without validation (passthrough)
-    node = svc.api.node("no_hints")
+    node = svc.route.node("no_hints")
     result = node("a", "b")
     assert result == "a:b"
 
@@ -236,20 +232,20 @@ def test_pydantic_handler_only_return_hint():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("pydantic")
+            self.route.plug("pydantic")
 
-        @route("api")
+        @route()
         def only_return(self, x, y) -> str:  # Only return type hint
             return f"{x}:{y}"
 
     svc = Svc()
     # Should work without validation (no param hints after removing return)
-    node = svc.api.node("only_return")
+    node = svc.route.node("only_return")
     result = node("a", "b")
     assert result == "a:b"
 
 
-# --- pydantic.py:107 - param not in signature raises error ---
+# --- pydantic.py - param not in signature raises error ---
 
 
 def test_pydantic_hint_not_in_signature_raises():
@@ -268,18 +264,18 @@ def test_pydantic_hint_not_in_signature_raises():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("pydantic")
+            self.route.plug("pydantic")
 
     # Assign decorated handler - this triggers on_decore
-    Svc.handler = route("api")(handler)
+    Svc.handler = route()(handler)
 
     # Error is raised at first use (lazy binding)
     svc = Svc()
     with pytest.raises(ValueError, match="type hint for 'phantom'.*not in the function signature"):
-        svc.api.node("handler")
+        svc.route.node("handler")
 
 
-# --- pydantic.py:159-167 - get_model disabled/no model ---
+# --- pydantic.py - get_model disabled/no model ---
 
 
 def test_pydantic_get_model_disabled():
@@ -287,24 +283,24 @@ def test_pydantic_get_model_disabled():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("pydantic")
+            self.route.plug("pydantic")
 
-        @route("api")
+        @route()
         def handler(self, text: str) -> str:
             return text
 
     svc = Svc()
-    svc.api.nodes()  # Trigger lazy binding
-    entry = svc.api._entries["handler"]
+    svc.route.nodes()  # Trigger lazy binding
+    entry = svc.route._entries["handler"]
 
     # Initially should return model
-    result = svc.api.pydantic.get_model(entry)
+    result = svc.route.pydantic.get_model(entry)
     assert result is not None
     assert result[0] == "pydantic_model"
 
     # After disabling, should return None
-    svc.api.pydantic.configure(disabled=True)
-    result = svc.api.pydantic.get_model(entry)
+    svc.route.pydantic.configure(disabled=True)
+    result = svc.route.pydantic.get_model(entry)
     assert result is None
 
 
@@ -313,22 +309,22 @@ def test_pydantic_get_model_no_model():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("pydantic")
+            self.route.plug("pydantic")
 
-        @route("api")
+        @route()
         def no_hints(self, x, y):  # No type hints
             return f"{x}:{y}"
 
     svc = Svc()
-    svc.api.nodes()  # Trigger lazy binding
-    entry = svc.api._entries["no_hints"]
+    svc.route.nodes()  # Trigger lazy binding
+    entry = svc.route._entries["no_hints"]
 
     # No model was created
-    result = svc.api.pydantic.get_model(entry)
+    result = svc.route.pydantic.get_model(entry)
     assert result is None
 
 
-# --- pydantic.py:164-173 - entry_metadata with signature info ---
+# --- pydantic.py - entry_metadata with signature info ---
 
 
 def test_pydantic_entry_metadata_no_hints():
@@ -336,17 +332,17 @@ def test_pydantic_entry_metadata_no_hints():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("pydantic")
+            self.route.plug("pydantic")
 
-        @route("api")
+        @route()
         def no_hints(self, x, y):  # No type hints but signature is captured
             return f"{x}:{y}"
 
     svc = Svc()
-    svc.api.nodes()  # Trigger lazy binding
-    entry = svc.api._entries["no_hints"]
+    svc.route.nodes()  # Trigger lazy binding
+    entry = svc.route._entries["no_hints"]
 
-    result = svc.api.pydantic.entry_metadata(svc.api, entry)
+    result = svc.route.pydantic.entry_metadata(svc.route, entry)
     # Now always returns signature info (accepts_varargs, hints)
     assert result["accepts_varargs"] is False
     assert result["hints"] == {}
@@ -358,17 +354,17 @@ def test_pydantic_entry_metadata_with_meta():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("pydantic")
+            self.route.plug("pydantic")
 
-        @route("api")
+        @route()
         def with_hints(self, text: str, num: int) -> str:
             return f"{text}:{num}"
 
     svc = Svc()
-    svc.api.nodes()  # Trigger lazy binding
-    entry = svc.api._entries["with_hints"]
+    svc.route.nodes()  # Trigger lazy binding
+    entry = svc.route._entries["with_hints"]
 
-    result = svc.api.pydantic.entry_metadata(svc.api, entry)
+    result = svc.route.pydantic.entry_metadata(svc.route, entry)
     assert "model" in result
     assert "hints" in result
     assert "accepts_varargs" in result
@@ -383,19 +379,16 @@ def test_inherited_plugin_is_separate_instance():
     """Test that inherited plugin is a new instance, not shared with parent."""
 
     class ChildSvc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def child_handler(self):
             return "child"
 
     class ParentSvc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("logging")
+            self.route.plug("logging")
             self.child = ChildSvc()
 
-        @route("api")
+        @route()
         def parent_handler(self):
             return "parent"
 
@@ -403,44 +396,41 @@ def test_inherited_plugin_is_separate_instance():
     parent.attach_instance(parent.child, name="child")
 
     # Plugin instances should be DIFFERENT objects
-    parent_plugin = parent.api._plugins_by_name["logging"]
-    child_plugin = parent.child.api._plugins_by_name["logging"]
+    parent_plugin = parent.route._plugins_by_name["logging"]
+    child_plugin = parent.child.route._plugins_by_name["logging"]
 
     assert parent_plugin is not child_plugin
-    assert parent_plugin._router is parent.api
-    assert child_plugin._router is parent.child.api
+    assert parent_plugin._router is parent.route
+    assert child_plugin._router is parent.child.route
 
 
 def test_inherited_plugin_copies_parent_config():
     """Test that child inherits a copy of parent's config at attach time."""
 
     class ChildSvc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def child_handler(self):
             return "child"
 
     class ParentSvc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("logging")
+            self.route.plug("logging")
             self.child = ChildSvc()
 
-        @route("api")
+        @route()
         def parent_handler(self):
             return "parent"
 
     parent = ParentSvc()
 
     # Configure parent BEFORE attach
-    parent.api.logging.configure(before=False, after=True)
+    parent.route.logging.configure(before=False, after=True)
 
     # Attach child - should copy config
     parent.attach_instance(parent.child, name="child")
 
     # Child should have same config values
-    child_cfg = parent.child.api.logging.configuration()
+    child_cfg = parent.child.route.logging.configuration()
     assert child_cfg.get("before") is False
     assert child_cfg.get("after") is True
 
@@ -449,32 +439,29 @@ def test_child_config_independent_from_parent():
     """Test that after attach, child's config is independent from parent."""
 
     class ChildSvc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def child_handler(self):
             return "child"
 
     class ParentSvc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("logging")
+            self.route.plug("logging")
             self.child = ChildSvc()
 
-        @route("api")
+        @route()
         def parent_handler(self):
             return "parent"
 
     parent = ParentSvc()
-    parent.api.logging.configure(before=True, after=False)
+    parent.route.logging.configure(before=True, after=False)
     parent.attach_instance(parent.child, name="child")
 
     # Child modifies its own config
-    parent.child.api.logging.configure(before=False, after=True)
+    parent.child.route.logging.configure(before=False, after=True)
 
     # Configs should be different
-    parent_cfg = parent.api.logging.configuration()
-    child_cfg = parent.child.api.logging.configuration()
+    parent_cfg = parent.route.logging.configuration()
+    child_cfg = parent.child.route.logging.configuration()
 
     assert parent_cfg.get("before") is True
     assert parent_cfg.get("after") is False
@@ -497,24 +484,21 @@ def test_parent_config_change_notifies_children():
             pass
 
         def on_parent_config_changed(self, old_config, new_config):
-            notifications.append({"router": self._router.name, "config": new_config})
+            notifications.append({"router": self._router, "config": new_config})
 
     Router.register_plugin(TrackingPlugin)
 
     class ChildSvc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="child_api")
-
-        @route("api")
+        @route()
         def child_handler(self):
             return "child"
 
     class ParentSvc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="parent_api").plug("tracking")
+            self.route.plug("tracking")
             self.child = ChildSvc()
 
-        @route("api")
+        @route()
         def parent_handler(self):
             return "parent"
 
@@ -525,11 +509,11 @@ def test_parent_config_change_notifies_children():
     notifications.clear()
 
     # Change parent config
-    parent.api.tracking.configure(value=42)
+    parent.route.tracking.configure(value=42)
 
     # Child should have been notified
     assert len(notifications) == 1
-    assert notifications[0]["router"] == "child_api"
+    assert notifications[0]["router"] is parent.child.route
     assert notifications[0]["config"]["value"] == 42
 
 
@@ -545,35 +529,31 @@ def test_cascading_notifications():
             pass
 
         def on_parent_config_changed(self, old_config, new_config):
-            notifications.append({"router": self._router.name, "config": new_config})
+            notifications.append({"router": self._router, "config": new_config})
             # Apply the config - this should cascade to our children
             self.configure(**new_config)
 
     Router.register_plugin(CascadePlugin)
 
     class GrandchildSvc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="grandchild_api")
-
-        @route("api")
+        @route()
         def grandchild_handler(self):
             return "grandchild"
 
     class ChildSvc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="child_api")
             self.grandchild = GrandchildSvc()
 
-        @route("api")
+        @route()
         def child_handler(self):
             return "child"
 
     class ParentSvc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="parent_api").plug("cascade")
+            self.route.plug("cascade")
             self.child = ChildSvc()
 
-        @route("api")
+        @route()
         def parent_handler(self):
             return "parent"
 
@@ -585,13 +565,13 @@ def test_cascading_notifications():
     notifications.clear()
 
     # Change parent config
-    parent.api.cascade.configure(level=99)
+    parent.route.cascade.configure(level=99)
 
     # Both child and grandchild should have been notified
     assert len(notifications) == 2
     routers_notified = [n["router"] for n in notifications]
-    assert "child_api" in routers_notified
-    assert "grandchild_api" in routers_notified
+    assert parent.child.route in routers_notified
+    assert parent.child.grandchild.route in routers_notified
 
 
 def test_child_ignores_parent_config_no_cascade():
@@ -606,34 +586,30 @@ def test_child_ignores_parent_config_no_cascade():
             pass
 
         def on_parent_config_changed(self, old_config, new_config):
-            notifications.append({"router": self._router.name, "config": new_config})
+            notifications.append({"router": self._router, "config": new_config})
             # Do NOT call configure - stop the cascade
 
     Router.register_plugin(IgnorePlugin)
 
     class GrandchildSvc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="grandchild_api")
-
-        @route("api")
+        @route()
         def grandchild_handler(self):
             return "grandchild"
 
     class ChildSvc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="child_api")
             self.grandchild = GrandchildSvc()
 
-        @route("api")
+        @route()
         def child_handler(self):
             return "child"
 
     class ParentSvc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="parent_api").plug("ignore")
+            self.route.plug("ignore")
             self.child = ChildSvc()
 
-        @route("api")
+        @route()
         def parent_handler(self):
             return "parent"
 
@@ -645,11 +621,11 @@ def test_child_ignores_parent_config_no_cascade():
     notifications.clear()
 
     # Change parent config
-    parent.api.ignore.configure(value=77)
+    parent.route.ignore.configure(value=77)
 
     # Only child should be notified (grandchild NOT because child ignores)
     assert len(notifications) == 1
-    assert notifications[0]["router"] == "child_api"
+    assert notifications[0]["router"] is parent.child.route
 
 
 # --- exceptions.py: test selector format ---
@@ -698,23 +674,20 @@ def test_auth_deny_reason_with_router_interface():
     """Test auth plugin deny_reason when passed a RouterInterface (child router)."""
 
     class ChildSvc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="child_api")
-
-        @route("api", auth_rule="admin")
+        @route(auth_rule="admin")
         def admin_only(self):
             return "admin"
 
-        @route("api")
+        @route()
         def public(self):
             return "public"
 
     class ParentSvc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="parent_api").plug("auth")
+            self.route.plug("auth")
             self.child = ChildSvc()
 
-        @route("api")
+        @route()
         def parent_handler(self):
             return "parent"
 
@@ -722,10 +695,10 @@ def test_auth_deny_reason_with_router_interface():
     parent.attach_instance(parent.child, name="child")
 
     # Get child router via parent
-    child_router = parent.api._children["child"]
+    child_router = parent.route._children["child"]
 
     # Test deny_reason with RouterInterface
-    auth_plugin = parent.api._plugins_by_name["auth"]
+    auth_plugin = parent.route._plugins_by_name["auth"]
 
     # Without tags - should return "" because public handler exists
     result = auth_plugin.deny_reason(child_router)
@@ -740,24 +713,22 @@ def test_auth_deny_reason_router_empty():
     """Test auth deny_reason with empty router returns empty string."""
 
     class ChildSvc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="child_api")
-            # No routes defined
+        pass  # No routes defined
 
     class ParentSvc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="parent_api").plug("auth")
+            self.route.plug("auth")
             self.child = ChildSvc()
 
-        @route("api")
+        @route()
         def parent_handler(self):
             return "parent"
 
     parent = ParentSvc()
     parent.attach_instance(parent.child, name="child")
 
-    child_router = parent.api._children["child"]
-    auth_plugin = parent.api._plugins_by_name["auth"]
+    child_router = parent.route._children["child"]
+    auth_plugin = parent.route._plugins_by_name["auth"]
 
     # Empty router returns "" (no entries to check)
     result = auth_plugin.deny_reason(child_router)
@@ -844,15 +815,12 @@ def test_openapi_nested_typeddict_defs_at_root():
     from genro_routes.plugins.openapi import OpenAPITranslator
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def get_person(self) -> _Person:
             return {"name": "John", "address": {"street": "123 Main", "city": "NYC"}}
 
     svc = Svc()
-    nodes = svc.api.nodes()
+    nodes = svc.route.nodes()
     result = OpenAPITranslator.translate_openapi(nodes)
 
     # $defs should be at the root level
@@ -874,15 +842,12 @@ def test_openapi_nested_typeddict_h_openapi_defs_at_root():
     from genro_routes.plugins.openapi import OpenAPITranslator
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def get_outer(self) -> _Outer:
             return {"inner": {"value": 42}}
 
     svc = Svc()
-    nodes = svc.api.nodes()
+    nodes = svc.route.nodes()
     result = OpenAPITranslator.translate_h_openapi(nodes)
 
     # $defs should be at the root level
@@ -894,65 +859,60 @@ def test_openapi_nested_typeddict_h_openapi_defs_at_root():
 
 
 def test_get_default_handler_constructor_param():
-    """Test get_default_handler constructor parameter (line 154)."""
+    """Test get_default_handler constructor parameter."""
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api", get_default_handler="index")
-
-        @route("api")
+        @route()
         def index(self):
             return "index"
 
-        @route("api")
+        @route()
         def other(self):
             return "other"
 
+    # Construct the router explicitly BEFORE accessing .route:
+    # the constructed router becomes the instance's router.
     svc = Svc()
+    router = Router(svc, get_default_handler="index")
+    assert svc.route is router
     # Default handler should be index
-    assert svc.api.default_entry == "index"
+    assert svc.route.default_entry == "index"
 
 
 def test_add_entry_with_meta_kwargs():
-    """Test add_entry with meta_* kwargs (lines 261-263, 376-378)."""
+    """Test add_entry with meta_* kwargs."""
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api", meta_author="John", meta_version="1.0")
+        @route(meta_author="John", meta_version="1.0")
         def handler(self):
             return "ok"
 
     svc = Svc()
-    node = svc.api.node("handler")
+    node = svc.route.node("handler")
     # meta_ kwargs should be grouped under "meta" key
     assert node.metadata.get("author") == "John"
     assert node.metadata.get("version") == "1.0"
 
 
 def test_nodes_with_pattern_filter():
-    """Test nodes() with pattern filter (line 721)."""
+    """Test nodes() with pattern filter."""
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def get_users(self):
             return []
 
-        @route("api")
+        @route()
         def get_orders(self):
             return []
 
-        @route("api")
+        @route()
         def create_user(self):
             return {}
 
     svc = Svc()
     # Filter by pattern
-    nodes = svc.api.nodes(pattern="^get_")
+    nodes = svc.route.nodes(pattern="^get_")
     entries = nodes.get("entries", {})
     assert "get_users" in entries
     assert "get_orders" in entries
@@ -968,23 +928,21 @@ def test_base_router_entry_invalid_reason():
     from genro_routes.core.base_router import BaseRouter
 
     class Svc(RoutingClass):
-        def __init__(self):
-            # Use BaseRouter directly, not Router
-            self.api = BaseRouter(self, name="api")
-
-        @route("api")
+        @route()
         def handler(self):
             return "ok"
 
     svc = Svc()
+    # Use BaseRouter directly, not Router (owner has no router yet)
+    api = BaseRouter(svc)
     # BaseRouter._entry_invalid_reason with None returns "not_found"
-    assert svc.api._entry_invalid_reason(None) == "not_found"
+    assert api._entry_invalid_reason(None) == "not_found"
     # BaseRouter._entry_invalid_reason with valid entry returns ""
-    entry = svc.api._entries.get("handler")
-    assert svc.api._entry_invalid_reason(entry) == ""
+    entry = api._entries.get("handler")
+    assert api._entry_invalid_reason(entry) == ""
 
 
-# --- base_router.py:251-255 - meta_* kwargs shorthand ---
+# --- base_router.py - meta_* kwargs shorthand ---
 
 
 def test_add_entry_meta_kwargs_shorthand():
@@ -998,10 +956,7 @@ def test_add_entry_meta_kwargs_shorthand():
     """
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def handler(self):
             return "ok"
 
@@ -1011,15 +966,15 @@ def test_add_entry_meta_kwargs_shorthand():
     def extra_handler():
         return "extra"
 
-    svc.api.add_entry(extra_handler, name="extra", meta_author="john", meta_version=2)
+    svc.route.add_entry(extra_handler, name="extra", meta_author="john", meta_version=2)
 
     # Verify the metadata was correctly grouped
-    entry = svc.api._entries["extra"]
+    entry = svc.route._entries["extra"]
     assert entry.metadata.get("meta", {}).get("author") == "john"
     assert entry.metadata.get("meta", {}).get("version") == 2
 
 
-# --- base_router.py:261 - non-plugin options as metadata ---
+# --- base_router.py - non-plugin options as metadata ---
 
 
 def test_add_entry_custom_options_as_metadata():
@@ -1030,8 +985,7 @@ def test_add_entry_custom_options_as_metadata():
     """
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
+        pass
 
     svc = Svc()
 
@@ -1039,9 +993,9 @@ def test_add_entry_custom_options_as_metadata():
         return "ok"
 
     # Pass custom options without underscore (so they don't go through plugin check)
-    svc.api.add_entry(handler, name="test", deprecated=True, priority=10)
+    svc.route.add_entry(handler, name="test", deprecated=True, priority=10)
 
-    entry = svc.api._entries["test"]
+    entry = svc.route._entries["test"]
     assert entry.metadata.get("deprecated") is True
     assert entry.metadata.get("priority") == 10
 
@@ -1054,8 +1008,7 @@ def test_add_entry_unknown_plugin_option_as_metadata():
     """
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
+        pass
 
     svc = Svc()
 
@@ -1063,9 +1016,9 @@ def test_add_entry_unknown_plugin_option_as_metadata():
         return "ok"
 
     # 'unknown' is not a registered plugin, so 'unknown_option' goes to metadata
-    svc.api.add_entry(handler, name="test", unknown_option="value")
+    svc.route.add_entry(handler, name="test", unknown_option="value")
 
-    entry = svc.api._entries["test"]
+    entry = svc.route._entries["test"]
     assert entry.metadata.get("unknown_option") == "value"
 
 
@@ -1080,10 +1033,7 @@ def test_router_node_custom_exceptions_in_init():
         pass
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def handler(self):
             return "ok"
 
@@ -1091,7 +1041,7 @@ def test_router_node_custom_exceptions_in_init():
 
     # Create node with custom exceptions
     node = RouterNode(
-        svc.api,
+        svc.route,
         errors={"not_found": CustomNotFound},
         entry_name="nonexistent",
     )
@@ -1106,17 +1056,14 @@ def test_router_node_doc_and_metadata_when_entry_none():
     from genro_routes.core.router_node import RouterNode
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def handler(self):
             return "ok"
 
     svc = Svc()
 
     # Create node for nonexistent entry
-    node = RouterNode(svc.api, entry_name="nonexistent")
+    node = RouterNode(svc.route, entry_name="nonexistent")
 
     # Properties should return empty values when entry is None
     assert node.doc == ""
@@ -1125,16 +1072,12 @@ def test_router_node_doc_and_metadata_when_entry_none():
 
 def test_router_node_custom_validation_error_exception():
     """Test RouterNode remaps ValidationError to custom exception."""
-    from pydantic import ValidationError as PydanticValidationError
 
     class CustomValidationError(Exception):
         pass
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def handler(self):
             # Raise a pydantic ValidationError
             from pydantic import BaseModel
@@ -1145,14 +1088,14 @@ def test_router_node_custom_validation_error_exception():
             Model(value="not_an_int")  # This raises ValidationError
 
     svc = Svc()
-    node = svc.api.node("handler")
+    node = svc.route.node("handler")
     node.set_custom_exceptions({"validation_error": CustomValidationError})
 
     with pytest.raises(CustomValidationError):
         node()
 
 
-# --- auth.py:111 - deny_reason with RouterInterface where child is accessible ---
+# --- auth.py - deny_reason with RouterInterface where child is accessible ---
 
 
 def test_auth_deny_reason_router_with_accessible_child():
@@ -1160,28 +1103,25 @@ def test_auth_deny_reason_router_with_accessible_child():
     import genro_routes.plugins.auth  # noqa: F401
 
     class Child(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api", auth_rule="public")
+        @route(auth_rule="public")
         def public_handler(self):
             return "public"
 
-        @route("api", auth_rule="admin")
+        @route(auth_rule="admin")
         def admin_handler(self):
             return "admin"
 
     class Parent(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("auth")
+            self.route.plug("auth")
             self.child = Child()
             self.attach_instance(self.child, name="child")
 
     parent = Parent()
-    auth_plugin = parent.api._plugins_by_name["auth"]
+    auth_plugin = parent.route._plugins_by_name["auth"]
 
     # Get child router
-    child_router = parent.child.api
+    child_router = parent.child.route
 
     # deny_reason on router should return "" if any child is accessible
     result = auth_plugin.deny_reason(child_router, auth_tags="public")
@@ -1206,8 +1146,7 @@ def test_routing_class_result_wrapper_method():
     """Test RoutingClass.result_wrapper() method."""
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
+        pass
 
     svc = Svc()
     result = svc.result_wrapper("content", mime_type="application/json")
@@ -1224,8 +1163,7 @@ def test_routing_class_ctx_property():
     from genro_routes.core.context import RoutingContext
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
+        pass
 
     svc = Svc()
 
@@ -1249,12 +1187,10 @@ def test_routing_class_ctx_parent_chain():
     from genro_routes.core.context import RoutingContext
 
     class Parent(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
+        pass
 
     class Child(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
+        pass
 
     parent = Parent()
     child = Child()
@@ -1273,31 +1209,28 @@ def test_plugin_on_parent_config_changed_propagates():
     """Test that parent config changes propagate to aligned children."""
 
     class Child(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def child_handler(self):
             return "child"
 
     class Parent(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("logging")
+            self.route.plug("logging")
             self.child = Child()
             self.attach_instance(self.child, name="child")
 
-        @route("api")
+        @route()
         def parent_handler(self):
             return "parent"
 
     parent = Parent()
 
     # Get child's logging plugin
-    child_plugin = parent.child.api._plugins_by_name.get("logging")
+    child_plugin = parent.child.route._plugins_by_name.get("logging")
     assert child_plugin is not None
 
     # Initially child should have same config as parent (aligned)
-    parent_plugin = parent.api._plugins_by_name.get("logging")
+    parent_plugin = parent.route._plugins_by_name.get("logging")
     assert child_plugin.configuration() == parent_plugin.configuration()
 
     # Change parent config
@@ -1312,38 +1245,13 @@ def test_plugin_on_parent_config_changed_propagates():
 # =============================================================================
 
 
-# --- base_router.py:157->161 - _register_router hook not callable ---
-
-
-def test_router_owner_without_callable_register_hook():
-    """Test router creation when owner has non-callable _register_router."""
-
-    class BadOwner(RoutingClass):
-        def __init__(self):
-            # Override _register_router with non-callable
-            object.__setattr__(self, "_register_router", "not_callable")
-            # Router should still work - just skips the hook
-            self.api = Router(self, name="api")
-
-        @route("api")
-        def handler(self):
-            return "ok"
-
-    # Should not raise - hook is skipped when not callable
-    svc = BadOwner()
-    assert svc.api.node("handler")() == "ok"
-
-
-# --- base_router.py:290->288 - empty chunk in comma-separated add_entry ---
+# --- base_router.py - empty chunk in comma-separated add_entry ---
 
 
 def test_add_entry_comma_separated_with_empty_chunks():
     """Test add_entry with comma-separated targets including empty chunks."""
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
         def foo(self):
             return "foo"
 
@@ -1352,13 +1260,13 @@ def test_add_entry_comma_separated_with_empty_chunks():
 
     svc = Svc()
     # Include empty chunks via extra commas
-    svc.api.add_entry("foo, , bar, ")
+    svc.route.add_entry("foo, , bar, ")
 
-    assert "foo" in svc.api._entries
-    assert "bar" in svc.api._entries
+    assert "foo" in svc.route._entries
+    assert "bar" in svc.route._entries
 
 
-# --- base_router.py:393 - plugin_options not None in _register_marked ---
+# --- base_router.py - plugin_options not None in _register_marked ---
 
 
 def test_register_marked_with_plugin_options():
@@ -1366,121 +1274,75 @@ def test_register_marked_with_plugin_options():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("logging")
+            self.route.plug("logging")
 
-        @route("api", logging_before=False)
+        @route(logging_before=False)
         def handler(self):
             return "ok"
 
     svc = Svc()
     # Plugin options from @route should be in entry metadata
-    entry = svc.api._entries["handler"]
+    entry = svc.route._entries["handler"]
     assert "plugin_config" in entry.metadata
     assert entry.metadata["plugin_config"].get("logging", {}).get("before") is False
 
 
-# --- base_router.py:507-508 - _require_bound when already bound ---
+# --- base_router.py - _require_bound when already bound ---
 
 
 def test_require_bound_when_already_bound():
     """Test _require_bound does nothing when already bound."""
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def handler(self):
             return "ok"
 
     svc = Svc()
     # Force binding
-    _ = svc.api._entries
+    _ = svc.route._entries
 
     # Call _require_bound again - should be no-op
-    svc.api._require_bound("test_op")
-    assert svc.api._bound is True
+    svc.route._require_bound("test_op")
+    assert svc.route._bound is True
 
 
-# --- base_router.py:588-589 - attach_instance router_api mapping ---
+# --- RoutingClass.attach_instance with explicit alias ---
 
 
-def test_attach_instance_router_api_mapping():
-    """Test attach_instance with explicit router_api mapping (child_router:alias)."""
+def test_attach_instance_with_alias():
+    """Test attach_instance links the child router under the given alias."""
 
     class Child(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="child_api")
-            self.admin = Router(self, name="admin")
-
-        @route("child_api")
+        @route()
         def api_handler(self):
             return "api"
 
-        @route("admin")
-        def admin_handler(self):
-            return "admin"
-
     class Parent(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api")
             self.child = Child()
 
     parent = Parent()
-    # Explicit router_api mapping: child_router:alias
-    parent.attach_instance(parent.child, router_api="child_api:child_api")
+    parent.attach_instance(parent.child, name="child_api")
 
-    # Should be attached under original name
-    assert "child_api" in parent.api._children
-
-
-# --- base_router.py:603 - attach_instance unknown router in router_api ---
+    # Should be attached under the given alias
+    assert "child_api" in parent.route._children
+    assert parent.route._children["child_api"] is parent.child.route
 
 
-def test_attach_instance_router_api_unknown_router():
-    """Test attach_instance raises ValueError for unknown router in router_api."""
-
-    class Child(RoutingClass):
-        def __init__(self):
-            # Multiple routers so default_router is None and mapping is used
-            self.api = Router(self, name="child_api")
-            self.admin = Router(self, name="admin")
-
-        @route("child_api")
-        def handler(self):
-            return "ok"
-
-        @route("admin")
-        def admin_handler(self):
-            return "admin"
-
-    class Parent(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-            self.child = Child()
-
-    parent = Parent()
-    with pytest.raises(ValueError, match="No router named"):
-        parent.attach_instance(parent.child, router_api="nonexistent:alias")
-
-
-# --- base_router.py:611->613 - attach_instance _routing_parent already set correctly ---
+# --- attach_instance when _routing_parent already set correctly ---
 
 
 def test_attach_instance_routing_parent_already_correct():
     """Test attach_instance when _routing_parent is already set to correct parent."""
 
     class Child(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="child_api")
-
-        @route("child_api")
+        @route()
         def handler(self):
             return "ok"
 
     class Parent(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api")
             self.child = Child()
 
     parent = Parent()
@@ -1492,92 +1354,82 @@ def test_attach_instance_routing_parent_already_correct():
     assert parent.child._routing_parent is parent
 
 
-# --- base_router.py:631->638 - detach_instance with plugin_children cleanup ---
+# --- base_router.py - detach_instance with plugin_children cleanup ---
 
 
 def test_detach_instance_cleans_plugin_children():
     """Test detach_instance cleans up _plugin_children references."""
 
     class Child(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="child_api")
-
-        @route("child_api")
+        @route()
         def handler(self):
             return "ok"
 
     class Parent(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("logging")
+            self.route.plug("logging")
             self.child = Child()
             self.attach_instance(self.child, name="child")
 
-        @route("api")
+        @route()
         def parent_handler(self):
             return "parent"
 
     parent = Parent()
 
     # Verify plugin_children has the child
-    assert "logging" in parent.api._plugin_children
-    assert any(r.instance is parent.child for r in parent.api._plugin_children["logging"])
+    assert "logging" in parent.route._plugin_children
+    assert any(r.instance is parent.child for r in parent.route._plugin_children["logging"])
 
     # Detach
-    parent.api.detach_instance(parent.child)
+    parent.route.detach_instance(parent.child)
 
     # Plugin children should be cleaned up
-    assert not any(r.instance is parent.child for r in parent.api._plugin_children["logging"])
+    assert not any(r.instance is parent.child for r in parent.route._plugin_children["logging"])
 
 
-# --- base_router.py:752 - nodes with basepath and unknown mode ---
+# --- base_router.py - nodes with basepath and unknown mode ---
 
 
 def test_nodes_basepath_with_unknown_mode_raises():
     """Test nodes() with basepath and unknown mode raises ValueError."""
 
     class Child(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="child")
-
-        @route("child")
+        @route()
         def handler(self):
             return "ok"
 
     class Parent(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api")
             self.child = Child()
             self.attach_instance(self.child, name="child")
 
     parent = Parent()
     with pytest.raises(ValueError, match="Unknown mode"):
-        parent.api.nodes(basepath="child", mode="invalid_mode")
+        parent.route.nodes(basepath="child", mode="invalid_mode")
 
 
-# --- base_router.py:882-884 - node() with openapi=True but entry is None ---
+# --- base_router.py - node() with openapi=True but entry is None ---
 
 
 def test_node_openapi_with_not_found_entry():
     """Test node() with openapi=True when entry doesn't exist."""
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def handler(self):
             return "ok"
 
     svc = Svc()
     # Request non-existent entry with openapi=True
-    node = svc.api.node("nonexistent", openapi=True)
+    node = svc.route.node("nonexistent", openapi=True)
 
     # openapi should not be populated when entry is None
     assert node.error == "not_found"
     assert node.openapi is None
 
 
-# --- router.py:258 - _get_plugin_bucket initializing _all_ ---
+# --- router.py - _get_plugin_bucket initializing _all_ ---
 
 
 def test_get_plugin_bucket_initializes_all():
@@ -1585,26 +1437,26 @@ def test_get_plugin_bucket_initializes_all():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("logging")
+            self.route.plug("logging")
 
-        @route("api")
+        @route()
         def handler(self):
             return "ok"
 
     svc = Svc()
 
     # Manually remove _all_ to test re-initialization
-    bucket = svc.api._plugin_info["logging"]
+    bucket = svc.route._plugin_info["logging"]
     del bucket["_all_"]
 
     # Now call _get_plugin_bucket
-    result = svc.api._get_plugin_bucket("logging")
+    result = svc.route._get_plugin_bucket("logging")
 
     # Should have recreated _all_
     assert "_all_" in result
 
 
-# --- router.py:315-318 - is_plugin_enabled via config (not locals) ---
+# --- router.py - is_plugin_enabled via config (not locals) ---
 
 
 def test_is_plugin_enabled_via_config_only():
@@ -1612,19 +1464,19 @@ def test_is_plugin_enabled_via_config_only():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("logging")
+            self.route.plug("logging")
 
-        @route("api")
+        @route()
         def handler(self):
             return "ok"
 
     svc = Svc()
 
     # Set enabled=False via config (not locals)
-    svc.api.logging.configure(enabled=False)
+    svc.route.logging.configure(enabled=False)
 
     # Should read from config
-    assert svc.api.is_plugin_enabled("handler", "logging") is False
+    assert svc.route.is_plugin_enabled("handler", "logging") is False
 
 
 def test_is_plugin_enabled_global_config():
@@ -1632,19 +1484,19 @@ def test_is_plugin_enabled_global_config():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("logging")
+            self.route.plug("logging")
 
-        @route("api")
+        @route()
         def handler(self):
             return "ok"
 
     svc = Svc()
 
     # Set enabled=False globally via config
-    svc.api.logging.configure(enabled=False)
+    svc.route.logging.configure(enabled=False)
 
     # Should read from _all_ config
-    assert svc.api.is_plugin_enabled("handler", "logging") is False
+    assert svc.route.is_plugin_enabled("handler", "logging") is False
 
 
 def test_is_plugin_enabled_global_locals():
@@ -1652,48 +1504,45 @@ def test_is_plugin_enabled_global_locals():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("logging")
+            self.route.plug("logging")
 
-        @route("api")
+        @route()
         def handler(self):
             return "ok"
 
     svc = Svc()
 
     # Set enabled globally via set_plugin_enabled (_all_)
-    svc.api.set_plugin_enabled("_all_", "logging", False)
+    svc.route.set_plugin_enabled("_all_", "logging", False)
 
     # Should read from _all_ locals
-    assert svc.api.is_plugin_enabled("handler", "logging") is False
+    assert svc.route.is_plugin_enabled("handler", "logging") is False
 
 
-# --- router.py:429->431 - _apply_plugin_to_entries skip already-present plugin ---
+# --- router.py - _apply_plugin_to_entries skip already-present plugin ---
 
 
 def test_apply_plugin_to_entries_skips_duplicate():
     """Test _apply_plugin_to_entries doesn't double-add plugin name."""
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def handler(self):
             return "ok"
 
     svc = Svc()
     # Force binding
-    _ = svc.api._entries
+    _ = svc.route._entries
 
     # Now plug - should apply to existing entries
-    svc.api.plug("logging")
+    svc.route.plug("logging")
 
-    entry = svc.api._entries["handler"]
+    entry = svc.route._entries["handler"]
     # Plugin name should appear only once
     assert entry.plugins.count("logging") == 1
 
 
-# --- router.py:458-462, 469 - _on_attached_to_parent child already has plugin ---
+# --- router.py - _on_attached_to_parent child already has plugin ---
 
 
 def test_on_attached_to_parent_child_has_same_plugin():
@@ -1702,25 +1551,25 @@ def test_on_attached_to_parent_child_has_same_plugin():
     class Child(RoutingClass):
         def __init__(self):
             # Child creates its own logging plugin
-            self.api = Router(self, name="child").plug("logging")
+            self.route.plug("logging")
 
-        @route("child")
+        @route()
         def handler(self):
             return "ok"
 
     class Parent(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("logging")
+            self.route.plug("logging")
             self.child = Child()
 
     parent = Parent()
     parent.attach_instance(parent.child, name="child")
 
     # Child should still have exactly one logging plugin
-    assert len([p for p in parent.child.api._plugins if p.name == "logging"]) == 1
+    assert len([p for p in parent.child.route._plugins if p.name == "logging"]) == 1
 
 
-# --- router.py:533->536, 545->529 - _describe_entry_extra with config/metadata ---
+# --- router.py - _describe_entry_extra with config/metadata ---
 
 
 def test_describe_entry_extra_with_plugin_data():
@@ -1741,14 +1590,14 @@ def test_describe_entry_extra_with_plugin_data():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("testplugin2")
+            self.route.plug("testplugin2")
 
-        @route("api")
+        @route()
         def handler(self):
             return "ok"
 
     svc = Svc()
-    tree = svc.api.nodes()
+    tree = svc.route.nodes()
 
     entry_info = tree["entries"]["handler"]
     # Plugin with config should appear (has enabled: True by default)
@@ -1761,7 +1610,7 @@ def test_describe_entry_extra_with_plugin_data():
     assert "metadata" not in plugin_info or plugin_info.get("metadata") == {}
 
 
-# --- router_node.py:70->73 - ValidationError is None ---
+# --- router_node.py - ValidationError is None ---
 
 
 def test_router_node_default_exceptions_without_pydantic():
@@ -1773,117 +1622,107 @@ def test_router_node_default_exceptions_without_pydantic():
     assert "not_authorized" in RouterNode.DEFAULT_EXCEPTIONS
 
 
-# --- router_node.py:225->230 - __call__ with non-pydantic ValidationError ---
+# --- router_node.py - __call__ with non-pydantic ValidationError ---
 
 
 def test_router_node_call_non_pydantic_exception_reraises():
     """Test RouterNode.__call__ re-raises non-ValidationError exceptions."""
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def handler(self):
             raise RuntimeError("test error")
 
     svc = Svc()
-    node = svc.api.node("handler")
+    node = svc.route.node("handler")
 
     with pytest.raises(RuntimeError, match="test error"):
         node()
 
 
-# --- base_router.py:393 - plugin_options passed to _register_marked ---
+# --- base_router.py - plugin_options passed to _register_marked ---
 
 
 def test_add_entry_star_with_plugin_options():
     """Test add_entry('*') with plugin_* kwargs merged via _register_marked.
 
-    This covers line 393: merged_plugin_opts.update(plugin_options)
     The plugin_options dict gets populated from plugin-prefixed kwargs
-    passed to add_entry (e.g., logging_before=False).
+    passed to add_entry (e.g., logging_before=False) and merged in
+    _register_marked.
     """
     from genro_routes.core.base_router import BaseRouter
 
     # Create a fresh class for this test
     class SvcForPluginOpts(RoutingClass):
-        def __init__(self):
-            self.api = BaseRouter(self, name="api")
-
         def my_handler(self):
             return "ok"
 
     # Mark the method BEFORE instantiation
-    SvcForPluginOpts.my_handler._route_decorator_kw = [{"router_name": "api"}]
+    SvcForPluginOpts.my_handler._route_decorator_kw = [{}]
 
     svc = SvcForPluginOpts()
+    api = BaseRouter(svc)
 
     # Trigger initial binding (registers handler without plugin_options)
-    _ = svc.api._entries
-    assert "my_handler" in svc.api._BaseRouter__entries_raw
+    _ = api._entries
+    assert "my_handler" in api._BaseRouter__entries_raw
 
     # Now call add_entry("*") with plugin kwargs AND replace=True
     # logging_before=False gets split into plugin_options={"logging": {"before": False}}
-    # by add_entry, then merged in _register_marked (line 393)
-    svc.api.add_entry("*", logging_before=False, replace=True)
+    # by add_entry, then merged in _register_marked
+    api.add_entry("*", logging_before=False, replace=True)
 
-    entry = svc.api._BaseRouter__entries_raw["my_handler"]
+    entry = api._BaseRouter__entries_raw["my_handler"]
     # Plugin options should be in entry metadata under plugin_config
     config = entry.metadata.get("plugin_config", {})
     assert config.get("logging", {}).get("before") is False
 
 
-# --- base_router.py:494 - _bind when already bound ---
+# --- base_router.py - _bind when already bound ---
 
 
 def test_bind_when_already_bound():
     """Test _bind() returns early when already bound.
 
-    This covers line 494: return statement when self._bound is True.
+    Covers the early-return statement when self._bound is True.
     """
     from genro_routes.core.base_router import BaseRouter
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = BaseRouter(self, name="api")
-
-        @route("api")
+        @route()
         def handler(self):
             return "ok"
 
     svc = Svc()
+    api = BaseRouter(svc)
 
     # Force binding via _entries access
-    _ = svc.api._entries
-    assert svc.api._bound is True
+    _ = api._entries
+    assert api._bound is True
 
     # Call _bind directly - should return early (no error, no-op)
-    svc.api._bind()
-    assert svc.api._bound is True
+    api._bind()
+    assert api._bound is True
 
 
-# --- base_router.py:882-884 - node() with openapi=True and existing entry ---
+# --- base_router.py - node() with openapi=True and existing entry ---
 
 
 def test_node_openapi_with_existing_entry():
     """Test node() with openapi=True when entry exists.
 
-    This covers lines 882-884: openapi population when entry is not None.
+    Covers openapi population when entry is not None.
     """
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def handler(self, value: int) -> str:
             """A documented handler."""
             return str(value)
 
     svc = Svc()
     # Request existing entry with openapi=True
-    node = svc.api.node("handler", openapi=True)
+    node = svc.route.node("handler", openapi=True)
 
     # openapi should be populated when entry exists
     assert node.error is None
@@ -1892,20 +1731,20 @@ def test_node_openapi_with_existing_entry():
     assert "operationId" in str(node.openapi) or node.openapi.get("get") or node.openapi.get("post")
 
 
-# --- router.py:318 - is_plugin_enabled returns True when no enabled config ---
+# --- router.py - is_plugin_enabled returns True when no enabled config ---
 
 
 def test_is_plugin_enabled_returns_true_default():
     """Test is_plugin_enabled returns True when no enabled config is set.
 
-    This covers line 318: return True (fallback).
+    Covers the return True fallback.
     """
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("logging")
+            self.route.plug("logging")
 
-        @route("api")
+        @route()
         def handler(self):
             return "ok"
 
@@ -1913,7 +1752,7 @@ def test_is_plugin_enabled_returns_true_default():
 
     # Don't set any enabled config - should return True by default
     # Note: we need to clear any implicit config
-    bucket = svc.api._plugin_info.get("logging", {})
+    bucket = svc.route._plugin_info.get("logging", {})
     handler_data = bucket.get("handler", {})
     # Remove enabled from both locals and config if present
     handler_data.pop("locals", None)
@@ -1927,4 +1766,4 @@ def test_is_plugin_enabled_returns_true_default():
         all_data["config"].pop("enabled", None)
 
     # Now is_plugin_enabled should return True (default)
-    assert svc.api.is_plugin_enabled("handler", "logging") is True
+    assert svc.route.is_plugin_enabled("handler", "logging") is True

--- a/tests/test_env_plugin.py
+++ b/tests/test_env_plugin.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import pytest
 
-from genro_routes import NotAvailable, Router, RoutingClass, route
+from genro_routes import NotAvailable, RoutingClass, route
 from genro_routes.plugins.env import CapabilitiesSet, capability
 
 
@@ -130,14 +130,14 @@ class TestEnvPluginBasic:
 
         class Service(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("env")
+                self.route.plug("env")
 
-            @route("api")
+            @route()
             def public(self):
                 return "public"
 
         svc = Service()
-        entries = svc.api.nodes().get("entries", {})
+        entries = svc.route.nodes().get("entries", {})
         assert "public" in entries
 
     def test_entry_with_rule_requires_capabilities(self):
@@ -145,20 +145,20 @@ class TestEnvPluginBasic:
 
         class Service(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("env")
+                self.route.plug("env")
 
-            @route("api", env_requires="redis")
+            @route(env_requires="redis")
             def cached(self):
                 return "cached"
 
         svc = Service()
 
         # Without capabilities - entry not accessible
-        entries = svc.api.nodes().get("entries", {})
+        entries = svc.route.nodes().get("entries", {})
         assert "cached" not in entries
 
         # With matching capability - entry accessible
-        entries = svc.api.nodes(env_capabilities="redis").get("entries", {})
+        entries = svc.route.nodes(env_capabilities="redis").get("entries", {})
         assert "cached" in entries
 
     def test_or_rule_accepts_any_capability(self):
@@ -166,24 +166,24 @@ class TestEnvPluginBasic:
 
         class Service(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("env")
+                self.route.plug("env")
 
-            @route("api", env_requires="stripe|paypal")
+            @route(env_requires="stripe|paypal")
             def payment(self):
                 return "payment"
 
         svc = Service()
 
         # With stripe - accessible
-        entries = svc.api.nodes(env_capabilities="stripe").get("entries", {})
+        entries = svc.route.nodes(env_capabilities="stripe").get("entries", {})
         assert "payment" in entries
 
         # With paypal - accessible
-        entries = svc.api.nodes(env_capabilities="paypal").get("entries", {})
+        entries = svc.route.nodes(env_capabilities="paypal").get("entries", {})
         assert "payment" in entries
 
         # Without either - not accessible
-        entries = svc.api.nodes(env_capabilities="bitcoin").get("entries", {})
+        entries = svc.route.nodes(env_capabilities="bitcoin").get("entries", {})
         assert "payment" not in entries
 
     def test_and_rule_requires_all_capabilities(self):
@@ -191,20 +191,20 @@ class TestEnvPluginBasic:
 
         class Service(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("env")
+                self.route.plug("env")
 
-            @route("api", env_requires="pyjwt&redis")
+            @route(env_requires="pyjwt&redis")
             def jwt_cached(self):
                 return "jwt_cached"
 
         svc = Service()
 
         # With only pyjwt - not accessible
-        entries = svc.api.nodes(env_capabilities="pyjwt").get("entries", {})
+        entries = svc.route.nodes(env_capabilities="pyjwt").get("entries", {})
         assert "jwt_cached" not in entries
 
         # With both - accessible
-        entries = svc.api.nodes(env_capabilities="pyjwt,redis").get("entries", {})
+        entries = svc.route.nodes(env_capabilities="pyjwt,redis").get("entries", {})
         assert "jwt_cached" in entries
 
 
@@ -216,21 +216,21 @@ class TestEnvPluginInstanceCapabilities:
 
         class Service(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("env")
+                self.route.plug("env")
                 self.capabilities = RedisPyjwtCapabilities()
 
-            @route("api", env_requires="redis")
+            @route(env_requires="redis")
             def cached(self):
                 return "cached"
 
-            @route("api", env_requires="postgres")
+            @route(env_requires="postgres")
             def db_only(self):
                 return "db"
 
         svc = Service()
 
         # Instance has redis - cached accessible without passing capabilities
-        entries = svc.api.nodes().get("entries", {})
+        entries = svc.route.nodes().get("entries", {})
         assert "cached" in entries
         assert "db_only" not in entries  # needs postgres, instance doesn't have it
 
@@ -253,28 +253,28 @@ class TestEnvPluginInstanceCapabilities:
 
         class Service(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("env")
+                self.route.plug("env")
                 self._has_stripe = True
                 self._has_paypal = False
                 self.capabilities = DynamicPaymentCapabilities(self)
 
-            @route("api", env_requires="stripe")
+            @route(env_requires="stripe")
             def stripe_payment(self):
                 return "stripe"
 
-            @route("api", env_requires="paypal")
+            @route(env_requires="paypal")
             def paypal_payment(self):
                 return "paypal"
 
         svc = Service()
 
-        entries = svc.api.nodes().get("entries", {})
+        entries = svc.route.nodes().get("entries", {})
         assert "stripe_payment" in entries
         assert "paypal_payment" not in entries
 
         # Change runtime state
         svc._has_paypal = True
-        entries = svc.api.nodes().get("entries", {})
+        entries = svc.route.nodes().get("entries", {})
         assert "stripe_payment" in entries
         assert "paypal_payment" in entries
 
@@ -283,21 +283,21 @@ class TestEnvPluginInstanceCapabilities:
 
         class Service(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("env")
+                self.route.plug("env")
                 self.capabilities = RedisCapabilities()
 
-            @route("api", env_requires="redis&pyjwt")
+            @route(env_requires="redis&pyjwt")
             def jwt_cached(self):
                 return "jwt_cached"
 
         svc = Service()
 
         # Instance has redis, but entry needs both redis AND pyjwt
-        entries = svc.api.nodes().get("entries", {})
+        entries = svc.route.nodes().get("entries", {})
         assert "jwt_cached" not in entries
 
         # Pass pyjwt via request - now has both
-        entries = svc.api.nodes(env_capabilities="pyjwt").get("entries", {})
+        entries = svc.route.nodes(env_capabilities="pyjwt").get("entries", {})
         assert "jwt_cached" in entries
 
 
@@ -309,16 +309,15 @@ class TestEnvPluginHierarchyAccumulation:
 
         class ChildService(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api")
                 self.capabilities = PyjwtCapabilities()
 
-            @route("api", env_requires="redis&pyjwt")
+            @route(env_requires="redis&pyjwt")
             def jwt_cached(self):
                 return "jwt_cached"
 
         class ParentService(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("env")
+                self.route.plug("env")
                 self.capabilities = RedisCapabilities()
                 self.child = ChildService()
                 self.attach_instance(self.child, name="child")
@@ -328,7 +327,7 @@ class TestEnvPluginHierarchyAccumulation:
         # Child entry needs redis&pyjwt
         # Parent has redis, child has pyjwt
         # Combined: {redis, pyjwt} - entry is accessible
-        node = parent.api.node("child/jwt_cached")
+        node = parent.route.node("child/jwt_cached")
         assert node.error is None
 
     def test_deep_hierarchy_accumulation(self):
@@ -336,23 +335,21 @@ class TestEnvPluginHierarchyAccumulation:
 
         class Level3(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api")
                 self.capabilities = Level3Capabilities()
 
-            @route("api", env_requires="level1&level2&level3")
+            @route(env_requires="level1&level2&level3")
             def deep_action(self):
                 return "deep"
 
         class Level2(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api")
                 self.capabilities = Level2Capabilities()
                 self.level3 = Level3()
                 self.attach_instance(self.level3, name="level3")
 
         class Level1(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("env")
+                self.route.plug("env")
                 self.capabilities = Level1Capabilities()
                 self.level2 = Level2()
                 self.attach_instance(self.level2, name="level2")
@@ -361,7 +358,7 @@ class TestEnvPluginHierarchyAccumulation:
 
         # Entry needs level1&level2&level3
         # Accumulated from hierarchy: {level1, level2, level3}
-        node = root.api.node("level2/level3/deep_action")
+        node = root.route.node("level2/level3/deep_action")
         assert node.error is None
 
     def test_request_capabilities_add_to_hierarchy(self):
@@ -369,16 +366,15 @@ class TestEnvPluginHierarchyAccumulation:
 
         class Child(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api")
                 self.capabilities = ChildCapCapabilities()
 
-            @route("api", env_requires="parent_cap&child_cap&request_cap")
+            @route(env_requires="parent_cap&child_cap&request_cap")
             def action(self):
                 return "action"
 
         class Parent(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("env")
+                self.route.plug("env")
                 self.capabilities = ParentCapCapabilities()
                 self.child = Child()
                 self.attach_instance(self.child, name="child")
@@ -386,11 +382,11 @@ class TestEnvPluginHierarchyAccumulation:
         root = Parent()
 
         # Without request_cap - not accessible
-        node = root.api.node("child/action")
+        node = root.route.node("child/action")
         assert node.error == "not_available"
 
         # With request_cap - accessible
-        node = root.api.node("child/action", env_capabilities="request_cap")
+        node = root.route.node("child/action", env_capabilities="request_cap")
         assert node.error is None
 
 
@@ -402,14 +398,14 @@ class TestEnvPluginNodeBehavior:
 
         class Service(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("env")
+                self.route.plug("env")
 
-            @route("api", env_requires="required_cap")
+            @route(env_requires="required_cap")
             def protected(self):
                 return "protected"
 
         svc = Service()
-        node = svc.api.node("protected")
+        node = svc.route.node("protected")
         assert node.error == "not_available"
 
     def test_node_call_raises_not_available(self):
@@ -417,14 +413,14 @@ class TestEnvPluginNodeBehavior:
 
         class Service(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("env")
+                self.route.plug("env")
 
-            @route("api", env_requires="required_cap")
+            @route(env_requires="required_cap")
             def protected(self):
                 return "protected"
 
         svc = Service()
-        node = svc.api.node("protected")
+        node = svc.route.node("protected")
 
         with pytest.raises(NotAvailable):
             node()
@@ -434,15 +430,15 @@ class TestEnvPluginNodeBehavior:
 
         class Service(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("env")
+                self.route.plug("env")
                 self.capabilities = RequiredCapCapabilities()
 
-            @route("api", env_requires="required_cap")
+            @route(env_requires="required_cap")
             def protected(self):
                 return "protected"
 
         svc = Service()
-        node = svc.api.node("protected")
+        node = svc.route.node("protected")
         assert node() == "protected"
 
 
@@ -454,27 +450,27 @@ class TestEnvPluginRuleValidation:
 
         class Service(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("env")
+                self.route.plug("env")
 
         svc = Service()
 
         with pytest.raises(ValueError, match="Comma not allowed"):
-            svc.routing.configure("api:env/_all_", requires="stripe,paypal")
+            svc.routing.configure("env/_all_", requires="stripe,paypal")
 
     def test_pipe_in_env_requires_works(self):
         """Pipe (|) in env_requires works for OR."""
 
         class Service(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("env")
+                self.route.plug("env")
 
-            @route("api", env_requires="stripe|paypal")
+            @route(env_requires="stripe|paypal")
             def payment(self):
                 return "payment"
 
         svc = Service()
         svc.capabilities = StripeCapabilities()
-        entries = svc.api.nodes().get("entries", {})
+        entries = svc.route.nodes().get("entries", {})
         assert "payment" in entries
 
 
@@ -486,20 +482,19 @@ class TestEnvPluginSubRouterFiltering:
 
         class Child(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api")
                 self.capabilities = Cap1Capabilities()
 
-            @route("api", env_requires="cap1")
+            @route(env_requires="cap1")
             def action1(self):
                 return "action1"
 
-            @route("api", env_requires="cap2")
+            @route(env_requires="cap2")
             def action2(self):
                 return "action2"
 
         class Parent(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("env")
+                self.route.plug("env")
                 self.child = Child()
                 self.attach_instance(self.child, name="child")
 
@@ -507,23 +502,20 @@ class TestEnvPluginSubRouterFiltering:
 
         # Child router has cap1, so action1 is accessible
         # When checking "child" sub-router, should return True (at least one accessible)
-        routers = parent.api.nodes().get("routers", {})
+        routers = parent.route.nodes().get("routers", {})
         assert "child" in routers
 
     def test_subrouter_hidden_when_all_entries_blocked(self):
         """Sub-router is hidden when all entries are blocked."""
 
         class Child(RoutingClass):
-            def __init__(self):
-                self.api = Router(self, name="api")
-
-            @route("api", env_requires="missing_cap")
+            @route(env_requires="missing_cap")
             def action1(self):
                 return "action1"
 
         class Parent(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("env")
+                self.route.plug("env")
                 self.child = Child()
                 self.attach_instance(self.child, name="child")
 
@@ -531,7 +523,7 @@ class TestEnvPluginSubRouterFiltering:
 
         # Child router has no capabilities, entry requires missing_cap
         # Router should be filtered out
-        routers = parent.api.nodes().get("routers", {})
+        routers = parent.route.nodes().get("routers", {})
         assert "child" not in routers
 
 
@@ -542,8 +534,7 @@ class TestCapabilitiesSetter:
         """Setting capabilities with CapabilitiesSet works."""
 
         class Service(RoutingClass):
-            def __init__(self):
-                self.api = Router(self, name="api")
+            pass
 
         svc = Service()
         svc.capabilities = RedisCapabilities()
@@ -553,8 +544,7 @@ class TestCapabilitiesSetter:
         """Setting capabilities to invalid type raises TypeError."""
 
         class Service(RoutingClass):
-            def __init__(self):
-                self.api = Router(self, name="api")
+            pass
 
         svc = Service()
 
@@ -565,8 +555,7 @@ class TestCapabilitiesSetter:
         """Setting capabilities to set raises TypeError."""
 
         class Service(RoutingClass):
-            def __init__(self):
-                self.api = Router(self, name="api")
+            pass
 
         svc = Service()
 
@@ -577,8 +566,7 @@ class TestCapabilitiesSetter:
         """Setting capabilities to string raises TypeError."""
 
         class Service(RoutingClass):
-            def __init__(self):
-                self.api = Router(self, name="api")
+            pass
 
         svc = Service()
 
@@ -589,8 +577,7 @@ class TestCapabilitiesSetter:
         """Setting capabilities to list raises TypeError."""
 
         class Service(RoutingClass):
-            def __init__(self):
-                self.api = Router(self, name="api")
+            pass
 
         svc = Service()
 
@@ -601,8 +588,7 @@ class TestCapabilitiesSetter:
         """Setting capabilities to None raises TypeError."""
 
         class Service(RoutingClass):
-            def __init__(self):
-                self.api = Router(self, name="api")
+            pass
 
         svc = Service()
 
@@ -613,8 +599,7 @@ class TestCapabilitiesSetter:
         """Setting capabilities to int raises TypeError."""
 
         class Service(RoutingClass):
-            def __init__(self):
-                self.api = Router(self, name="api")
+            pass
 
         svc = Service()
 
@@ -630,18 +615,18 @@ class TestNodesForbiddenParameter:
 
         class Service(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("env")
+                self.route.plug("env")
 
-            @route("api")
+            @route()
             def public(self):
                 return "public"
 
-            @route("api", env_requires="redis")
+            @route(env_requires="redis")
             def needs_redis(self):
                 return "needs_redis"
 
         svc = Service()
-        entries = svc.api.nodes().get("entries", {})
+        entries = svc.route.nodes().get("entries", {})
         assert "public" in entries
         assert "needs_redis" not in entries
 
@@ -650,18 +635,18 @@ class TestNodesForbiddenParameter:
 
         class Service(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("env")
+                self.route.plug("env")
 
-            @route("api")
+            @route()
             def public(self):
                 return "public"
 
-            @route("api", env_requires="redis")
+            @route(env_requires="redis")
             def needs_redis(self):
                 return "needs_redis"
 
         svc = Service()
-        entries = svc.api.nodes(forbidden=True).get("entries", {})
+        entries = svc.route.nodes(forbidden=True).get("entries", {})
 
         # Public entry has no forbidden field
         assert "public" in entries
@@ -675,27 +660,24 @@ class TestNodesForbiddenParameter:
         """forbidden=True propagates to child routers."""
 
         class Child(RoutingClass):
-            def __init__(self):
-                self.api = Router(self, name="api")
-
-            @route("api", env_requires="child_cap")
+            @route(env_requires="child_cap")
             def child_action(self):
                 return "child_action"
 
         class Parent(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("env")
+                self.route.plug("env")
                 self.child = Child()
                 self.attach_instance(self.child, name="child")
 
         parent = Parent()
 
         # Without forbidden, child router is filtered out (no accessible entries)
-        routers = parent.api.nodes().get("routers", {})
+        routers = parent.route.nodes().get("routers", {})
         assert "child" not in routers
 
         # With forbidden=True, child router is visible with blocked entry
-        result = parent.api.nodes(forbidden=True)
+        result = parent.route.nodes(forbidden=True)
         routers = result.get("routers", {})
         assert "child" in routers
 
@@ -708,20 +690,20 @@ class TestNodesForbiddenParameter:
 
         class Service(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("auth")
+                self.route.plug("auth")
 
-            @route("api")
+            @route()
             def public(self):
                 return "public"
 
-            @route("api", auth_rule="admin")
+            @route(auth_rule="admin")
             def admin_only(self):
                 return "admin_only"
 
         svc = Service()
 
         # Without auth_tags, admin_only is blocked (not_authenticated = no tags provided)
-        entries = svc.api.nodes(forbidden=True).get("entries", {})
+        entries = svc.route.nodes(forbidden=True).get("entries", {})
         assert "public" in entries
         assert "forbidden" not in entries["public"]
         assert "admin_only" in entries
@@ -732,15 +714,15 @@ class TestNodesForbiddenParameter:
 
         class Service(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("env")
+                self.route.plug("env")
 
-            @route("api", env_requires="redis")
+            @route(env_requires="redis")
             def needs_redis(self):
                 """This action requires redis."""
                 return "needs_redis"
 
         svc = Service()
-        entries = svc.api.nodes(forbidden=True).get("entries", {})
+        entries = svc.route.nodes(forbidden=True).get("entries", {})
 
         entry = entries["needs_redis"]
         assert entry["forbidden"] == "not_available"

--- a/tests/test_env_plugin.py
+++ b/tests/test_env_plugin.py
@@ -10,7 +10,6 @@ import pytest
 from genro_routes import NotAvailable, RoutingClass, route
 from genro_routes.plugins.env import CapabilitiesSet, capability
 
-
 # ---------------------------------------------------------------------------
 # CapabilitiesSet helper classes for tests
 # ---------------------------------------------------------------------------

--- a/tests/test_node_resolution.py
+++ b/tests/test_node_resolution.py
@@ -1,6 +1,7 @@
 """Tests for node() path resolution with nested routers."""
 
 import pytest
+
 from genro_routes import RoutingClass, route
 from genro_routes.exceptions import NotFound
 

--- a/tests/test_node_resolution.py
+++ b/tests/test_node_resolution.py
@@ -1,21 +1,18 @@
 """Tests for node() path resolution with nested routers."""
 
 import pytest
-from genro_routes import Router, RoutingClass, route
+from genro_routes import RoutingClass, route
 from genro_routes.exceptions import NotFound
 
 
 class AdminService(RoutingClass):
     """Child router with default entry accepting optional param."""
 
-    def __init__(self):
-        self.api = Router(self, name="api", default_entry="index")
-
-    @route("api")
+    @route()
     def index(self, item_id=None):
         return f"admin.index: {item_id}"
 
-    @route("api")
+    @route()
     def users(self):
         return "admin.users"
 
@@ -24,15 +21,14 @@ class RootService(RoutingClass):
     """Root router with entries and child router."""
 
     def __init__(self):
-        self.api = Router(self, name="api", default_entry="index")
         self.admin = AdminService()
         self.attach_instance(self.admin, name="admin")
 
-    @route("api")
+    @route()
     def index(self):
         return "root.index"
 
-    @route("api")
+    @route()
     def action(self, x, y):
         return f"root.action: {x}, {y}"
 
@@ -47,27 +43,27 @@ class TestFindCandidateNode:
 
     def test_empty_path_uses_default_entry(self, root):
         """Case 1: path.strip('/') is empty -> RouterNode(self)."""
-        node = root.api.node("")
+        node = root.route.node("")
         assert node() == "root.index"
 
     def test_empty_path_with_slash(self, root):
         """Case 1 variant: '/' also resolves to default_entry."""
-        node = root.api.node("/")
+        node = root.route.node("/")
         assert node() == "root.index"
 
     def test_entry_found_with_partial(self, root):
         """Case 2: head in router._entries -> entry with partial args."""
-        node = root.api.node("action/1/2")
+        node = root.route.node("action/1/2")
         assert node() == "root.action: 1, 2"
 
     def test_child_router_uses_its_default_entry(self, root):
         """Case 3: consumed all path navigating children -> RouterNode(router)."""
-        node = root.api.node("admin")
+        node = root.route.node("admin")
         assert node() == "admin.index: None"
 
     def test_head_not_entry_not_child_uses_default(self, root):
         """Case 4: head not entry nor child -> fallback to default_entry."""
-        node = root.api.node("admin/zuz")
+        node = root.route.node("admin/zuz")
         assert node() == "admin.index: zuz"
 
 
@@ -76,20 +72,20 @@ class TestRouterNodeInit:
 
     def test_entry_found_and_partial_valid(self, root):
         """Entry found and _assign_partial returns True -> _entry populated."""
-        node = root.api.node("action/a/b")
+        node = root.route.node("action/a/b")
         assert node.error is None
         assert node() == "root.action: a, b"
 
     def test_entry_not_found(self, root):
         """default_entry doesn't accept partial -> _entry is None."""
-        node = root.api.node("zuz")
+        node = root.route.node("zuz")
         # root.index() has no params, so partial ['zuz'] won't fit
         with pytest.raises(NotFound):
             node()
 
     def test_too_many_args_for_signature(self, root):
         """Entry found but partial exceeds signature -> _entry is None."""
-        node = root.api.node("action/1/2/3")
+        node = root.route.node("action/1/2/3")
         with pytest.raises(NotFound):
             node()
 
@@ -97,14 +93,11 @@ class TestRouterNodeInit:
         """Router has no matching default_entry -> NotFound on call."""
 
         class NoDefaultService(RoutingClass):
-            def __init__(self):
-                self.api = Router(self, name="api")
-
-            @route("api")
+            @route()
             def only_action(self):
                 return "only"
 
         svc = NoDefaultService()
-        node = svc.api.node("nonexistent")
+        node = svc.route.node("nonexistent")
         with pytest.raises(NotFound):
             node()

--- a/tests/test_plugin_shorthand.py
+++ b/tests/test_plugin_shorthand.py
@@ -64,7 +64,7 @@ class Owner(RoutingClass):
 
 
 def _make_router():
-    return Router(Owner(), name="api").plug("shorthand").plug("nodefault")
+    return Owner().route.plug("shorthand").plug("nodefault")
 
 
 def _get_plugin_config(router, entry_name):
@@ -115,33 +115,33 @@ class TestShorthandViaDecorator:
     """Test shorthand syntax through @route decorator."""
 
     def test_shorthand_via_route_decorator(self):
-        """@route('api', shorthand='admin') resolves to shorthand_rule='admin'."""
+        """@route(shorthand='admin') resolves to shorthand_rule='admin'."""
 
         class Svc(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("shorthand").plug("nodefault")
+                self.route.plug("shorthand").plug("nodefault")
 
-            @route("api", shorthand="admin")
+            @route(shorthand="admin")
             def action(self):
                 return "ok"
 
         svc = Svc()
-        cfg = _get_plugin_config(svc.api, "action")
+        cfg = _get_plugin_config(svc.route, "action")
         assert cfg.get("shorthand") == {"rule": "admin"}
 
     def test_longform_via_route_decorator(self):
-        """@route('api', shorthand_rule='admin') still works."""
+        """@route(shorthand_rule='admin') still works."""
 
         class Svc(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("shorthand").plug("nodefault")
+                self.route.plug("shorthand").plug("nodefault")
 
-            @route("api", shorthand_rule="admin")
+            @route(shorthand_rule="admin")
             def action(self):
                 return "ok"
 
         svc = Svc()
-        cfg = _get_plugin_config(svc.api, "action")
+        cfg = _get_plugin_config(svc.route, "action")
         assert cfg.get("shorthand") == {"rule": "admin"}
 
     def test_mixed_shorthand_and_longform_in_decorator(self):
@@ -149,13 +149,13 @@ class TestShorthandViaDecorator:
 
         class Svc(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api").plug("shorthand").plug("nodefault")
+                self.route.plug("shorthand").plug("nodefault")
 
-            @route("api", shorthand="admin", nodefault_value="test")
+            @route(shorthand="admin", nodefault_value="test")
             def action(self):
                 return "ok"
 
         svc = Svc()
-        cfg = _get_plugin_config(svc.api, "action")
+        cfg = _get_plugin_config(svc.route, "action")
         assert cfg.get("shorthand") == {"rule": "admin"}
         assert cfg.get("nodefault") == {"value": "test"}

--- a/tests/test_plugins_new.py
+++ b/tests/test_plugins_new.py
@@ -16,15 +16,15 @@
 
 # Import to trigger plugin registration
 import genro_routes.plugins.logging  # noqa: F401
-from genro_routes import RoutingClass, Router, route
+from genro_routes import RoutingClass, route
 
 
 class LoggedService(RoutingClass):
     def __init__(self):
         self.calls = 0
-        self.routes = Router(self, name="routes").plug("logging")
+        self.route.plug("logging")
 
-    @route("routes")
+    @route()
     def hello(self):
         self.calls += 1
         return "ok"
@@ -47,9 +47,9 @@ def test_logging_plugin_runs_per_instance(monkeypatch):
             records.append(message)
 
     svc = LoggedService()
-    svc.routes.logging._logger = DummyLogger()  # type: ignore[attr-defined]
+    svc.route.logging._logger = DummyLogger()  # type: ignore[attr-defined]
 
-    assert svc.routes.node("hello")() == "ok"
+    assert svc.route.node("hello")() == "ok"
     assert svc.calls == 1
     assert records and "hello" in records[0]
 
@@ -69,16 +69,16 @@ def test_logging_plugin_respects_route_plugin_flags():
 
     class Service(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("logging")
+            self.route.plug("logging")
             # Inject dummy logger so we can see if logging fires.
-            self.api.logging._logger = DummyLogger()  # type: ignore[attr-defined]
+            self.route.logging._logger = DummyLogger()  # type: ignore[attr-defined]
 
-        @route("api", logging_flags="enabled:off")
+        @route(logging_flags="enabled:off")
         def hello(self):
             return "hi"
 
     svc = Service()
-    svc.api.node("hello")()
+    svc.route.node("hello")()
     assert records == []
 
 
@@ -94,17 +94,17 @@ def test_logging_plugin_respects_runtime_config_toggle():
 
     class Service(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("logging")
-            self.api.logging._logger = DummyLogger()  # type: ignore[attr-defined]
+            self.route.plug("logging")
+            self.route.logging._logger = DummyLogger()  # type: ignore[attr-defined]
 
-        @route("api")
+        @route()
         def ping(self):
             return "pong"
 
     svc = Service()
     # Disable "before" and keep "after" via flags.
-    svc.api.logging.configure(flags="before:off,after:on")
-    svc.api.node("ping")()
+    svc.route.logging.configure(flags="before:off,after:on")
+    svc.route.node("ping")()
     # Check format: "ping end (X.XX ms)" - timing varies so we check pattern
     assert len(records) == 1
     assert records[0].startswith("ping end (") and records[0].endswith(" ms)")
@@ -122,15 +122,15 @@ def test_logging_plugin_print_sink_overrides_logger(capsys):
 
     class Service(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("logging")
-            self.api.logging._logger = DummyLogger()  # type: ignore[attr-defined]
+            self.route.plug("logging")
+            self.route.logging._logger = DummyLogger()  # type: ignore[attr-defined]
 
-        @route("api", logging_log=False, logging_print=True)
+        @route(logging_log=False, logging_print=True)
         def hello(self):
             return "hi"
 
     svc = Service()
-    svc.api.node("hello")()
+    svc.route.node("hello")()
     # Should bypass logger and print instead.
     captured = capsys.readouterr()
     assert records == []
@@ -150,25 +150,25 @@ def test_configure_enabled_false_disables_plugin():
 
     class Service(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("logging")
-            self.api.logging._logger = DummyLogger()  # type: ignore[attr-defined]
+            self.route.plug("logging")
+            self.route.logging._logger = DummyLogger()  # type: ignore[attr-defined]
 
-        @route("api")
+        @route()
         def hello(self):
             return "hi"
 
     svc = Service()
 
     # First call - logging should fire
-    svc.api.node("hello")()
+    svc.route.node("hello")()
     assert len(records) == 2  # start + end
 
     # Disable via configure
-    svc.api.logging.configure(enabled=False)
+    svc.route.logging.configure(enabled=False)
 
     # Second call - logging should be disabled
     records.clear()
-    svc.api.node("hello")()
+    svc.route.node("hello")()
     assert records == []  # No logging because plugin is disabled
 
 
@@ -185,28 +185,28 @@ def test_configure_enabled_per_handler():
 
     class Service(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("logging")
-            self.api.logging._logger = DummyLogger()  # type: ignore[attr-defined]
+            self.route.plug("logging")
+            self.route.logging._logger = DummyLogger()  # type: ignore[attr-defined]
 
-        @route("api")
+        @route()
         def hello(self):
             return "hi"
 
-        @route("api")
+        @route()
         def world(self):
             return "world"
 
     svc = Service()
 
     # Disable only 'hello' via configure
-    svc.api.logging.configure(_target="hello", enabled=False)
+    svc.route.logging.configure(_target="hello", enabled=False)
 
     # Call hello - should NOT log
-    svc.api.node("hello")()
+    svc.route.node("hello")()
     assert records == []
 
     # Call world - SHOULD log
-    svc.api.node("world")()
+    svc.route.node("world")()
     assert len(records) == 2  # start + end
 
 
@@ -223,20 +223,20 @@ def test_set_plugin_enabled_overrides_configure():
 
     class Service(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("logging")
-            self.api.logging._logger = DummyLogger()  # type: ignore[attr-defined]
+            self.route.plug("logging")
+            self.route.logging._logger = DummyLogger()  # type: ignore[attr-defined]
 
-        @route("api")
+        @route()
         def hello(self):
             return "hi"
 
     svc = Service()
 
     # Disable via configure (config)
-    svc.api.logging.configure(enabled=False)
+    svc.route.logging.configure(enabled=False)
 
     # But re-enable via set_plugin_enabled (locals) - should take precedence
-    svc.api.set_plugin_enabled("hello", "logging", True)
+    svc.route.set_plugin_enabled("hello", "logging", True)
 
-    svc.api.node("hello")()
+    svc.route.node("hello")()
     assert len(records) == 2  # Logging fires because locals override config

--- a/tests/test_pydantic_plugin.py
+++ b/tests/test_pydantic_plugin.py
@@ -19,15 +19,15 @@ from pydantic import ValidationError
 
 # Import to trigger plugin registration
 import genro_routes.plugins.pydantic  # noqa: F401
-from genro_routes import RoutingClass, Router, route
+from genro_routes import RoutingClass, route
 
 
 class ValidateService(RoutingClass):
     def __init__(self):
         self.calls = 0
-        self.api = Router(self, name="api").plug("pydantic")
+        self.route.plug("pydantic")
 
-    @route("api")
+    @route()
     def concat(self, text: str, number: int = 1) -> str:
         self.calls += 1
         return f"{text}:{number}"
@@ -35,16 +35,16 @@ class ValidateService(RoutingClass):
 
 def test_pydantic_plugin_accepts_valid_input():
     svc = ValidateService()
-    assert svc.api.node("concat")("hello", 3) == "hello:3"
+    assert svc.route.node("concat")("hello", 3) == "hello:3"
     # default value still works
-    assert svc.api.node("concat")("hi") == "hi:1"
+    assert svc.route.node("concat")("hi") == "hi:1"
     assert svc.calls == 2
 
 
 def test_pydantic_plugin_rejects_invalid_input():
     svc = ValidateService()
     with pytest.raises(ValidationError):
-        svc.api.node("concat")(123, "oops")
+        svc.route.node("concat")(123, "oops")
 
 
 def test_pydantic_plugin_disabled_at_runtime():
@@ -53,13 +53,13 @@ def test_pydantic_plugin_disabled_at_runtime():
 
     # First verify validation is active
     with pytest.raises(ValidationError):
-        svc.api.node("concat")(123, "oops")
+        svc.route.node("concat")(123, "oops")
 
     # Disable validation at runtime
-    svc.api.pydantic.configure(disabled=True)
+    svc.route.pydantic.configure(disabled=True)
 
     # Now invalid input passes through (no validation)
-    result = svc.api.node("concat")(123, "oops")
+    result = svc.route.node("concat")(123, "oops")
     assert result == "123:oops"
 
 
@@ -68,27 +68,27 @@ def test_pydantic_plugin_disabled_per_handler():
 
     class MultiService(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("pydantic")
+            self.route.plug("pydantic")
 
-        @route("api")
+        @route()
         def strict(self, text: str, number: int) -> str:
             return f"{text}:{number}"
 
-        @route("api")
+        @route()
         def lenient(self, text: str, number: int) -> str:
             return f"{text}:{number}"
 
     svc = MultiService()
 
     # Disable only for "lenient" handler
-    svc.api.pydantic.configure(_target="lenient", disabled=True)
+    svc.route.pydantic.configure(_target="lenient", disabled=True)
 
     # "strict" still validates
     with pytest.raises(ValidationError):
-        svc.api.node("strict")(123, "oops")
+        svc.route.node("strict")(123, "oops")
 
     # "lenient" bypasses validation
-    result = svc.api.node("lenient")(123, "oops")
+    result = svc.route.node("lenient")(123, "oops")
     assert result == "123:oops"
 
 
@@ -97,30 +97,30 @@ def test_pydantic_plugin_config_merge_base_and_handler():
 
     class MergeService(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("pydantic")
+            self.route.plug("pydantic")
 
-        @route("api")
+        @route()
         def handler_a(self, text: str, number: int) -> str:
             return f"{text}:{number}"
 
-        @route("api")
+        @route()
         def handler_b(self, text: str, number: int) -> str:
             return f"{text}:{number}"
 
     svc = MergeService()
 
     # Disable validation globally (base config)
-    svc.api.pydantic.configure(disabled=True)
+    svc.route.pydantic.configure(disabled=True)
 
     # Both handlers should bypass validation now
-    assert svc.api.node("handler_a")(123, "oops") == "123:oops"
-    assert svc.api.node("handler_b")(123, "oops") == "123:oops"
+    assert svc.route.node("handler_a")(123, "oops") == "123:oops"
+    assert svc.route.node("handler_b")(123, "oops") == "123:oops"
 
     # Re-enable validation only for handler_a (per-handler overrides base)
-    svc.api.pydantic.configure(_target="handler_a", disabled=False)
+    svc.route.pydantic.configure(_target="handler_a", disabled=False)
 
     # handler_a validates again, handler_b still disabled
     with pytest.raises(ValidationError):
-        svc.api.node("handler_a")(123, "oops")
+        svc.route.node("handler_a")(123, "oops")
 
-    assert svc.api.node("handler_b")(123, "oops") == "123:oops"
+    assert svc.route.node("handler_b")(123, "oops") == "123:oops"

--- a/tests/test_router_basic.py
+++ b/tests/test_router_basic.py
@@ -16,7 +16,7 @@
 
 import pytest
 
-from genro_routes import RoutingClass, Router, route
+from genro_routes import Router, RoutingClass, route
 from genro_routes.plugins._base_plugin import BasePlugin  # Not public API
 
 
@@ -24,34 +24,32 @@ def test_orders_quick_example():
     class OrdersAPI(RoutingClass):
         def __init__(self, label: str):
             self.label = label
-            self.api = Router(self, name="orders")
 
-        @route("orders")
+        @route()
         def list(self):
             return ["order-1", "order-2"]
 
-        @route("orders")
+        @route()
         def retrieve(self, ident: str):
             return f"{self.label}:{ident}"
 
-        @route("orders")
+        @route()
         def create(self, payload: dict):
             return {"status": "created", **payload}
 
     orders = OrdersAPI("acme")
     # Use node() and call it
-    assert orders.api.node("list")() == ["order-1", "order-2"]
-    assert orders.api.node("retrieve")("42") == "acme:42"
-    overview = orders.api.nodes()
+    assert orders.route.node("list")() == ["order-1", "order-2"]
+    assert orders.route.node("retrieve")("42") == "acme:42"
+    overview = orders.route.nodes()
     assert set(overview["entries"].keys()) == {"list", "retrieve", "create"}
 
 
 class Service(RoutingClass):
     def __init__(self, label: str):
         self.label = label
-        self.api = Router(self, name="api")
 
-    @route("api")
+    @route()
     def describe(self):
         return f"service:{self.label}"
 
@@ -59,13 +57,13 @@ class Service(RoutingClass):
 class SubService(RoutingClass):
     def __init__(self, prefix: str):
         self.prefix = prefix
-        self.routes = Router(self, name="routes", prefix="handle_")
+        self.route.prefix = "handle_"
 
-    @route("routes")
+    @route()
     def handle_list(self):
         return f"{self.prefix}:list"
 
-    @route("routes", name="detail")
+    @route(name="detail")
     def handle_detail(self, ident: int):
         return f"{self.prefix}:detail:{ident}"
 
@@ -73,7 +71,6 @@ class SubService(RoutingClass):
 class RootAPI(RoutingClass):
     def __init__(self):
         self.services: list[Service] = []
-        self.api = Router(self, name="api")
 
 
 class CapturePlugin(BasePlugin):
@@ -84,10 +81,10 @@ class CapturePlugin(BasePlugin):
         super().__init__(router, **config)
         self.calls = []
 
-    def on_decore(self, route, func, entry):
+    def on_decore(self, router, func, entry):
         entry.metadata["capture"] = True
 
-    def wrap_handler(self, route, entry, call_next):
+    def wrap_handler(self, router, entry, call_next):
         def wrapper(*args, **kwargs):
             self.calls.append("wrap")
             return call_next(*args, **kwargs)
@@ -102,9 +99,9 @@ Router.register_plugin(CapturePlugin)
 class PluginService(RoutingClass):
     def __init__(self):
         self.touched = False
-        self.api = Router(self, name="api").plug("capture")
+        self.route.plug("capture")
 
-    @route("api")
+    @route()
     def do_work(self):
         self.touched = True
         return "ok"
@@ -117,9 +114,9 @@ class TogglePlugin(BasePlugin):
     def __init__(self, router, **config):
         super().__init__(router, **config)
 
-    def wrap_handler(self, route, entry, call_next):
+    def wrap_handler(self, router, entry, call_next):
         def wrapper(*args, **kwargs):
-            route.set_runtime_data(entry.name, self.name, "last", True)
+            router.set_runtime_data(entry.name, self.name, "last", True)
             return call_next(*args, **kwargs)
 
         return wrapper
@@ -131,18 +128,17 @@ Router.register_plugin(TogglePlugin)
 
 class ToggleService(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("toggle")
+        self.route.plug("toggle")
 
-    @route("api")
+    @route()
     def touch(self):
         return "done"
 
 
 class DynamicRouterService(RoutingClass):
     def __init__(self):
-        self.dynamic = Router(self, name="dynamic")
-        self.dynamic.add_entry(self.dynamic_alpha)
-        self.dynamic.add_entry("dynamic_beta")
+        self.route.add_entry(self.dynamic_alpha)
+        self.route.add_entry("dynamic_beta")
 
     def dynamic_alpha(self):
         return "alpha"
@@ -154,65 +150,61 @@ class DynamicRouterService(RoutingClass):
 def test_prefix_and_name_override():
     sub = SubService("users")
 
-    assert sub.routes.node("list")() == "users:list"
-    assert sub.routes.node("detail")(10) == "users:detail:10"
+    assert sub.route.node("list")() == "users:list"
+    assert sub.route.node("detail")(10) == "users:detail:10"
 
 
 def test_plugins_are_per_instance_and_accessible():
     svc = PluginService()
-    assert svc.api.capture.calls == []
-    result = svc.api.node("do_work")()
+    assert svc.route.capture.calls == []
+    result = svc.route.node("do_work")()
     assert result == "ok"
     assert svc.touched is True
-    assert svc.api.capture.calls == ["wrap"]
+    assert svc.route.capture.calls == ["wrap"]
     other = PluginService()
-    assert other.api.capture.calls == []
+    assert other.route.capture.calls == []
 
 
 def test_dynamic_router_add_entry_runtime():
     svc = DynamicRouterService()
-    assert svc.dynamic.node("dynamic_alpha")() == "alpha"
-    assert svc.dynamic.node("dynamic_beta")() == "beta"
+    assert svc.route.node("dynamic_alpha")() == "alpha"
+    assert svc.route.node("dynamic_beta")() == "beta"
     # Adding via string
-    svc.dynamic.add_entry("dynamic_alpha", name="alpha_alias")
-    assert svc.dynamic.node("alpha_alias")() == "alpha"
+    svc.route.add_entry("dynamic_alpha", name="alpha_alias")
+    assert svc.route.node("alpha_alias")() == "alpha"
 
 
 def test_plugin_enable_disable_runtime_data():
     svc = ToggleService()
-    node = svc.api.node("touch")
+    node = svc.route.node("touch")
     # Initially enabled
     node()
-    assert svc.api.get_runtime_data("touch", "toggle", "last") is True
+    assert svc.route.get_runtime_data("touch", "toggle", "last") is True
     # Disable and verify
-    svc.api.set_plugin_enabled("touch", "toggle", False)
-    svc.api.set_runtime_data("touch", "toggle", "last", None)
+    svc.route.set_plugin_enabled("touch", "toggle", False)
+    svc.route.set_runtime_data("touch", "toggle", "last", None)
     node()
-    assert svc.api.get_runtime_data("touch", "toggle", "last") is None
+    assert svc.route.get_runtime_data("touch", "toggle", "last") is None
     # Re-enable
-    svc.api.set_plugin_enabled("touch", "toggle", True)
+    svc.route.set_plugin_enabled("touch", "toggle", True)
     node()
-    assert svc.api.get_runtime_data("touch", "toggle", "last") is True
+    assert svc.route.get_runtime_data("touch", "toggle", "last") is True
 
 
 def test_dotted_path_and_nodes_with_attached_child():
     class Child(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def ping(self):
             return "pong"
 
     class Parent(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api")
             self.child = Child()
             self.attach_instance(self.child, name="child")
 
     parent = Parent()
-    assert parent.api.node("child/ping")() == "pong"
-    tree = parent.api.nodes()
+    assert parent.route.node("child/ping")() == "pong"
+    tree = parent.route.nodes()
     assert "child" in tree["routers"]
 
 
@@ -222,15 +214,12 @@ def test_dotted_path_and_nodes_with_attached_child():
 
 
 class TestSingleRouterDefault:
-    """Test @route() without arguments when class has a single router."""
+    """Test @route() without arguments on the class's single router."""
 
     def test_route_without_args_uses_single_router(self):
         """@route() without arguments uses the single router."""
 
         class Table(RoutingClass):
-            def __init__(self):
-                self.api = Router(self, name="table")
-
             @route()
             def add(self, data):
                 return f"added:{data}"
@@ -240,28 +229,25 @@ class TestSingleRouterDefault:
                 return f"got:{key}"
 
         t = Table()
-        assert t.api.node("add")("x") == "added:x"
-        assert t.api.node("get")("y") == "got:y"
-        assert set(t.api.nodes()["entries"].keys()) == {"add", "get"}
+        assert t.route.node("add")("x") == "added:x"
+        assert t.route.node("get")("y") == "got:y"
+        assert set(t.route.nodes()["entries"].keys()) == {"add", "get"}
 
     def test_route_with_custom_entry_name(self):
-        """@route(name='custom') works with single router."""
+        """@route(name='custom') works with the single router."""
 
         class Table(RoutingClass):
-            def __init__(self):
-                self.api = Router(self, name="table")
-
             @route(name="custom_add")
             def add_record(self, data):
                 return f"added:{data}"
 
         t = Table()
-        assert t.api.node("custom_add")("x") == "added:x"
-        assert "custom_add" in t.api.nodes()["entries"]
-        assert "add_record" not in t.api.nodes()["entries"]
+        assert t.route.node("custom_add")("x") == "added:x"
+        assert "custom_add" in t.route.nodes()["entries"]
+        assert "add_record" not in t.route.nodes()["entries"]
 
     def test_route_inheritance_with_single_router(self):
-        """Subclass with single router inherits @route() methods."""
+        """Subclass inherits @route() methods."""
 
         class BaseTable(RoutingClass):
             @route()
@@ -269,26 +255,23 @@ class TestSingleRouterDefault:
                 return "base_list"
 
         class ExtendedTable(BaseTable):
-            def __init__(self):
-                self.api = Router(self, name="table")
-
             @route()
             def add(self):
                 return "extended_add"
 
         t = ExtendedTable()
-        assert t.api.node("list")() == "base_list"
-        assert t.api.node("add")() == "extended_add"
-        entries = t.api.nodes()["entries"]
+        assert t.route.node("list")() == "base_list"
+        assert t.route.node("add")() == "extended_add"
+        entries = t.route.nodes()["entries"]
         assert "list" in entries
         assert "add" in entries
 
     def test_route_with_plugin_kwargs(self):
-        """@route() with kwargs works with single router."""
+        """@route() with kwargs works with the single router."""
 
         class TaggedTable(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="table").plug("auth")
+                self.route.plug("auth")
 
             @route(auth_rule="admin")
             def admin_only(self):
@@ -299,13 +282,13 @@ class TestSingleRouterDefault:
                 return "public"
 
         t = TaggedTable()
-        entries = t.api.nodes(auth_tags="admin")["entries"]
+        entries = t.route.nodes(auth_tags="admin")["entries"]
         assert "admin_only" in entries
         assert "public_action" not in entries
 
 
 # ============================================================================
-# RoutingClass requirement and default_router tests
+# RoutingClass requirement tests
 # ============================================================================
 
 
@@ -319,7 +302,12 @@ class TestRoutingClassRequirement:
             pass
 
         with pytest.raises(TypeError, match="must be a RoutingClass"):
-            Router(PlainClass(), name="api")
+            Router(PlainClass())
+
+    def test_router_requires_owner(self):
+        """Router raises ValueError if owner is None."""
+        with pytest.raises(ValueError, match="requires a parent instance"):
+            Router(None)
 
     def test_router_accepts_routed_class(self):
         """Router accepts RoutingClass instances."""
@@ -328,42 +316,19 @@ class TestRoutingClassRequirement:
             pass
 
         svc = MyService()
-        router = Router(svc, name="api")
+        router = Router(svc)
         assert router.instance is svc
 
+    def test_second_router_on_same_owner_raises(self):
+        """Creating a second Router on the same owner raises ValueError."""
 
-class TestDefaultRouter:
-    """Test default_router property on RoutingClass."""
-
-    def test_default_router_single_router(self):
-        """default_router returns the only router when there's exactly one."""
-
-        class SingleRouter(RoutingClass):
-            def __init__(self):
-                self.api = Router(self, name="api")
-
-        svc = SingleRouter()
-        assert svc.default_router is svc.api
-
-    def test_default_router_multiple_routers(self):
-        """default_router returns None when multiple routers exist."""
-
-        class MultiRouter(RoutingClass):
-            def __init__(self):
-                self.api = Router(self, name="api")
-                self.admin = Router(self, name="admin")
-
-        svc = MultiRouter()
-        assert svc.default_router is None
-
-    def test_default_router_no_routers(self):
-        """default_router returns None when no routers registered."""
-
-        class NoRouters(RoutingClass):
+        class MyService(RoutingClass):
             pass
 
-        svc = NoRouters()
-        assert svc.default_router is None
+        svc = MyService()
+        _ = svc.route  # auto-created router occupies the single slot
+        with pytest.raises(ValueError, match="already has a router"):
+            Router(svc)
 
 
 # -----------------------------------------------------------------------------
@@ -378,66 +343,56 @@ class TestDefaultEntry:
         """Router default_entry is 'index' by default."""
 
         class Service(RoutingClass):
-            def __init__(self):
-                self.api = Router(self, name="api")
-
-            @route("api")
+            @route()
             def action(self):
                 return "action"
 
         svc = Service()
-        assert svc.api.default_entry == "index"
+        assert svc.route.default_entry == "index"
 
     def test_default_entry_can_be_customized(self):
         """Router default_entry can be set to a custom value."""
 
         class Service(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api", default_entry="handle")
+                self.route.default_entry = "handle"
 
-            @route("api")
+            @route()
             def handle(self):
                 return "handle"
 
         svc = Service()
-        assert svc.api.default_entry == "handle"
+        assert svc.route.default_entry == "handle"
 
     def test_leading_slash_is_stripped(self):
         """node() strips leading slash from path."""
 
         class Service(RoutingClass):
-            def __init__(self):
-                self.api = Router(self, name="api")
-
-            @route("api")
+            @route()
             def action(self):
                 return "action result"
 
         svc = Service()
 
         # Both should work identically
-        assert svc.api.node("action")() == "action result"
-        assert svc.api.node("/action")() == "action result"
+        assert svc.route.node("action")() == "action result"
+        assert svc.route.node("/action")() == "action result"
 
     def test_leading_slash_with_hierarchy(self):
         """node() strips leading slash in hierarchical paths."""
 
         class Child(RoutingClass):
-            def __init__(self):
-                self.api = Router(self, name="api")
-
-            @route("api")
+            @route()
             def handler(self):
                 return "child handler"
 
         class Root(RoutingClass):
             def __init__(self):
-                self.api = Router(self, name="api")
                 self.child = Child()
                 self.attach_instance(self.child, name="child")
 
         root = Root()
 
         # Both should work identically
-        assert root.api.node("child/handler")() == "child handler"
-        assert root.api.node("/child/handler")() == "child handler"
+        assert root.route.node("child/handler")() == "child handler"
+        assert root.route.node("/child/handler")() == "child handler"

--- a/tests/test_router_edge_cases.py
+++ b/tests/test_router_edge_cases.py
@@ -16,7 +16,7 @@
 
 import pytest
 
-from genro_routes import RoutingClass, Router, route
+from genro_routes import Router, RoutingClass, Section, route
 from genro_routes.plugins import pydantic as pyd_mod
 from genro_routes.plugins._base_plugin import BasePlugin, MethodEntry  # Not public API
 
@@ -36,40 +36,40 @@ class SimplePlugin(BasePlugin):
 def test_plugin_configure_and_configuration():
     class Host(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("simple")
+            self.route.plug("simple")
 
     svc = Host()
     # Access plugin via public attribute
-    plugin = svc.api.simple
+    plugin = svc.route.simple
 
     # Test configure() with flags
     plugin.configure(flags="enabled,,beta")
-    assert svc.api.get_config("simple")["enabled"] is True
+    assert svc.route.get_config("simple")["enabled"] is True
     plugin.configure(threshold=5)
-    assert svc.api.get_config("simple")["threshold"] == 5
+    assert svc.route.get_config("simple")["threshold"] == 5
     # Test configuration() reads back
     assert plugin.configuration()["threshold"] == 5
 
     # Test per-handler config with _target
     plugin.configure(_target="foo", flags="enabled:off")
-    assert svc.api.get_config("simple", "foo")["enabled"] is False
+    assert svc.route.get_config("simple", "foo")["enabled"] is False
     plugin.configure(_target="foo", mode="strict")
-    assert svc.api.get_config("simple", "foo")["mode"] == "strict"
+    assert svc.route.get_config("simple", "foo")["mode"] == "strict"
 
 
 def test_plugin_constructor_flags():
     class Host(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("simple", flags="beta:on,alpha:off")
+            self.route.plug("simple", flags="beta:on,alpha:off")
 
     svc = Host()
     # Access plugin via public attribute
-    plugin = svc.api.simple
-    assert svc.api.get_config("simple")["beta"] is True
-    assert svc.api.get_config("simple")["alpha"] is False
+    plugin = svc.route.simple
+    assert svc.route.get_config("simple")["beta"] is True
+    assert svc.route.get_config("simple")["alpha"] is False
     # Per-handler config via configure()
     plugin.configure(_target="foo", enabled=False)
-    assert svc.api.get_config("simple", "foo")["enabled"] is False
+    assert svc.route.get_config("simple", "foo")["enabled"] is False
 
 
 def ensure_plugin(plugin_cls: type) -> None:
@@ -85,11 +85,11 @@ def test_plugin_configuration_has_defaults():
 
     class Host(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("simple")
+            self.route.plug("simple")
 
     svc = Host()
     # Fresh plugin has default enabled=True
-    assert svc.api.simple.configuration()["enabled"] is True
+    assert svc.route.simple.configuration()["enabled"] is True
 
 
 def test_plugin_missing_plugin_raises():
@@ -97,18 +97,18 @@ def test_plugin_missing_plugin_raises():
 
     class Host(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("simple")
+            self.route.plug("simple")
 
     svc = Host()
     # Missing plugin triggers AttributeError on public setters/getters
     with pytest.raises(AttributeError):
-        svc.api.set_plugin_enabled("foo", "ghost", True)
+        svc.route.set_plugin_enabled("foo", "ghost", True)
     with pytest.raises(AttributeError):
-        svc.api.get_runtime_data("foo", "ghost", "k")
+        svc.route.get_runtime_data("foo", "ghost", "k")
     with pytest.raises(AttributeError):
-        svc.api.set_runtime_data("foo", "ghost", "k", 1)
+        svc.route.set_runtime_data("foo", "ghost", "k", 1)
     with pytest.raises(AttributeError):
-        svc.api.is_plugin_enabled("foo", "ghost")
+        svc.route.is_plugin_enabled("foo", "ghost")
 
 
 def test_route_decorator_with_plugin_options():
@@ -116,17 +116,17 @@ def test_route_decorator_with_plugin_options():
 
     class Host(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("simple")
+            self.route.plug("simple")
 
-        @route("api", simple_flag=True, simple_mode="x")
+        @route(simple_flag=True, simple_mode="x")
         def run(self):
             return "ok"
 
     svc = Host()
     # Handler works and is registered
-    assert svc.api.node("run")() == "ok"
+    assert svc.route.node("run")() == "ok"
     # Entry is registered in nodes()
-    info = svc.api.nodes()
+    info = svc.route.nodes()
     assert "run" in info["entries"]
 
 
@@ -135,146 +135,112 @@ def test_plugin_configure_after_binding():
 
     class Host(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("simple")
+            self.route.plug("simple")
 
-        @route("api")
+        @route()
         def hello(self):
             return "hi"
 
     svc = Host()
     # Apply options via configure() after binding
-    svc.api.simple.configure(opt="via_configure")
+    svc.route.simple.configure(opt="via_configure")
     # Options from configure() call are accessible via get_config()
-    assert svc.api.get_config("simple")["opt"] == "via_configure"
+    assert svc.route.get_config("simple")["opt"] == "via_configure"
     # Handler still works
-    assert svc.api.node("hello")() == "hi"
+    assert svc.route.node("hello")() == "hi"
 
 
 def test_route_decorator_metadata_preserved():
     """Test that custom metadata from route decorator is preserved."""
 
     class Host(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api", core_value=123)
+        @route(core_value=123)
         def hello(self):
             return "hi"
 
     svc = Host()
     # Verify handler works
-    assert svc.api.node("hello")() == "hi"
+    assert svc.route.node("hello")() == "hi"
     # Verify entry is registered
-    info = svc.api.nodes()
+    info = svc.route.nodes()
     assert "hello" in info["entries"]
 
 
 def test_router_auto_registers_marked_methods_and_validates_plugins():
     class Demo(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api", name="alias")
+        @route(name="alias")
         def handle(self):
             return "ok"
 
     svc = Demo()
-    assert svc.api.node("alias")() == "ok"
+    assert svc.route.node("alias")() == "ok"
     ensure_plugin(SimplePlugin)
-    svc.api.plug("simple")
+    svc.route.plug("simple")
     with pytest.raises(ValueError):
-        svc.api.plug("missing")
+        svc.route.plug("missing")
 
 
 def test_router_detects_handler_name_collision():
     class DuplicateService(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api", name="dup")
+        @route(name="dup")
         def first(self):
             return "one"
 
-        @route("api", name="dup")
+        @route(name="dup")
         def second(self):
             return "two"
 
     svc = DuplicateService()
     with pytest.raises(ValueError):
-        svc.api.nodes()  # Lazy binding triggers collision error
+        svc.route.nodes()  # Lazy binding triggers collision error
 
 
 def test_iter_plugins_and_missing_attribute():
     class Service(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("simple")
+            self.route.plug("simple")
 
-        @route("api")
+        @route()
         def ping(self):
             return "pong"
 
     svc = Service()
-    plugins = svc.api.iter_plugins()
+    plugins = svc.route.iter_plugins()
     assert plugins and isinstance(plugins[0], SimplePlugin)
     with pytest.raises(AttributeError):
-        _ = svc.api.missing_plugin  # type: ignore[attr-defined]
+        _ = svc.route.missing_plugin  # type: ignore[attr-defined]
 
 
 def test_attach_and_detach_instance_single_router_with_alias():
     class Child(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def ping(self):
             return "pong"
 
     class Parent(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api")
             self.child = Child()
 
     parent = Parent()
     parent.attach_instance(parent.child, name="sales")
     # Verify child is accessible via nodes()
-    info = parent.api.nodes()
+    info = parent.route.nodes()
     assert "sales" in info.get("routers", {})
     # Verify handler is accessible via path
-    assert parent.api.node("sales/ping")() == "pong"
+    assert parent.route.node("sales/ping")() == "pong"
 
-    parent.api.detach_instance(parent.child)
+    parent.route.detach_instance(parent.child)
     # Verify child is no longer accessible
-    info = parent.api.nodes()
+    info = parent.route.nodes()
     assert "sales" not in info.get("routers", {})
-
-
-def test_attach_instance_multiple_routers_requires_mapping():
-    class Child(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-            self.admin = Router(self, name="admin")
-
-    class Parent(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-            self.child = Child()
-
-    parent = Parent()
-    # Auto-mapping when child has multiple routers requires explicit mapping
-    parent.attach_instance(parent.child, router_api="api:api,admin:admin")
-    # Verify both children are accessible via node()
-    assert parent.api.node("api")
-    assert parent.api.node("admin")
 
 
 def test_attach_instance_name_collision():
     class Child(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
+        pass
 
     class Parent(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api")
             self.child1 = Child()
             self.child2 = Child()
 
@@ -284,70 +250,73 @@ def test_attach_instance_name_collision():
         parent.attach_instance(parent.child2, name="sales")
 
 
-def test_detach_instance_missing_alias():
-    class Child(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-            self.admin = Router(self, name="admin")
+def test_detach_instance_removes_all_aliases():
+    """detach_instance removes every alias pointing to the child instance."""
 
-    parent = Child()
-    parent.self_ref = parent
-    parent.attach_instance(parent, router_api="api:self_api,admin:self_admin")
-    # detach without explicit mapping removes both
-    parent.api.detach_instance(parent)
-    info = parent.api.nodes()
+    class Child(RoutingClass):
+        @route()
+        def ping(self):
+            return "pong"
+
+    class Parent(RoutingClass):
+        pass
+
+    parent = Parent()
+    child = Child()
+    parent.attach_instance(child, name="first")
+    # Secondary navigation link to the same child router
+    parent.route.include(child.route, name="second")
+    info = parent.route.nodes()
+    assert "first" in info.get("routers", {})
+    assert "second" in info.get("routers", {})
+    # detach removes both aliases
+    parent.route.detach_instance(child)
+    info = parent.route.nodes()
     assert info.get("routers", {}) == {}
 
 
 def test_attach_instance_requires_routing_class():
     class Parent(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
+        pass
 
     parent = Parent()
     with pytest.raises(TypeError):
         parent.attach_instance(object(), name="x")
     with pytest.raises(TypeError):
-        parent.api.detach_instance(object())
+        parent.route.detach_instance(object())
 
 
 def test_auto_detach_on_attribute_replacement():
     class Child(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def ping(self):
             return "pong"
 
     class Parent(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api")
             self.child = Child()
             self.attach_instance(self.child, name="child")
 
     parent = Parent()
     # Verify child is attached via nodes()
-    info = parent.api.nodes()
+    info = parent.route.nodes()
     assert "child" in info.get("routers", {})
     # Verify handler is accessible
-    assert parent.api.node("child/ping")() == "pong"
+    assert parent.route.node("child/ping")() == "pong"
 
     parent.child = None  # triggers auto-detach
-    info = parent.api.nodes()
+    info = parent.route.nodes()
     assert "child" not in info.get("routers", {})
     assert parent.child is None
 
 
 def test_attach_instance_rejects_other_parent_when_already_bound():
     class Child(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
+        pass
 
     class Parent(RoutingClass):
         def __init__(self, label: str):
             self.label = label
-            self.api = Router(self, name="api")
             self.child = Child()
 
     first = Parent("first")
@@ -356,178 +325,100 @@ def test_attach_instance_rejects_other_parent_when_already_bound():
     # Bind to first parent
     first.attach_instance(first.child, name="child")
     # Verify child is attached via node()
-    assert first.api.node("child")
+    assert first.route.node("child")
 
     # Attempt to bind same child to another parent should fail
     with pytest.raises(ValueError):
         second.attach_instance(first.child, name="child")
 
 
-def test_routing_proxy_attach_instance_with_single_router():
-    """Test routing.attach_instance delegates to default_router."""
+def test_routing_proxy_attach_instance():
+    """Test routing.attach_instance delegates to the owner's attach_instance."""
 
     class Child(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def hello(self):
             return "hello from child"
 
     class Parent(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api")
             self.child = Child()
 
     parent = Parent()
-    # Use routing.attach_instance proxy (delegates to default router)
+    # Use routing.attach_instance proxy (delegates to owner)
     parent.routing.attach_instance(parent.child, name="child")
 
     # Verify child is accessible
-    assert parent.api.node("child/hello")() == "hello from child"
-
-
-def test_routing_proxy_attach_instance_fails_with_multiple_routers():
-    """Test routing.attach_instance raises RuntimeError with multiple routers."""
-
-    class Child(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-    class Parent(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-            self.admin = Router(self, name="admin")
-            self.child = Child()
-
-    parent = Parent()
-    with pytest.raises(ValueError) as exc_info:
-        parent.routing.attach_instance(parent.child, name="child")
-    assert "exactly one router" in str(exc_info.value)
-    assert "has 2" in str(exc_info.value)
-
-
-def test_routing_proxy_attach_instance_with_router_name():
-    """Test routing.attach_instance with explicit router_name."""
-
-    class Child(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
-        def hello(self):
-            return "hello from child"
-
-    class Parent(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-            self.admin = Router(self, name="admin")
-            self.child = Child()
-
-    parent = Parent()
-    # With multiple routers, use router_<name> kwarg to specify target
-    parent.routing.attach_instance(parent.child, router_admin="api:child")
-
-    # Verify child is accessible on the specified router
-    assert parent.admin.node("child/hello")() == "hello from child"
-
-
-def test_routing_proxy_attach_instance_invalid_router_name():
-    """Test routing.attach_instance raises AttributeError for invalid router_name."""
-
-    class Child(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-    class Parent(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-            self.child = Child()
-
-    parent = Parent()
-    with pytest.raises(ValueError) as exc_info:
-        parent.routing.attach_instance(parent.child, router_nonexistent="api:child")
-    assert "No router named 'nonexistent'" in str(exc_info.value)
+    assert parent.route.node("child/hello")() == "hello from child"
 
 
 def test_routing_proxy_instance():
     """Test routing.instance() returns child RoutingClass instance."""
 
     class UsersModule(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def list(self):
             return "users:list"
 
     class OrdersModule(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def list(self):
             return "orders:list"
 
     class App(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api")
             self.attach_instance(UsersModule(), name="users")
             self.attach_instance(OrdersModule(), name="orders")
 
     app = App()
 
     # Retrieve child instances via routing.instance()
-    users = app.routing.instance("api/users")
-    orders = app.routing.instance("api/orders")
+    users = app.routing.instance("users")
+    orders = app.routing.instance("orders")
 
     assert isinstance(users, UsersModule)
     assert isinstance(orders, OrdersModule)
 
     # Routing still works
-    assert app.api.node("users/list")() == "users:list"
-    assert app.api.node("orders/list")() == "orders:list"
+    assert app.route.node("users/list")() == "users:list"
+    assert app.route.node("orders/list")() == "orders:list"
 
 
 def test_routing_proxy_instance_not_found():
     """Test routing.instance() raises KeyError for non-existent child."""
 
     class App(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
+        pass
 
     app = App()
     with pytest.raises(KeyError):
-        app.routing.instance("api/nonexistent")
+        app.routing.instance("nonexistent")
 
 
 def test_endpoint_id_basic_lookup():
     """Test @endpoint_id resolution via node()."""
 
     class Service(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api", endpoint_id="USR-001/1")
+        @route(endpoint_id="USR-001/1")
         def list_users(self):
             return "users"
 
-        @route("api", endpoint_id="USR-002/1")
+        @route(endpoint_id="USR-002/1")
         def get_user(self, user_id):
             return f"user:{user_id}"
 
     svc = Service()
 
     # Resolve by endpoint_id
-    node = svc.api.node("@USR-001/1")
+    node = svc.route.node("@USR-001/1")
     assert node() == "users"
     assert node.endpoint_id == "USR-001/1"
 
     # Resolve by path still works
-    assert svc.api.node("list_users")() == "users"
+    assert svc.route.node("list_users")() == "users"
 
     # endpoint_id with positional args via call
-    node2 = svc.api.node("@USR-002/1")
+    node2 = svc.route.node("@USR-002/1")
     assert node2(42) == "user:42"
 
 
@@ -535,22 +426,18 @@ def test_endpoint_id_in_child_router():
     """Test @endpoint_id lookup across child routers."""
 
     class UsersModule(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api", endpoint_id="USR-LIST")
+        @route(endpoint_id="USR-LIST")
         def list(self):
             return "users:list"
 
     class App(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api")
             self.attach_instance(UsersModule(), name="users")
 
     app = App()
 
     # Endpoint_id found in child
-    node = app.api.node("@USR-LIST")
+    node = app.route.node("@USR-LIST")
     assert node() == "users:list"
     assert node.path == "users/list"
     assert node.endpoint_id == "USR-LIST"
@@ -560,15 +447,12 @@ def test_endpoint_id_not_found():
     """Test @endpoint_id returns not_found for unknown id."""
 
     class Service(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def hello(self):
             return "hello"
 
     svc = Service()
-    node = svc.api.node("@NONEXISTENT")
+    node = svc.route.node("@NONEXISTENT")
     assert node.error == "not_found"
 
 
@@ -576,134 +460,106 @@ def test_endpoint_id_accessible_from_path_node():
     """Test endpoint_id is accessible on nodes resolved by path."""
 
     class Service(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api", endpoint_id="MY-EP")
+        @route(endpoint_id="MY-EP")
         def handler(self):
             return "ok"
 
-        @route("api")
+        @route()
         def no_id(self):
             return "no id"
 
     svc = Service()
 
     # Has endpoint_id
-    assert svc.api.node("handler").endpoint_id == "MY-EP"
+    assert svc.route.node("handler").endpoint_id == "MY-EP"
 
     # No endpoint_id
-    assert svc.api.node("no_id").endpoint_id is None
+    assert svc.route.node("no_id").endpoint_id is None
 
 
-def test_branch_router_blocks_entries():
-    """Branch routers cannot register handlers directly."""
+def test_section_creates_hierarchy():
+    """Grouping via composition (one RoutingClass per surface) builds hierarchies."""
 
-    class Service(RoutingClass):
-        def __init__(self):
-            self.branch = Router(self, name="branch", branch=True)
-
-    svc = Service()
-    with pytest.raises(ValueError):
-        svc.branch.add_entry("missing")
-
-
-def test_parent_router_creates_hierarchy():
-    """Test that parent_router parameter creates router hierarchies."""
-
-    class Service(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api", branch=True)
-            self.users = Router(self, name="users", parent_router=self.api)
-            self.orders = Router(self, name="orders", parent_router=self.api)
-
-        @route("users")
+    class Users(RoutingClass):
+        @route()
         def list_users(self):
             return ["alice", "bob"]
 
-        @route("orders")
+    class Orders(RoutingClass):
+        @route()
         def list_orders(self):
             return ["order1", "order2"]
+
+    class Service(RoutingClass):
+        def __init__(self):
+            self.users = Users()
+            self.orders = Orders()
+            self.attach_instance(self.users, name="users")
+            self.attach_instance(self.orders, name="orders")
 
     svc = Service()
 
     # Verify hierarchy structure via nodes()
-    info = svc.api.nodes()
+    info = svc.route.nodes()
     assert "users" in info.get("routers", {})
     assert "orders" in info.get("routers", {})
 
     # Verify path resolution works
-    assert svc.api.node("users/list_users")() == ["alice", "bob"]
-    assert svc.api.node("orders/list_orders")() == ["order1", "order2"]
+    assert svc.route.node("users/list_users")() == ["alice", "bob"]
+    assert svc.route.node("orders/list_orders")() == ["order1", "order2"]
 
 
 def test_include_router_on_nested_router():
     """Test include(Router) for direct router-to-router linking. Closes #28."""
 
     class SysApp(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def status(self):
             return "ok"
 
     class Server(RoutingClass):
         def __init__(self):
-            self.main = Router(self, name="main", branch=True)
-            self._sys = Router(self, name="_sys", parent_router=self.main)
+            self._sys = Section()
+            self.attach_instance(self._sys, name="_sys")
             self.swagger = SysApp()
-            self._sys.include(self.swagger.api, name="swagger")
+            self._sys.route.include(self.swagger.route, name="swagger")
 
     server = Server()
 
     # Reachable through hierarchy
-    assert server.main.node("_sys/swagger/status")() == "ok"
+    assert server.route.node("_sys/swagger/status")() == "ok"
 
-    # _routing_parent set on the owner
-    assert server.swagger._routing_parent is server
-
-    # default_router still works (only main is root)
-    assert server.default_router is server.main
+    # _routing_parent set on the owner (the Section owning the linking router)
+    assert server.swagger._routing_parent is server._sys
 
 
 def test_include_router_without_name_uses_router_name():
-    """Test include(Router) without name uses the router's name as alias."""
+    """Test include(Router) without name uses the router's name ("route") as alias."""
 
     class Child(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="billing")
-
-        @route("billing")
+        @route()
         def invoice(self):
             return "inv"
 
     class Parent(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
+        pass
 
     parent = Parent()
     child = Child()
-    parent.api.include(child.api)
-    assert parent.api.node("billing/invoice")() == "inv"
+    parent.route.include(child.route)
+    assert parent.route.node("route/invoice")() == "inv"
 
 
 def test_include_node_as_entry_alias():
     """Test include(RouterNode) creates an entry alias."""
 
     class Pagamenti(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def collega_a_fattura(self, pag_id, fat_id):
             return f"linked:{pag_id}-{fat_id}"
 
     class Fatture(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def lista(self):
             return "fatture"
 
@@ -711,47 +567,41 @@ def test_include_node_as_entry_alias():
     fat = Fatture()
 
     # Include the entry as alias
-    fat.api.include(pag.api.node("collega_a_fattura"), name="collega_pagamento")
+    fat.route.include(pag.route.node("collega_a_fattura"), name="collega_pagamento")
 
     # Original still works
-    assert pag.api.node("collega_a_fattura")(1, 2) == "linked:1-2"
+    assert pag.route.node("collega_a_fattura")(1, 2) == "linked:1-2"
 
     # Alias works on fatture
-    assert fat.api.node("collega_pagamento")(3, 4) == "linked:3-4"
+    assert fat.route.node("collega_pagamento")(3, 4) == "linked:3-4"
 
     # Original entries still there
-    assert fat.api.node("lista")() == "fatture"
+    assert fat.route.node("lista")() == "fatture"
 
 
 def test_include_node_requires_name():
     """Test include(RouterNode) raises ValueError without name."""
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def action(self):
             return "ok"
 
     svc = Svc()
-    other = Router(type("Dummy", (RoutingClass,), {"__init__": lambda s: None})(), name="x")
-    # Actually test with a real setup
     parent = Svc()
     with pytest.raises(ValueError, match="requires name"):
-        parent.api.include(svc.api.node("action"))
+        parent.route.include(svc.route.node("action"))
 
 
 def test_include_rejects_invalid_type():
     """Test include() raises TypeError for invalid source."""
 
     class Parent(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
+        pass
 
     parent = Parent()
     with pytest.raises(TypeError, match="Router or RouterNode"):
-        parent.api.include(object(), name="x")
+        parent.route.include(object(), name="x")
 
 
 def test_include_router_secondary_link_no_plugin_inheritance():
@@ -759,52 +609,49 @@ def test_include_router_secondary_link_no_plugin_inheritance():
     must NOT trigger plugin inheritance or change _routing_parent."""
 
     class Child(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def action(self):
             return "child"
 
-    class Parent(RoutingClass):
+    class MainParent(RoutingClass):
         def __init__(self):
-            self.main = Router(self, name="main").plug("logging")
-            self.alt = Router(self, name="alt")
+            self.route.plug("logging")
 
-    parent = Parent()
+    class AltParent(RoutingClass):
+        pass
+
+    main = MainParent()
+    alt = AltParent()
     child = Child()
 
     # Primary include — sets _routing_parent, inherits plugins
-    parent.main.include(child.api, name="primary")
-    assert child._routing_parent is parent
-    original_plugins = list(child.api._plugins) if hasattr(child.api, "_plugins") else []
+    main.route.include(child.route, name="primary")
+    assert child._routing_parent is main
+    original_plugins = list(child.route._plugins)
 
     # Secondary include — just a navigation link
-    parent.alt.include(child.api, name="secondary")
+    alt.route.include(child.route, name="secondary")
 
     # _routing_parent unchanged
-    assert child._routing_parent is parent
+    assert child._routing_parent is main
 
     # Both paths work
-    assert parent.main.node("primary/action")() == "child"
-    assert parent.alt.node("secondary/action")() == "child"
+    assert main.route.node("primary/action")() == "child"
+    assert alt.route.node("secondary/action")() == "child"
 
     # Plugins not duplicated on child
-    if hasattr(child.api, "_plugins"):
-        assert len(child.api._plugins) == len(original_plugins)
+    assert len(child.route._plugins) == len(original_plugins)
 
 
 def test_include_entry_alias_not_affected_by_dest_plugins():
     """An aliased entry must use the source router's plugins, not destination's."""
 
-    call_log = []
-
     class Svc(RoutingClass):
         def __init__(self, label):
             self.label = label
-            self.api = Router(self, name="api").plug("logging")
+            self.route.plug("logging")
 
-        @route("api")
+        @route()
         def action(self):
             return f"{self.label}:action"
 
@@ -812,64 +659,52 @@ def test_include_entry_alias_not_affected_by_dest_plugins():
     dest = Svc("dest")
 
     # Include source's entry as alias in dest
-    dest.api.include(source.api.node("action"), name="alias_action")
+    dest.route.include(source.route.node("action"), name="alias_action")
 
     # Alias executes the source's handler (bound to source instance)
-    assert dest.api.node("alias_action")() == "source:action"
+    assert dest.route.node("alias_action")() == "source:action"
 
     # Dest's own entry still works
-    assert dest.api.node("action")() == "dest:action"
+    assert dest.route.node("action")() == "dest:action"
 
 
 def test_include_entry_alias_survives_rebuild_handlers():
     """Alias entry's handler must not be overwritten by dest router's _rebuild_handlers."""
 
     class Source(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def compute(self):
             return "computed"
 
     class Dest(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def local(self):
             return "local"
 
     source = Source()
     dest = Dest()
 
-    dest.api.include(source.api.node("compute"), name="remote_compute")
+    dest.route.include(source.route.node("compute"), name="remote_compute")
 
     # Force rebuild
-    dest.api._rebuild_handlers()
+    dest.route._rebuild_handlers()
 
     # Alias still works with source's handler
-    assert dest.api.node("remote_compute")() == "computed"
+    assert dest.route.node("remote_compute")() == "computed"
     # Local still works
-    assert dest.api.node("local")() == "local"
+    assert dest.route.node("local")() == "local"
 
 
 def test_include_entry_alias_with_plugins_on_dest():
     """Adding a plugin to dest after including an alias must not wrap the alias."""
 
     class Source(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def handler(self):
             return "source"
 
     class Dest(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def local(self):
             return "local"
 
@@ -877,116 +712,95 @@ def test_include_entry_alias_with_plugins_on_dest():
     dest = Dest()
 
     # Include alias first
-    dest.api.include(source.api.node("handler"), name="remote")
+    dest.route.include(source.route.node("handler"), name="remote")
 
     # Add plugin to dest after alias
-    dest.api.plug("logging")
+    dest.route.plug("logging")
 
     # Alias entry should not have been decorated by dest's logging plugin
-    alias_entry = dest.api._entries["remote"]
-    assert alias_entry.router is source.api  # still owned by source
+    alias_entry = dest.route._entries["remote"]
+    assert alias_entry.router is source.route  # still owned by source
 
     # Both still work
-    assert dest.api.node("remote")() == "source"
-    assert dest.api.node("local")() == "local"
+    assert dest.route.node("remote")() == "source"
+    assert dest.route.node("local")() == "local"
 
 
 def test_include_router_collision():
     """include() of a Router with existing alias raises ValueError."""
 
     class Child1(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
+        pass
 
     class Child2(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
+        pass
 
     class Parent(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
+        pass
 
     parent = Parent()
-    parent.api.include(Child1().api, name="slot")
+    parent.route.include(Child1().route, name="slot")
     with pytest.raises(ValueError, match="Child name collision"):
-        parent.api.include(Child2().api, name="slot")
+        parent.route.include(Child2().route, name="slot")
 
 
 def test_include_entry_collision():
     """include() of a RouterNode with existing entry name raises ValueError."""
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def action(self):
             return "svc"
 
     class Other(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def action(self):
             return "other"
 
     svc = Svc()
     other = Other()
     with pytest.raises(ValueError, match="Entry name collision"):
-        svc.api.include(other.api.node("action"), name="action")
+        svc.route.include(other.route.node("action"), name="action")
 
 
 def test_include_same_router_twice_is_idempotent():
     """Including the same Router with the same alias twice is a no-op."""
 
     class Child(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def action(self):
             return "ok"
 
     class Parent(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
+        pass
 
     parent = Parent()
     child = Child()
-    parent.api.include(child.api, name="child")
-    parent.api.include(child.api, name="child")  # no error
-    assert parent.api.node("child/action")() == "ok"
+    parent.route.include(child.route, name="child")
+    parent.route.include(child.route, name="child")  # no error
+    assert parent.route.node("child/action")() == "ok"
 
 
 def test_include_entry_from_deep_path():
     """include() with a node resolved from a deep hierarchy path."""
 
     class Deep(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def deep_action(self):
             return "deep"
 
     class Mid(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api")
             self.deep = Deep()
             self.attach_instance(self.deep, name="deep")
 
     class Root(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api")
             self.mid = Mid()
             self.attach_instance(self.mid, name="mid")
 
     class Other(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def local(self):
             return "local"
 
@@ -994,90 +808,78 @@ def test_include_entry_from_deep_path():
     other = Other()
 
     # Include a deep entry as alias
-    other.api.include(root.api.node("mid/deep/deep_action"), name="shortcut")
+    other.route.include(root.route.node("mid/deep/deep_action"), name="shortcut")
 
-    assert other.api.node("shortcut")() == "deep"
-    assert other.api.node("local")() == "local"
+    assert other.route.node("shortcut")() == "deep"
+    assert other.route.node("local")() == "local"
 
 
 def test_include_node_with_error_raises():
     """include() with a RouterNode that has an error raises ValueError."""
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
+        pass
 
     svc = Svc()
-    node = svc.api.node("nonexistent")  # error node
+    node = svc.route.node("nonexistent")  # error node
     with pytest.raises(ValueError, match="no entry resolved"):
-        svc.api.include(node, name="alias")
+        svc.route.include(node, name="alias")
 
 
 def test_get_url_with_endpoint_id():
     """Test get_url resolves @endpoint_id and appends positional params."""
 
     class Invoices(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api", endpoint_id="invoice.list")
+        @route(endpoint_id="invoice.list")
         def list(self):
             return "list"
 
-        @route("api", endpoint_id="invoice.detail")
+        @route(endpoint_id="invoice.detail")
         def detail(self, invoice_id):
             return f"detail:{invoice_id}"
 
     class App(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api")
             self.invoices = Invoices()
             self.attach_instance(self.invoices, name="invoices")
 
     app = App()
 
     # Without params
-    assert app.api.get_url("@invoice.list") == "invoices/list"
+    assert app.route.get_url("@invoice.list") == "invoices/list"
 
     # With positional param
-    assert app.api.get_url("@invoice.detail", invoice_id=123) == "invoices/detail/123"
+    assert app.route.get_url("@invoice.detail", invoice_id=123) == "invoices/detail/123"
 
 
 def test_get_url_with_path():
     """Test get_url with a regular path (not endpoint_id)."""
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def action(self, xx, yy):
             return f"{xx}:{yy}"
 
     class App(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api")
             self.svc = Svc()
             self.attach_instance(self.svc, name="svc")
 
     app = App()
-    assert app.api.get_url("svc/action", xx=23, yy="abc") == "svc/action/23/abc"
+    assert app.route.get_url("svc/action", xx=23, yy="abc") == "svc/action/23/abc"
 
 
 def test_get_url_preserves_param_order():
     """get_url appends params in signature order, regardless of kwarg order."""
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def handler(self, first, second, third):
             pass
 
     svc = Svc()
     # Pass kwargs in reverse order
-    url = svc.api.get_url("handler", third="c", first="a", second="b")
+    url = svc.route.get_url("handler", third="c", first="a", second="b")
     assert url == "handler/a/b/c"
 
 
@@ -1085,150 +887,75 @@ def test_get_url_partial_params():
     """get_url with only some params appends only those present."""
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def handler(self, required, optional="default"):
             pass
 
     svc = Svc()
-    assert svc.api.get_url("handler", required=42) == "handler/42"
-    assert svc.api.get_url("handler", required=42, optional="x") == "handler/42/x"
+    assert svc.route.get_url("handler", required=42) == "handler/42"
+    assert svc.route.get_url("handler", required=42, optional="x") == "handler/42/x"
 
 
 def test_get_url_no_params():
     """get_url without params returns just the path."""
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def simple(self):
             return "ok"
 
     svc = Svc()
-    assert svc.api.get_url("simple") == "simple"
+    assert svc.route.get_url("simple") == "simple"
 
 
 def test_get_url_invalid_path():
     """get_url raises ValueError for non-existent path."""
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
+        pass
 
     svc = Svc()
     with pytest.raises(ValueError, match="does not resolve"):
-        svc.api.get_url("nonexistent")
+        svc.route.get_url("nonexistent")
 
 
 def test_get_url_deep_hierarchy():
     """get_url works through deep hierarchies."""
 
     class Deep(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api", endpoint_id="deep.action")
+        @route(endpoint_id="deep.action")
         def action(self, x, y):
             return f"{x}:{y}"
 
     class Mid(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api")
             self.deep = Deep()
             self.attach_instance(self.deep, name="deep")
 
     class Root(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api")
             self.mid = Mid()
             self.attach_instance(self.mid, name="mid")
 
     root = Root()
 
     # Via path
-    assert root.api.get_url("mid/deep/action", x=1, y=2) == "mid/deep/action/1/2"
+    assert root.route.get_url("mid/deep/action", x=1, y=2) == "mid/deep/action/1/2"
 
     # Via endpoint_id
-    assert root.api.get_url("@deep.action", x=1, y=2) == "mid/deep/action/1/2"
+    assert root.route.get_url("@deep.action", x=1, y=2) == "mid/deep/action/1/2"
 
 
 def test_get_url_ignores_keyword_only_params():
     """get_url does not append keyword-only params to the path."""
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def handler(self, pos_param, *, kw_only="default"):
             pass
 
     svc = Svc()
-    assert svc.api.get_url("handler", pos_param=10, kw_only="ignore") == "handler/10"
-
-
-def test_parent_router_child_not_in_owner_routers():
-    """Test that a router with parent_router is NOT registered in owner._routers.
-
-    Closes #27: child routers created with parent_router are internal structure,
-    not root routers. They must not appear in _routers, so default_router
-    returns the single root and name= shortcut works in attach_instance.
-    """
-
-    class MyApp(RoutingClass):
-        def __init__(self):
-            self.main = Router(self, name="main", branch=True)
-            self._meta = Router(self, name="_meta", parent_router=self.main)
-
-        @route("_meta")
-        def info(self):
-            return "meta"
-
-    app = MyApp()
-
-    # _routers contains only the root
-    assert list(app._routers.keys()) == ["main"]
-    assert "_meta" not in app._routers
-
-    # default_router works (single root)
-    assert app.default_router is app.main
-
-    # child is in parent's _children
-    assert "_meta" in app.main._children
-
-    # path resolution works through the hierarchy
-    assert app.main.node("_meta/info")() == "meta"
-
-
-def test_parent_router_requires_name():
-    """Test that parent_router raises ValueError if child has no name."""
-
-    class Owner(RoutingClass):
-        pass
-
-    owner = Owner()
-    parent = Router(owner, name="parent", branch=True)
-
-    with pytest.raises(ValueError, match="must have a name"):
-        Router(owner, parent_router=parent)
-
-
-def test_parent_router_detects_collision():
-    """Test that parent_router raises ValueError on name collision."""
-
-    class Owner(RoutingClass):
-        pass
-
-    owner = Owner()
-    parent = Router(owner, name="parent", branch=True)
-    Router(owner, name="child", parent_router=parent)
-
-    with pytest.raises(ValueError, match="collision"):
-        Router(owner, name="child", parent_router=parent)
+    assert svc.route.get_url("handler", pos_param=10, kw_only="ignore") == "handler/10"
 
 
 def _make_router_for_plugin_test():
@@ -1237,7 +964,7 @@ def _make_router_for_plugin_test():
     class Owner(RoutingClass):
         pass
 
-    return Router(Owner(), name="test")
+    return Owner().route
 
 
 def test_base_plugin_default_hooks():
@@ -1355,36 +1082,35 @@ def test_router_get_config_paths():
 
     class Service(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("cfgplug", mode="x")
+            self.route.plug("cfgplug", mode="x")
             # Per-handler config via configure()
-            self.api._plugins_by_name["cfgplug"].configure(_target="hello", trace=True)
+            self.route._plugins_by_name["cfgplug"].configure(_target="hello", trace=True)
 
-        @route("api")
+        @route()
         def hello(self):
             return "ok"
 
     svc = Service()
-    assert svc.api.get_config("cfgplug")["mode"] == "x"
-    merged = svc.api.get_config("cfgplug", "hello")
+    assert svc.route.get_config("cfgplug")["mode"] == "x"
+    merged = svc.route.get_config("cfgplug", "hello")
     assert merged["mode"] == "x" and merged["trace"] is True
     with pytest.raises(AttributeError):
-        svc.api.get_config("missing")
+        svc.route.get_config("missing")
 
 
 def test_routed_proxy_get_router_handles_dotted_path():
     class Leaf(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="leaf")
+        pass
 
     class Parent(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api")
             self.child = Leaf()
-            self.api._children["child"] = self.child.api  # direct attach for test
+            self.route._children["child"] = self.child.route  # direct attach for test
 
     svc = Parent()
-    router = svc.routing.get_router("api/child")
-    assert router.name == "leaf"
+    router = svc.routing.get_router("child")
+    assert router is svc.child.route
+    assert router.name == "route"
 
 
 def test_routed_configure_updates_plugins_global_and_local():
@@ -1392,34 +1118,34 @@ def test_routed_configure_updates_plugins_global_and_local():
 
     class ConfService(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("simple")
+            self.route.plug("simple")
 
-        @route("api")
+        @route()
         def foo(self):
             return "foo"
 
-        @route("api")
+        @route()
         def bar(self):
             return "bar"
 
     svc = ConfService()
-    svc.api.nodes()  # Trigger lazy binding before configure
-    svc.routing.configure("api:simple/_all_", threshold=10)
-    assert svc.api.simple.configuration()["threshold"] == 10
+    svc.route.nodes()  # Trigger lazy binding before configure
+    svc.routing.configure("simple/_all_", threshold=10)
+    assert svc.route.simple.configuration()["threshold"] == 10
 
-    svc.routing.configure("api:simple/foo", enabled=False)
-    assert svc.api.simple.configuration("foo")["enabled"] is False
+    svc.routing.configure("simple/foo", enabled=False)
+    assert svc.route.simple.configuration("foo")["enabled"] is False
 
-    svc.routing.configure("api:simple/b*", mode="strict")
-    assert svc.api.simple.configuration("bar")["mode"] == "strict"
+    svc.routing.configure("simple/b*", mode="strict")
+    assert svc.route.simple.configuration("bar")["mode"] == "strict"
 
     payload = [
-        {"target": "api:simple/_all_", "flags": "trace"},
-        {"target": "api:simple/foo", "limit": 5},
+        {"target": "simple/_all_", "flags": "trace"},
+        {"target": "simple/foo", "limit": 5},
     ]
     result = svc.routing.configure(payload)
     assert len(result) == 2
-    assert svc.api.simple.configuration("foo")["limit"] == 5
+    assert svc.route.simple.configuration("foo")["limit"] == 5
 
 
 def test_routed_configure_question_lists_tree():
@@ -1427,14 +1153,15 @@ def test_routed_configure_question_lists_tree():
 
     class Root(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("simple")
+            self.route.plug("simple")
 
-        @route("api")
+        @route()
         def root_ping(self):
             return "root"
 
     svc = Root()
     info = svc.routing.configure("?")
-    assert "api" in info
-    assert info["api"]["plugins"]
-    assert info["api"]["routers"] == {}
+    assert info["name"] == "route"
+    assert info["plugins"]
+    assert "root_ping" in info["entries"]
+    assert info["routers"] == {}

--- a/tests/test_router_filters_and_validation.py
+++ b/tests/test_router_filters_and_validation.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import pytest
 
-from genro_routes import RoutingClass, Router
+from genro_routes import Router, RoutingClass
 from genro_routes.plugins._base_plugin import BasePlugin, MethodEntry
 
 
@@ -48,7 +48,7 @@ def _make_router():
     class Owner(RoutingClass):
         pass
 
-    return Router(Owner(), name="api")
+    return Owner().route
 
 
 def test_nodes_entry_extra_rejects_non_dict_from_plugin():

--- a/tests/test_router_runtime_extras.py
+++ b/tests/test_router_runtime_extras.py
@@ -45,10 +45,7 @@ class _FullUser(TypedDict):
 
 
 class ManualService(RoutingClass):
-    """Service with manual router registration."""
-
-    def __init__(self):
-        self.api = Router(self, name="api")
+    """Service using the auto-created single router."""
 
     def first(self):
         return "first"
@@ -56,40 +53,20 @@ class ManualService(RoutingClass):
     def second(self):
         return "second"
 
-    @route("api", marker="yes")
+    @route(marker="yes")
     def auto(self):
         return "auto"
-
-
-class DualRoutes(RoutingClass):
-    def __init__(self):
-        self.one = Router(self, name="one")
-        self.two = Router(self, name="two")
-
-    @route("one")
-    @route("two", name="two_alias")
-    def shared(self):
-        return "shared"
-
-
-class MultiChild(RoutingClass):
-    def __init__(self):
-        self.router_a = Router(self, name="router_a")
-        self.router_b = Router(self, name="router_b")
 
 
 class SlotRouted(RoutingClass):
     __slots__ = ("slot_router",)
 
     def __init__(self):
-        self.slot_router = Router(self, name="slot")
+        self.slot_router = Router(self)
 
 
 class DuplicateMarkers(RoutingClass):
-    def __init__(self):
-        self.api = Router(self, name="api")
-
-    @route("api")
+    @route()
     def original(self):
         return "ok"
 
@@ -110,9 +87,9 @@ if "stamp_extra" not in Router.available_plugins():
 
 class LoggingService(RoutingClass):
     def __init__(self):
-        self.api = Router(self, name="api").plug("logging")
+        self.route.plug("logging")
 
-    @route("api")
+    @route()
     def hello(self):
         return "ok"
 
@@ -120,6 +97,14 @@ class LoggingService(RoutingClass):
 def test_router_requires_owner():
     with pytest.raises(ValueError):
         Router(None)  # type: ignore[arg-type]
+
+
+def test_router_rejects_second_router():
+    """Creating a Router on an owner whose router already exists raises."""
+    svc = ManualService()
+    _ = svc.route  # ensure router exists
+    with pytest.raises(ValueError, match="already has a router"):
+        Router(svc)
 
 
 def test_register_plugin_requires_plugin_code():
@@ -133,53 +118,53 @@ def test_register_plugin_requires_plugin_code():
 def test_plug_validates_type_and_known_plugin():
     svc = ManualService()
     with pytest.raises(TypeError):
-        svc.api.plug(object())  # type: ignore[arg-type]
+        svc.route.plug(object())  # type: ignore[arg-type]
     with pytest.raises(ValueError):
-        svc.api.plug("missing_plugin")
+        svc.route.plug("missing_plugin")
 
 
 def test_plug_rejects_duplicate_plugin():
     """Plugging the same plugin twice should raise ValueError."""
     svc = ManualService()
-    svc.api.plug("logging")
+    svc.route.plug("logging")
     with pytest.raises(ValueError, match="already attached"):
-        svc.api.plug("logging")
+        svc.route.plug("logging")
 
 
 def test_add_entry_variants_and_wildcards():
     svc = ManualService()
-    svc.api.add_entry(["first", "second"])
-    assert "first" in svc.api._entries
-    assert "second" in svc.api._entries
+    svc.route.add_entry(["first", "second"])
+    assert "first" in svc.route._entries
+    assert "second" in svc.route._entries
 
-    svc.api.add_entry("first, second", replace=True)
-    before = set(svc.api._entries.keys())
-    assert svc.api.add_entry("   ") is svc.api
-    assert set(svc.api._entries.keys()) == before
+    svc.route.add_entry("first, second", replace=True)
+    before = set(svc.route._entries.keys())
+    assert svc.route.add_entry("   ") is svc.route
+    assert set(svc.route._entries.keys()) == before
 
     with pytest.raises(TypeError):
-        svc.api.add_entry(123)
+        svc.route.add_entry(123)
 
     # Use replace=True since "auto" was already registered by lazy binding
-    svc.api.add_entry("*", metadata={"source": "wild"}, replace=True)
-    entry = svc.api._entries["auto"]
+    svc.route.add_entry("*", metadata={"source": "wild"}, replace=True)
+    entry = svc.route._entries["auto"]
     assert entry.metadata["marker"] == "yes"
     assert entry.metadata["source"] == "wild"
 
 
 def test_plugin_on_decore_runs_for_existing_entries():
     svc = ManualService()
-    svc.api.plug("stamp_extra")
-    svc.api.add_entry(svc.first, name="alias_first")
-    assert svc.api._entries["alias_first"].metadata["stamped"] is True
+    svc.route.plug("stamp_extra")
+    svc.route.add_entry(svc.first, name="alias_first")
+    assert svc.route._entries["alias_first"].metadata["stamped"] is True
 
 
 def test_iter_marked_methods_deduplicate_same_function():
     """Test that duplicate markers on same function don't cause double registration."""
     svc = DuplicateMarkers()
-    assert svc.api.node("original")() == "ok"
+    assert svc.route.node("original")() == "ok"
     # Verify only one entry via nodes()
-    info = svc.api.nodes()
+    info = svc.route.nodes()
     assert len(info.get("entries", {})) == 1
 
 
@@ -192,9 +177,6 @@ def test_mro_override_derived_wins():
     """
 
     class Base(RoutingClass):
-        def __init__(self):
-            self.main = Router(self, name="main")
-
         @route()
         def index(self):
             return "BASE"
@@ -207,9 +189,9 @@ def test_mro_override_derived_wins():
     # Should not raise ValueError: Handler name collision
     d = Derived()
     # Derived.index should be used, not Base.index
-    assert d.main.node("index")() == "DERIVED"
+    assert d.route.node("index")() == "DERIVED"
     # Verify only one entry registered
-    info = d.main.nodes()
+    info = d.route.nodes()
     assert len(info.get("entries", {})) == 1
 
 
@@ -217,8 +199,8 @@ def test_router_node_and_nodes_structure():
     """Test node() and nodes() work correctly."""
     svc = ManualService()
     # auto is marked with @route, so it's available
-    assert svc.api.node("auto")() == "auto"
-    tree = svc.api.nodes()
+    assert svc.route.node("auto")() == "auto"
+    tree = svc.route.nodes()
     assert tree["entries"]
     assert "routers" not in tree
 
@@ -226,38 +208,38 @@ def test_router_node_and_nodes_structure():
 def test_inherit_plugins_branches():
     parent = ManualService()
     child = ManualService()
-    parent.api.plug("stamp_extra")
-    before = len(child.api._plugins_by_name)
-    child.api._on_attached_to_parent(parent.api)
-    after = len(child.api._plugins_by_name)
+    parent.route.plug("stamp_extra")
+    before = len(child.route._plugins_by_name)
+    child.route._on_attached_to_parent(parent.route)
+    after = len(child.route._plugins_by_name)
     assert after > before
-    child.api._on_attached_to_parent(parent.api)
-    assert len(child.api._plugins_by_name) == after
+    child.route._on_attached_to_parent(parent.route)
+    assert len(child.route._plugins_by_name) == after
     # Force missing plugin bucket to exercise seed path
-    parent.api._plugin_info.pop("stamp_extra", None)
-    child.api._on_attached_to_parent(parent.api)
+    parent.route._plugin_info.pop("stamp_extra", None)
+    child.route._on_attached_to_parent(parent.route)
 
     orphan = ManualService()
     plain = ManualService()
-    plain_before = len(orphan.api._plugins_by_name)
-    orphan.api._on_attached_to_parent(plain.api)
-    assert len(orphan.api._plugins_by_name) == plain_before
+    plain_before = len(orphan.route._plugins_by_name)
+    orphan.route._on_attached_to_parent(plain.route)
+    assert len(orphan.route._plugins_by_name) == plain_before
 
 
 def test_inherit_plugins_seed_from_empty_parent_bucket():
     parent = ManualService()
-    parent.api.plug("stamp_extra")
-    parent.api._plugin_info.pop("stamp_extra", None)
+    parent.route.plug("stamp_extra")
+    parent.route._plugin_info.pop("stamp_extra", None)
     child = ManualService()
-    child.api._on_attached_to_parent(parent.api)
+    child.route._on_attached_to_parent(parent.route)
     # Config is now a callable lookup, verify plugin is accessible
-    assert "stamp_extra" in child.api._plugins_by_name
+    assert "stamp_extra" in child.route._plugins_by_name
 
 
 def test_router_nodes_include_metadata_tree():
     parent = ManualService()
-    parent.api.add_entry(parent.first)
-    info = parent.api.nodes()
+    parent.route.add_entry(parent.first)
+    info = parent.route.nodes()
     assert "entries" in info
 
 
@@ -265,59 +247,52 @@ def test_router_nodes_with_basepath():
     """Test nodes() with basepath navigates to child router."""
 
     class Child(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def child_action(self):
             return "child"
 
     class Grandchild(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def grandchild_action(self):
             return "grandchild"
 
     class Root(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api")
             self.child = Child()
             self.child.grandchild = Grandchild()
             self.attach_instance(self.child, name="child")
             self.child.attach_instance(self.child.grandchild, name="grandchild")
 
-        @route("api")
+        @route()
         def root_action(self):
             return "root"
 
     root = Root()
 
     # Without basepath - returns full tree
-    full = root.api.nodes()
+    full = root.route.nodes()
     assert "root_action" in full["entries"]
     assert "child" in full["routers"]
 
     # With basepath="child" - returns child subtree
-    child_nodes = root.api.nodes(basepath="child")
-    assert child_nodes["name"] == "api"
+    child_nodes = root.route.nodes(basepath="child")
+    assert child_nodes["name"] == "route"
     assert "child_action" in child_nodes["entries"]
     assert "grandchild" in child_nodes["routers"]
     assert "root_action" not in child_nodes.get("entries", {})
 
     # With basepath="child/grandchild" - returns grandchild subtree
-    grandchild_nodes = root.api.nodes(basepath="child/grandchild")
-    assert grandchild_nodes["name"] == "api"
+    grandchild_nodes = root.route.nodes(basepath="child/grandchild")
+    assert grandchild_nodes["name"] == "route"
     assert "grandchild_action" in grandchild_nodes["entries"]
     assert "routers" not in grandchild_nodes  # no children
 
     # With basepath pointing to a handler - returns empty dict
-    handler_nodes = root.api.nodes(basepath="root_action")
+    handler_nodes = root.route.nodes(basepath="root_action")
     assert handler_nodes == {}
 
     # With basepath pointing to non-existent path - returns empty dict
-    missing_nodes = root.api.nodes(basepath="nonexistent")
+    missing_nodes = root.route.nodes(basepath="nonexistent")
     assert missing_nodes == {}
 
 
@@ -325,32 +300,28 @@ def test_nodes_lazy_returns_router_references():
     """Test nodes(lazy=True) returns router references for child routers."""
 
     class Child(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def child_action(self):
             return "child"
 
     class Root(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api")
             self.child = Child()
             self.attach_instance(self.child, name="child")
 
-        @route("api")
+        @route()
         def root_action(self):
             return "root"
 
     root = Root()
 
     # Without lazy - routers dict contains expanded nodes
-    full = root.api.nodes()
+    full = root.route.nodes()
     assert isinstance(full["routers"]["child"], dict)
     assert "child_action" in full["routers"]["child"]["entries"]
 
     # With lazy=True - routers dict contains router references (not expanded)
-    lazy_nodes = root.api.nodes(lazy=True)
+    lazy_nodes = root.route.nodes(lazy=True)
     child_router = lazy_nodes["routers"]["child"]
     assert isinstance(child_router, Router)
 
@@ -360,7 +331,7 @@ def test_nodes_lazy_returns_router_references():
     assert "child_action" in child_nodes["entries"]
 
     # Or use basepath from parent
-    child_via_basepath = root.api.nodes(basepath="child")
+    child_via_basepath = root.route.nodes(basepath="child")
     assert "child_action" in child_via_basepath["entries"]
 
 
@@ -368,21 +339,17 @@ def test_openapi_returns_schema():
     """Test openapi() returns OpenAPI-compatible schema."""
 
     class Child(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def get_user(self, user_id: int, name: str = "default") -> dict:
             """Get a user by ID."""
             return {"id": user_id, "name": name}
 
     class Root(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api")
             self.child = Child()
             self.attach_instance(self.child, name="users")
 
-        @route("api")
+        @route()
         def health(self) -> str:
             """Health check endpoint."""
             return "ok"
@@ -390,7 +357,7 @@ def test_openapi_returns_schema():
     root = Root()
 
     # Full schema (non-lazy)
-    schema = root.api.nodes(mode="openapi")
+    schema = root.route.nodes(mode="openapi")
     assert "paths" in schema
     assert "/health" in schema["paths"]
     assert "/users/get_user" in schema["paths"]
@@ -410,33 +377,29 @@ def test_openapi_lazy_returns_router_references():
     """Test openapi(lazy=True) returns router references for child routers."""
 
     class Child(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def action(self):
             return "child"
 
     class Root(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api")
             self.child = Child()
             self.attach_instance(self.child, name="child")
 
-        @route("api")
+        @route()
         def root_action(self):
             return "root"
 
     root = Root()
 
     # Lazy mode - returns router references
-    lazy_schema = root.api.nodes(mode="openapi", lazy=True)
+    lazy_schema = root.route.nodes(mode="openapi", lazy=True)
     assert "/root_action" in lazy_schema["paths"]
     assert "routers" in lazy_schema
     assert isinstance(lazy_schema["routers"]["child"], Router)
 
     # Expand child via basepath - paths are absolute from root
-    child_schema = root.api.nodes(basepath="child", mode="openapi")
+    child_schema = root.route.nodes(basepath="child", mode="openapi")
     assert "/child/action" in child_schema["paths"]
 
 
@@ -444,27 +407,23 @@ def test_openapi_with_basepath():
     """Test openapi(basepath=...) navigates to child with absolute paths."""
 
     class Child(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def child_action(self):
             return "child"
 
     class Root(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api")
             self.child = Child()
             self.attach_instance(self.child, name="child")
 
-        @route("api")
+        @route()
         def root_action(self):
             return "root"
 
     root = Root()
 
     # Get schema starting from child - paths include basepath prefix (issue #16)
-    child_schema = root.api.nodes(mode="openapi", basepath="child")
+    child_schema = root.route.nodes(mode="openapi", basepath="child")
     assert "/child/child_action" in child_schema["paths"]
     assert "/root_action" not in child_schema.get("paths", {})
 
@@ -478,26 +437,22 @@ def test_openapi_basepath_absolute_paths_issue_16():
     """
 
     class PurchaseService(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def list(self) -> list:
             """List all purchases."""
             return []
 
-        @route("api")
+        @route()
         def create(self, item: str, qty: int = 1) -> dict:
             """Create a purchase."""
             return {"item": item, "qty": qty}
 
     class Shop(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api")
             self.purchase = PurchaseService()
             self.attach_instance(self.purchase, name="purchase")
 
-        @route("api")
+        @route()
         def info(self) -> dict:
             """Shop info."""
             return {"name": "My Shop"}
@@ -505,7 +460,7 @@ def test_openapi_basepath_absolute_paths_issue_16():
     shop = Shop()
 
     # Get OpenAPI for purchase subtree via basepath
-    purchase_schema = shop.api.nodes(basepath="purchase", mode="openapi")
+    purchase_schema = shop.route.nodes(basepath="purchase", mode="openapi")
 
     # Paths must be absolute from root (include /purchase prefix)
     assert "/purchase/list" in purchase_schema["paths"]
@@ -536,52 +491,41 @@ def test_configure_validates_inputs_and_targets():
     with pytest.raises(ValueError):
         svc.routing.configure("?", foo="bar")
     with pytest.raises(ValueError):
-        svc.routing.configure("missingcolon", mode="x")
-    with pytest.raises(ValueError):
-        svc.routing.configure(":logging/_all_", mode="x")
-    with pytest.raises(ValueError):
-        svc.routing.configure("api:/_all_", mode="x")
+        svc.routing.configure("/_all_", mode="x")
     with pytest.raises(AttributeError):
-        svc.routing.configure("api:ghost/_all_", flags="on")
+        svc.routing.configure("ghost/_all_", flags="on")
     with pytest.raises(ValueError):
-        svc.routing.configure("api:logging/_all_")
+        svc.routing.configure("logging/_all_")
     with pytest.raises(KeyError):
-        svc.routing.configure("api:logging/missing*", flags="before")
-    result = svc.routing.configure("api:logging", flags="before")
+        svc.routing.configure("logging/missing*", flags="before")
+    result = svc.routing.configure("logging", flags="before")
     assert result["updated"] == ["_all_"]
 
 
 def test_configure_question_success_and_router_proxy_errors():
     svc = LoggingService()
-    tree = svc.routing.configure("?")
-    assert "api" in tree
-    with pytest.raises(AttributeError):
+    description = svc.routing.configure("?")
+    assert description["name"] == "route"
+    assert "hello" in description["entries"]
+    assert any(plugin["name"] == "logging" for plugin in description["plugins"])
+    with pytest.raises(KeyError):
         svc.routing.get_router("missing")
-    svc._routers.pop("api")
-    router = svc.routing.get_router("api")
-    assert router is svc.api
-
-
-def test_iter_registered_routers_lists_entries():
-    svc = ManualService()
-    pairs = list(svc._iter_registered_routers())
-    assert pairs and pairs[0][0] == "api"
+    router = svc.routing.get_router()
+    assert router is svc.route
 
 
 def test_get_router_skips_empty_segments():
     class Leaf(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="leaf")
+        pass
 
     class Parent(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api")
             self.child = Leaf()
-            self.api._children["child"] = self.child.api  # direct attach for test
+            self.route._children["child"] = self.child.route  # direct attach for test
 
     svc = Parent()
-    router = svc.routing.get_router("api/child//")
-    assert router.name == "leaf"
+    router = svc.routing.get_router("child//")
+    assert router is svc.child.route
 
 
 def test_is_routing_class_helper():
@@ -594,21 +538,18 @@ def test_openapi_basepath_to_handler_returns_empty():
     """Test openapi(basepath=...) returns empty when pointing to handler."""
 
     class Root(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def action(self):
             return "ok"
 
     root = Root()
 
     # basepath pointing to handler returns empty (handler is not a router)
-    result = root.api.nodes(mode="openapi", basepath="action")
+    result = root.route.nodes(mode="openapi", basepath="action")
     assert result == {}
 
     # basepath pointing to non-existent path also returns empty
-    result = root.api.nodes(mode="openapi", basepath="nonexistent")
+    result = root.route.nodes(mode="openapi", basepath="nonexistent")
     assert result == {}
 
 
@@ -617,15 +558,15 @@ def test_openapi_with_pydantic_model():
 
     class Service(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("pydantic")
+            self.route.plug("pydantic")
 
-        @route("api")
+        @route()
         def get_user(self, user_id: int, name: str = "default") -> dict:
             """Get a user by ID."""
             return {"id": user_id, "name": name}
 
     svc = Service()
-    schema = svc.api.nodes(mode="openapi")
+    schema = svc.route.nodes(mode="openapi")
 
     # Should have parameters with pydantic schema
     # Method is GET because all params are scalar
@@ -643,16 +584,13 @@ def test_openapi_handler_without_type_hints():
     """Test openapi() handles handlers without type hints."""
 
     class Service(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def no_hints(self, arg):
             """No type hints here."""
             return arg
 
     svc = Service()
-    schema = svc.api.nodes(mode="openapi")
+    schema = svc.route.nodes(mode="openapi")
 
     path_item = schema["paths"]["/no_hints"]
     # Without type hints, get_type_hints returns empty → no typed params → GET
@@ -666,15 +604,12 @@ def test_openapi_type_conversion():
     """Test pydantic schema handles various types in requestBody."""
 
     class Service(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def typed_params(self, s: str, i: int, f: float, b: bool, items: list, data: dict) -> str:
             return "ok"
 
     svc = Service()
-    schema = svc.api.nodes(mode="openapi")
+    schema = svc.route.nodes(mode="openapi")
 
     # POST uses requestBody with pydantic schema
     operation = schema["paths"]["/typed_params"]["post"]
@@ -694,15 +629,12 @@ def test_openapi_generic_types():
     """Test pydantic schema handles generic types like list[str]."""
 
     class Service(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def generic_params(self, items: list[str], data: dict[str, int]) -> list[str]:
             return items
 
     svc = Service()
-    schema = svc.api.nodes(mode="openapi")
+    schema = svc.route.nodes(mode="openapi")
 
     # POST uses requestBody with pydantic schema
     operation = schema["paths"]["/generic_params"]["post"]
@@ -721,15 +653,12 @@ def test_openapi_unknown_type_graceful_fallback():
         pass
 
     class Service(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def custom_param(self, obj: CustomType) -> CustomType:
             return obj
 
     svc = Service()
-    schema = svc.api.nodes(mode="openapi")
+    schema = svc.route.nodes(mode="openapi")
 
     # Pydantic can't handle arbitrary types without special config
     # So operation won't have requestBody, but should still work
@@ -743,15 +672,12 @@ def test_openapi_required_vs_optional_params():
     """Test openapi correctly marks required vs optional in query parameters."""
 
     class Service(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def mixed_params(self, required: int, optional: str = "default"):
             return "ok"
 
     svc = Service()
-    schema = svc.api.nodes(mode="openapi")
+    schema = svc.route.nodes(mode="openapi")
 
     # Scalar params → GET with query parameters
     operation = schema["paths"]["/mixed_params"]["get"]
@@ -770,17 +696,14 @@ def test_openapi_handles_broken_type_hints():
     """Test openapi() gracefully handles functions with unresolvable type hints."""
 
     class Service(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def handler(self):
             return "ok"
 
     svc = Service()
 
     # Manually break the function's type hints by adding unresolvable annotation
-    entry = svc.api._entries["handler"]
+    entry = svc.route._entries["handler"]
     original_func = entry.func
 
     # Create a wrapper with broken annotations
@@ -791,7 +714,7 @@ def test_openapi_handles_broken_type_hints():
     entry.func = broken_hints
 
     # Should not raise, should fall back gracefully
-    schema = svc.api.nodes(mode="openapi")
+    schema = svc.route.nodes(mode="openapi")
     assert "/handler" in schema["paths"]
 
     # Restore
@@ -802,17 +725,14 @@ def test_openapi_handles_hint_param_mismatch():
     """Test openapi() when type hint references non-existent parameter."""
 
     class Service(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def handler(self, real_param: int):
             return "ok"
 
     svc = Service()
 
     # Manually modify the entry's func annotations to have a mismatch
-    entry = svc.api._entries["handler"]
+    entry = svc.route._entries["handler"]
     original_func = entry.func
 
     # Create a function with mismatched hint/signature
@@ -824,7 +744,7 @@ def test_openapi_handles_hint_param_mismatch():
     entry.func = mismatched
 
     # Should not raise, should skip the mismatched param
-    schema = svc.api.nodes(mode="openapi")
+    schema = svc.route.nodes(mode="openapi")
     # Scalar param hint → GET (even if mismatched)
     operation = schema["paths"]["/handler"]["get"]
     # No parameters should be added since ghost_param isn't in signature
@@ -838,17 +758,14 @@ def test_nodes_unknown_mode_raises():
     """Test that nodes(mode='unknown') raises ValueError."""
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def handler(self):
             pass
 
     svc = Svc()
 
     with pytest.raises(ValueError, match="Unknown mode: unknown"):
-        svc.api.nodes(mode="unknown")
+        svc.route.nodes(mode="unknown")
 
 
 # -----------------------------------------------------------------------------
@@ -860,21 +777,17 @@ def test_h_openapi_returns_hierarchical_schema():
     """Test h_openapi mode returns nested OpenAPI structure."""
 
     class Child(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def get_user(self, user_id: int) -> dict:
             """Get a user by ID."""
             return {"id": user_id}
 
     class Root(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api")
             self.child = Child()
             self.attach_instance(self.child, name="users")
 
-        @route("api")
+        @route()
         def health(self) -> str:
             """Health check endpoint."""
             return "ok"
@@ -882,7 +795,7 @@ def test_h_openapi_returns_hierarchical_schema():
     root = Root()
 
     # Hierarchical schema
-    schema = root.api.nodes(mode="h_openapi")
+    schema = root.route.nodes(mode="h_openapi")
 
     # Root level has paths for its own entries
     assert "paths" in schema
@@ -904,44 +817,39 @@ def test_h_openapi_vs_openapi_comparison():
     """Test difference between h_openapi (hierarchical) and openapi (flat)."""
 
     class GrandChild(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def deep_action(self):
             return "deep"
 
     class Child(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api")
             self.grandchild = GrandChild()
             self.attach_instance(self.grandchild, name="grand")
 
-        @route("api")
+        @route()
         def child_action(self):
             return "child"
 
     class Root(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api")
             self.child = Child()
             self.attach_instance(self.child, name="child")
 
-        @route("api")
+        @route()
         def root_action(self):
             return "root"
 
     root = Root()
 
     # Flat openapi - all paths at top level
-    flat = root.api.nodes(mode="openapi")
+    flat = root.route.nodes(mode="openapi")
     assert "/root_action" in flat["paths"]
     assert "/child/child_action" in flat["paths"]
     assert "/child/grand/deep_action" in flat["paths"]
     assert "routers" not in flat  # No routers in eager flat mode
 
     # Hierarchical h_openapi - paths nested
-    hier = root.api.nodes(mode="h_openapi")
+    hier = root.route.nodes(mode="h_openapi")
     assert "/root_action" in hier["paths"]
     assert "/child/child_action" not in hier["paths"]  # Not at root level
     assert "routers" in hier
@@ -960,34 +868,30 @@ def test_h_openapi_lazy_returns_router_references():
     """Test h_openapi lazy=True returns router references."""
 
     class Child(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def action(self):
             return "child"
 
     class Root(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api")
             self.child = Child()
             self.attach_instance(self.child, name="child")
 
-        @route("api")
+        @route()
         def root_action(self):
             return "root"
 
     root = Root()
 
     # Lazy h_openapi
-    lazy = root.api.nodes(mode="h_openapi", lazy=True)
+    lazy = root.route.nodes(mode="h_openapi", lazy=True)
     assert "/root_action" in lazy["paths"]
     assert "routers" in lazy
     # In lazy mode, child is a Router reference
     assert isinstance(lazy["routers"]["child"], Router)
 
     # Can expand via basepath - paths are absolute from root
-    child_schema = root.api.nodes(basepath="child", mode="h_openapi")
+    child_schema = root.route.nodes(basepath="child", mode="h_openapi")
     assert "/child/action" in child_schema["paths"]
 
 
@@ -995,16 +899,13 @@ def test_h_openapi_preserves_openapi_format():
     """Test h_openapi produces valid OpenAPI format for entries."""
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def create_item(self, name: str, count: int = 1) -> dict:
             """Create a new item."""
             return {"name": name, "count": count}
 
     svc = Svc()
-    schema = svc.api.nodes(mode="h_openapi")
+    schema = svc.route.nodes(mode="h_openapi")
 
     # Check OpenAPI structure - scalar params means GET with query parameters
     path_item = schema["paths"]["/create_item"]
@@ -1019,15 +920,12 @@ def test_h_openapi_empty_routers_excluded():
     """Test h_openapi excludes empty routers dict."""
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def action(self):
             return "ok"
 
     svc = Svc()
-    schema = svc.api.nodes(mode="h_openapi")
+    schema = svc.route.nodes(mode="h_openapi")
 
     # No children, so no routers key
     assert "paths" in schema
@@ -1041,14 +939,14 @@ def test_nodes_includes_description_and_owner_doc():
         """Service for managing articles."""
 
         def __init__(self):
-            self.api = Router(self, name="api", description="API for articles")
+            self.route.description = "API for articles"
 
-        @route("api")
+        @route()
         def list_articles(self):
             return []
 
     svc = ArticleService()
-    nodes = svc.api.nodes()
+    nodes = svc.route.nodes()
 
     assert nodes["description"] == "API for articles"
     assert nodes["owner_doc"] == "Service for managing articles."
@@ -1058,15 +956,12 @@ def test_nodes_description_none_when_not_set():
     """Test nodes() returns None for description when not set."""
 
     class SimpleService(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def action(self):
             pass
 
     svc = SimpleService()
-    nodes = svc.api.nodes()
+    nodes = svc.route.nodes()
 
     assert nodes["description"] is None
     assert nodes["owner_doc"] is None  # No docstring on class
@@ -1079,9 +974,9 @@ def test_h_openapi_includes_description_and_owner_doc():
         """Child service for users."""
 
         def __init__(self):
-            self.api = Router(self, name="api", description="User management")
+            self.route.description = "User management"
 
-        @route("api")
+        @route()
         def get_user(self):
             return {}
 
@@ -1089,16 +984,16 @@ def test_h_openapi_includes_description_and_owner_doc():
         """Main API service."""
 
         def __init__(self):
-            self.api = Router(self, name="api", description="Main API")
+            self.route.description = "Main API"
             self.users = ChildService()
             self.attach_instance(self.users, name="users")
 
-        @route("api")
+        @route()
         def health(self):
             return "ok"
 
     root = RootService()
-    schema = root.api.nodes(mode="h_openapi")
+    schema = root.route.nodes(mode="h_openapi")
 
     # Root level
     assert schema["description"] == "Main API"
@@ -1188,31 +1083,28 @@ def test_openapi_uses_guessed_http_method():
     """Test openapi output uses guessed HTTP method from signature."""
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def get_item(self, item_id: int) -> dict:
             """Get an item - GET (scalar param)."""
             return {"id": item_id}
 
-        @route("api")
+        @route()
         def create_item(self, data: dict) -> dict:
             """Create an item - POST (complex param)."""
             return data
 
-        @route("api")
+        @route()
         def list_items(self) -> list:
             """List items - GET (no params)."""
             return []
 
-        @route("api")
+        @route()
         def reset_cache(self):
             """Reset cache - GET (no typed params)."""
             pass
 
     svc = Svc()
-    schema = svc.api.nodes(mode="openapi")
+    schema = svc.route.nodes(mode="openapi")
 
     # GET for scalar params
     assert "get" in schema["paths"]["/get_item"]
@@ -1241,20 +1133,20 @@ def test_openapi_plugin_method_override():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("openapi")
+            self.route.plug("openapi")
 
-        @route("api", openapi_method="delete")
+        @route(openapi_method="delete")
         def remove_item(self, item_id: int) -> dict:
             """Delete an item - explicitly DELETE despite scalar params."""
             return {"deleted": item_id}
 
-        @route("api", openapi_method="PUT")
+        @route(openapi_method="PUT")
         def update_item(self, item_id: int, name: str) -> dict:
             """Update an item - explicitly PUT."""
             return {"id": item_id, "name": name}
 
     svc = Svc()
-    schema = svc.api.nodes(mode="openapi")
+    schema = svc.route.nodes(mode="openapi")
 
     # Override to DELETE
     assert "delete" in schema["paths"]["/remove_item"]
@@ -1269,18 +1161,18 @@ def test_openapi_plugin_tags():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("openapi")
+            self.route.plug("openapi")
 
-        @route("api", openapi_tags=["users", "admin"])
+        @route(openapi_tags=["users", "admin"])
         def admin_action(self) -> str:
             return "ok"
 
-        @route("api", openapi_tags="public")
+        @route(openapi_tags="public")
         def public_action(self) -> str:
             return "ok"
 
     svc = Svc()
-    schema = svc.api.nodes(mode="openapi")
+    schema = svc.route.nodes(mode="openapi")
 
     # List of tags
     admin_op = schema["paths"]["/admin_action"]["get"]
@@ -1296,15 +1188,15 @@ def test_openapi_plugin_no_effect_without_config():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("openapi")
+            self.route.plug("openapi")
 
-        @route("api")
+        @route()
         def get_item(self, item_id: int) -> dict:
             """Should still use guessed method (GET because scalar param)."""
             return {"id": item_id}
 
     svc = Svc()
-    schema = svc.api.nodes(mode="openapi")
+    schema = svc.route.nodes(mode="openapi")
 
     # Method should be guessed as GET (scalar param, not overridden)
     assert "get" in schema["paths"]["/get_item"]
@@ -1324,16 +1216,13 @@ def test_node_returns_entry_info():
     """Test node() returns RouterNode for a single entry."""
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def get_item(self, item_id: int) -> dict:
             """Get an item by ID."""
             return {"id": item_id}
 
     svc = Svc()
-    node = svc.api.node("get_item")
+    node = svc.route.node("get_item")
 
     assert node.path == "get_item"
     assert node.doc == "Get an item by ID."
@@ -1353,16 +1242,13 @@ def test_openapi_typeddict_response_schema():
     """Test openapi generates schema from TypedDict return type."""
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def get_user(self) -> _UserResponse:
             """Get user info."""
             return {"id": 1, "name": "test", "active": True}
 
     svc = Svc()
-    schema = svc.api.nodes(mode="openapi")
+    schema = svc.route.nodes(mode="openapi")
 
     # No params + return = GET
     operation = schema["paths"]["/get_user"]["get"]
@@ -1384,21 +1270,18 @@ def test_openapi_typeddict_with_required_keys():
     """Test openapi includes required keys from TypedDict."""
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def get_full_user(self) -> _FullUser:
             """All fields required."""
             return {"id": 1, "name": "test"}
 
-        @route("api")
+        @route()
         def get_partial_user(self) -> _PartialUser:
             """No fields required (total=False)."""
             return {}
 
     svc = Svc()
-    schema = svc.api.nodes(mode="openapi")
+    schema = svc.route.nodes(mode="openapi")
 
     # Full user has required keys
     full_schema = schema["paths"]["/get_full_user"]["get"]["responses"]["200"]["content"]["application/json"]["schema"]
@@ -1414,23 +1297,20 @@ def test_openapi_non_typeddict_still_works():
     """Test openapi still works for non-TypedDict return types."""
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def get_string(self) -> str:
             return "ok"
 
-        @route("api")
+        @route()
         def get_list(self) -> list:
             return []
 
-        @route("api")
+        @route()
         def get_dict(self) -> dict:
             return {}
 
     svc = Svc()
-    schema = svc.api.nodes(mode="openapi")
+    schema = svc.route.nodes(mode="openapi")
 
     # Simple types still work
     str_schema = schema["paths"]["/get_string"]["get"]["responses"]["200"]["content"]["application/json"]["schema"]
@@ -1453,15 +1333,15 @@ def test_openapi_summary_override():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("openapi")
+            self.route.plug("openapi")
 
-        @route("api", openapi_summary="Custom summary")
+        @route(openapi_summary="Custom summary")
         def action(self) -> dict:
             """Original docstring."""
             return {}
 
     svc = Svc()
-    schema = svc.api.nodes(mode="openapi")
+    schema = svc.route.nodes(mode="openapi")
     op = schema["paths"]["/action"]["get"]
     assert op["summary"] == "Custom summary"
 
@@ -1471,20 +1351,20 @@ def test_openapi_deprecated_flag():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("openapi")
+            self.route.plug("openapi")
 
-        @route("api", openapi_deprecated=True)
+        @route(openapi_deprecated=True)
         def old_action(self) -> dict:
             """Deprecated endpoint."""
             return {}
 
-        @route("api")
+        @route()
         def new_action(self) -> dict:
             """Active endpoint."""
             return {}
 
     svc = Svc()
-    schema = svc.api.nodes(mode="openapi")
+    schema = svc.route.nodes(mode="openapi")
     old_op = schema["paths"]["/old_action"]["get"]
     new_op = schema["paths"]["/new_action"]["get"]
     assert old_op.get("deprecated") is True
@@ -1496,15 +1376,15 @@ def test_openapi_description_override():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("openapi")
+            self.route.plug("openapi")
 
-        @route("api", openapi_description="Custom description")
+        @route(openapi_description="Custom description")
         def action(self) -> dict:
             """Original docstring."""
             return {}
 
     svc = Svc()
-    schema = svc.api.nodes(mode="openapi")
+    schema = svc.route.nodes(mode="openapi")
     op = schema["paths"]["/action"]["get"]
     assert op["description"] == "Custom description"
 
@@ -1519,14 +1399,14 @@ def test_openapi_security_from_auth_rule():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("openapi").plug("auth")
+            self.route.plug("openapi").plug("auth")
 
-        @route("api", auth_rule="admin")
+        @route(auth_rule="admin")
         def admin_action(self) -> dict:
             return {}
 
     svc = Svc()
-    schema = svc.api.nodes(mode="openapi", forbidden=True)
+    schema = svc.route.nodes(mode="openapi", forbidden=True)
     op = schema["paths"]["/admin_action"]["get"]
     assert "security" in op
     assert op["security"] == [{"BearerAuth": []}]
@@ -1537,14 +1417,14 @@ def test_openapi_security_empty_for_public():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("openapi").plug("auth")
+            self.route.plug("openapi").plug("auth")
 
-        @route("api")
+        @route()
         def public_action(self) -> dict:
             return {}
 
     svc = Svc()
-    schema = svc.api.nodes(mode="openapi")
+    schema = svc.route.nodes(mode="openapi")
     op = schema["paths"]["/public_action"]["get"]
     assert "security" in op
     assert op["security"] == []
@@ -1555,14 +1435,14 @@ def test_openapi_security_absent_without_auth_plugin():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("openapi")
+            self.route.plug("openapi")
 
-        @route("api")
+        @route()
         def action(self) -> dict:
             return {}
 
     svc = Svc()
-    schema = svc.api.nodes(mode="openapi")
+    schema = svc.route.nodes(mode="openapi")
     op = schema["paths"]["/action"]["get"]
     assert "security" not in op
 
@@ -1572,14 +1452,14 @@ def test_openapi_security_scheme_configurable():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("openapi").plug("auth")
+            self.route.plug("openapi").plug("auth")
 
-        @route("api", auth_rule="admin", openapi_security_scheme="OAuth2")
+        @route(auth_rule="admin", openapi_security_scheme="OAuth2")
         def admin_action(self) -> dict:
             return {}
 
     svc = Svc()
-    schema = svc.api.nodes(mode="openapi", forbidden=True)
+    schema = svc.route.nodes(mode="openapi", forbidden=True)
     op = schema["paths"]["/admin_action"]["get"]
     assert op["security"] == [{"OAuth2": []}]
 
@@ -1594,18 +1474,18 @@ def test_openapi_x_requires_from_env():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("openapi").plug("env")
+            self.route.plug("openapi").plug("env")
 
-        @route("api", env_requires="redis&pyjwt")
+        @route(env_requires="redis&pyjwt")
         def cached_action(self) -> dict:
             return {}
 
-        @route("api")
+        @route()
         def simple_action(self) -> dict:
             return {}
 
     svc = Svc()
-    schema = svc.api.nodes(mode="openapi", forbidden=True)
+    schema = svc.route.nodes(mode="openapi", forbidden=True)
     cached_op = schema["paths"]["/cached_action"]["get"]
     simple_op = schema["paths"]["/simple_action"]["get"]
     assert cached_op.get("x-requires") == "redis&pyjwt"
@@ -1622,18 +1502,18 @@ def test_openapi_security_explicit_override():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("openapi").plug("auth")
+            self.route.plug("openapi").plug("auth")
 
-        @route("api", auth_rule="admin", openapi_security=[{"OAuth2": ["read"]}])
+        @route(auth_rule="admin", openapi_security=[{"OAuth2": ["read"]}])
         def custom_auth(self) -> dict:
             return {}
 
-        @route("api", auth_rule="admin", openapi_security=[])
+        @route(auth_rule="admin", openapi_security=[])
         def force_public(self) -> dict:
             return {}
 
     svc = Svc()
-    schema = svc.api.nodes(mode="openapi", forbidden=True)
+    schema = svc.route.nodes(mode="openapi", forbidden=True)
     custom_op = schema["paths"]["/custom_auth"]["get"]
     public_op = schema["paths"]["/force_public"]["get"]
     # Explicit override takes precedence over auth-derived security
@@ -1651,15 +1531,15 @@ def test_pydantic_captures_response_schema():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("pydantic")
+            self.route.plug("pydantic")
 
-        @route("api")
+        @route()
         def get_data(self) -> dict[str, int]:
             """Return data."""
             return {"a": 1}
 
     svc = Svc()
-    entry = svc.api._entries["get_data"]
+    entry = svc.route._entries["get_data"]
     meta = entry.metadata.get("pydantic", {})
     assert "response_schema" in meta
     schema = meta["response_schema"]
@@ -1671,14 +1551,14 @@ def test_pydantic_no_response_schema_without_annotation():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("pydantic")
+            self.route.plug("pydantic")
 
-        @route("api")
+        @route()
         def no_return(self):
             return {}
 
     svc = Svc()
-    entry = svc.api._entries["no_return"]
+    entry = svc.route._entries["no_return"]
     meta = entry.metadata.get("pydantic", {})
     assert "response_schema" not in meta
 
@@ -1692,14 +1572,14 @@ def test_pydantic_captures_typeddict_response_schema():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("pydantic")
+            self.route.plug("pydantic")
 
-        @route("api")
+        @route()
         def get_user(self) -> _UserResponse:
             return {"id": 1, "name": "test", "active": True}
 
     svc = Svc()
-    entry = svc.api._entries["get_user"]
+    entry = svc.route._entries["get_user"]
     schema = entry.metadata["pydantic"]["response_schema"]
     assert schema["type"] == "object"
     assert "properties" in schema
@@ -1713,15 +1593,15 @@ def test_response_schema_in_nodes_metadata():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("pydantic")
+            self.route.plug("pydantic")
 
-        @route("api")
+        @route()
         def get_data(self) -> dict[str, int]:
             """Return data."""
             return {"a": 1}
 
     svc = Svc()
-    nodes = svc.api.nodes()
+    nodes = svc.route.nodes()
     entry_info = nodes["entries"]["get_data"]
     pydantic_meta = entry_info["plugins"]["pydantic"]["metadata"]
     assert "response_schema" in pydantic_meta
@@ -1733,15 +1613,15 @@ def test_openapi_uses_precomputed_response_schema():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("pydantic").plug("openapi")
+            self.route.plug("pydantic").plug("openapi")
 
-        @route("api")
+        @route()
         def get_data(self) -> dict[str, int]:
             """Return data."""
             return {"a": 1}
 
     svc = Svc()
-    schema = svc.api.nodes(mode="openapi")
+    schema = svc.route.nodes(mode="openapi")
     response = schema["paths"]["/get_data"]["get"]["responses"]["200"]
     response_schema = response["content"]["application/json"]["schema"]
     assert response_schema["type"] == "object"
@@ -1751,16 +1631,13 @@ def test_openapi_fallback_without_pydantic():
     """OpenAPI generates response schema even without pydantic plugin."""
 
     class Svc(RoutingClass):
-        def __init__(self):
-            self.api = Router(self, name="api")
-
-        @route("api")
+        @route()
         def get_data(self) -> dict[str, int]:
             """Return data."""
             return {"a": 1}
 
     svc = Svc()
-    schema = svc.api.nodes(mode="openapi")
+    schema = svc.route.nodes(mode="openapi")
     response = schema["paths"]["/get_data"]["get"]["responses"]["200"]
     response_schema = response["content"]["application/json"]["schema"]
     assert response_schema["type"] == "object"
@@ -1775,14 +1652,14 @@ def test_list_typeddict_response_schema():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("pydantic")
+            self.route.plug("pydantic")
 
-        @route("api")
+        @route()
         def list_users(self) -> list[_UserResponse]:
             return []
 
     svc = Svc()
-    entry = svc.api._entries["list_users"]
+    entry = svc.route._entries["list_users"]
     schema = entry.metadata["pydantic"]["response_schema"]
     assert schema["type"] == "array"
 
@@ -1792,20 +1669,20 @@ def test_response_schema_not_mutated_by_openapi():
 
     class Svc(RoutingClass):
         def __init__(self):
-            self.api = Router(self, name="api").plug("pydantic").plug("openapi")
+            self.route.plug("pydantic").plug("openapi")
 
-        @route("api")
+        @route()
         def get_data(self) -> dict[str, int]:
             """Return data."""
             return {"a": 1}
 
     svc = Svc()
-    entry = svc.api._entries["get_data"]
+    entry = svc.route._entries["get_data"]
     original_schema = entry.metadata["pydantic"]["response_schema"].copy()
 
     # Call nodes(mode="openapi") twice
-    svc.api.nodes(mode="openapi")
-    svc.api.nodes(mode="openapi")
+    svc.route.nodes(mode="openapi")
+    svc.route.nodes(mode="openapi")
 
     # Original schema in metadata should be unchanged
     assert entry.metadata["pydantic"]["response_schema"] == original_schema

--- a/tests/test_router_runtime_extras.py
+++ b/tests/test_router_runtime_extras.py
@@ -19,10 +19,10 @@ from typing import TypedDict
 
 import pytest
 
-from genro_routes import RoutingClass, Router, route
+from genro_routes import Router, RoutingClass, route
 from genro_routes.core.routing import is_routing_class
 from genro_routes.plugins._base_plugin import BasePlugin, MethodEntry
-
+from genro_routes.plugins.openapi import OpenAPITranslator
 
 # TypedDict classes at module level for cross-Python-version compatibility
 # (pydantic handles TypedDict differently when defined inside functions
@@ -1016,7 +1016,6 @@ def test_h_openapi_includes_description_and_owner_doc():
 
 def test_guess_http_method_no_params_with_return_is_get():
     """Test guess_http_method returns GET for no-param functions with return."""
-    from genro_routes.plugins.openapi import OpenAPITranslator
 
     def no_params() -> str:
         return "ok"
@@ -1026,7 +1025,6 @@ def test_guess_http_method_no_params_with_return_is_get():
 
 def test_guess_http_method_no_params_no_return_is_get():
     """Test guess_http_method returns GET for no-param functions (regardless of return)."""
-    from genro_routes.plugins.openapi import OpenAPITranslator
 
     def no_params_no_return():
         pass
@@ -1041,7 +1039,6 @@ def test_guess_http_method_no_params_no_return_is_get():
 
 def test_guess_http_method_scalar_params_is_get():
     """Test guess_http_method returns GET for functions with scalar params."""
-    from genro_routes.plugins.openapi import OpenAPITranslator
 
     def scalar_params(name: str, count: int) -> str:
         return "ok"
@@ -1052,7 +1049,6 @@ def test_guess_http_method_scalar_params_is_get():
 
 def test_guess_http_method_complex_params_is_post():
     """Test guess_http_method returns POST for functions with complex params."""
-    from genro_routes.plugins.openapi import OpenAPITranslator
 
     def complex_params(items: list) -> list:
         return items
@@ -1067,7 +1063,6 @@ def test_guess_http_method_complex_params_is_post():
 
 def test_guess_http_method_broken_hints_is_post():
     """Test guess_http_method returns POST when hints can't be resolved."""
-    from genro_routes.plugins.openapi import OpenAPITranslator
 
     def broken():
         return "ok"

--- a/tests/test_routing_context.py
+++ b/tests/test_routing_context.py
@@ -14,8 +14,11 @@
 
 """Tests for RoutingContext and slot-based ctx property on RoutingClass."""
 
+from pathlib import Path
+
 import pytest
 
+import genro_routes.core.routing
 from genro_routes import RoutingClass, RoutingContext
 
 
@@ -206,7 +209,6 @@ class TestCtxSlot:
 
     def test_no_contextvar_import(self):
         """Verify ContextVar is not imported in routing.py."""
-        import genro_routes.core.routing as mod
-        source = open(mod.__file__).read()
+        source = Path(genro_routes.core.routing.__file__).read_text()
         assert "from contextvars" not in source
         assert "ContextVar" not in source

--- a/tests/test_routing_context.py
+++ b/tests/test_routing_context.py
@@ -16,7 +16,7 @@
 
 import pytest
 
-from genro_routes import Router, RoutingClass, RoutingContext
+from genro_routes import RoutingClass, RoutingContext
 
 
 class TestRoutingContextAttributes:
@@ -89,8 +89,7 @@ class TestCtxSlot:
     def test_default_none(self):
         """ctx returns None when not set."""
         class Svc(RoutingClass):
-            def __init__(self):
-                self.api = Router(self, name="api")
+            pass
 
         svc = Svc()
         assert svc.ctx is None
@@ -98,8 +97,7 @@ class TestCtxSlot:
     def test_set_and_get(self):
         """Set and get ctx via property."""
         class Svc(RoutingClass):
-            def __init__(self):
-                self.api = Router(self, name="api")
+            pass
 
         svc = Svc()
         ctx = RoutingContext()
@@ -111,8 +109,7 @@ class TestCtxSlot:
     def test_clear_ctx(self):
         """Setting ctx to None clears the local slot."""
         class Svc(RoutingClass):
-            def __init__(self):
-                self.api = Router(self, name="api")
+            pass
 
         svc = Svc()
         ctx = RoutingContext()
@@ -124,12 +121,10 @@ class TestCtxSlot:
     def test_parent_chain_lookup(self):
         """ctx walks up _routing_parent chain."""
         class Parent(RoutingClass):
-            def __init__(self):
-                self.api = Router(self, name="api")
+            pass
 
         class Child(RoutingClass):
-            def __init__(self):
-                self.api = Router(self, name="api")
+            pass
 
         parent = Parent()
         child = Child()
@@ -146,12 +141,10 @@ class TestCtxSlot:
     def test_child_override(self):
         """Child can set its own ctx, overriding parent's."""
         class Parent(RoutingClass):
-            def __init__(self):
-                self.api = Router(self, name="api")
+            pass
 
         class Child(RoutingClass):
-            def __init__(self):
-                self.api = Router(self, name="api")
+            pass
 
         parent = Parent()
         child = Child()
@@ -171,12 +164,10 @@ class TestCtxSlot:
     def test_clear_child_falls_through_to_parent(self):
         """Clearing child's ctx makes it fall through to parent."""
         class Parent(RoutingClass):
-            def __init__(self):
-                self.api = Router(self, name="api")
+            pass
 
         class Child(RoutingClass):
-            def __init__(self):
-                self.api = Router(self, name="api")
+            pass
 
         parent = Parent()
         child = Child()
@@ -200,8 +191,7 @@ class TestCtxSlot:
     def test_instances_are_independent(self):
         """Two unrelated instances have independent ctx slots."""
         class Svc(RoutingClass):
-            def __init__(self):
-                self.api = Router(self, name="api")
+            pass
 
         a = Svc()
         b = Svc()


### PR DESCRIPTION
## Summary

Implements #32: every `RoutingClass` owns exactly one `Router`, created lazily on first access to the read-only property `route`. The `Router` constructor leaves the public API; grouping and hierarchy are expressed exclusively by composing `RoutingClass` instances (new `Section` helper).

**One class, one router, composition by attach.**

- `@route()` is keyword-only — no router selector; old positional usage (`@route("api")`) fails loudly with `TypeError`
- `attach_instance(child, name=alias)` is the only calling style; the `router_*` cross-mapping DSL is removed
- `configure()` targets drop the router prefix: `"plugin/selector"`
- `parent_router=` and `branch=True` constructor params are removed; grouping nodes are `Section` instances
- `default_router` and the per-instance router registry are removed (single private slot)
- CLI builds from `instance.route` only (subgroup-per-router removed)
- Tests, examples and all documentation migrated (including the HTML tutorial and CODE_READING_GUIDE, realigned with the current source)

Net -1,700 lines across the repo. Full migration table in #32.

## Breaking changes

Clean break, no deprecation period. Migration is mechanical:

| Before | After |
|--------|-------|
| `self.api = Router(self, name="api")` | remove — use `self.route` |
| `@route("api", k=v)` | `@route(k=v)` |
| `Router(self, name="x", parent_router=...)` / `branch=True` | `attach_instance(Section(), name="x")` |
| `attach_instance(child, router_api="a:b")` | `attach_instance(a_instance, name="b")` |
| `routing.configure("api:plugin/sel", ...)` | `routing.configure("plugin/sel", ...)` |
| `svc.default_router` / `routing.get_router("api")` | `svc.route` |

## Cross-repo impact (Sourcerer check)

Downstream code using the old API, to migrate on upgrade:

- **genro-asgi** — `asgi_application.py` (routers `main`/`backoffice`), `openapi_application.py` (uses `branch=True` + `parent_router=`), `mcp_application` tests. Already adapted on its `develop` branch.
- **smartpublisher** — `app_manager.py`, `chan_registry.py`, `channels/cli_channel.py`, `channels/http_channel.py`, `conftest.py` (single-router constructions, mechanical rename).
- **genropy** — `gnr/web/gnrwsgisite_proxy/gnrapidispatcher.py:84` uses `Router(self, name='api', branch=True)`: needs `Section` or an empty owner instance.

## Test plan

- 359 tests green locally (`pytest tests/`), ruff clean, mypy advisory clean
- Examples executed end-to-end: `service_composition`, `deep_repo_explorer` (dynamic tree via `Section`), `self_documentation` (fixed a pre-existing KeyError verified broken on main too)
- Verified against genro-asgi `develop` (consumer integration)
- Documentation code samples runtime-verified during migration

Closes #32