### PR TITLE
chore: bump version to 0.23.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genro-routes"
-version = "0.22.0"
+version = "0.23.0"
 description = "Instance-scoped routing engine for Python with hierarchical handlers and composable plugins"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Version bump for the breaking single-router release (#32, merged in #33).

## Test plan

CI on this PR (tests 3.10–3.12 + docs build). Tag v0.23.0 will follow the merge to trigger the PyPI publish.