### PR TITLE
feat: dialect-neutral params block on the node (input side)

### DIFF
--- a/examples/mcp_bridge/bridge.py
+++ b/examples/mcp_bridge/bridge.py
@@ -24,21 +24,20 @@ class GenroMCPBridge:
         entries = nodes.get("entries", {})
         for name, info in entries.items():
             tool_name = f"{path_prefix}{name}"
-            metadata = info.get("metadata", {})
-            pydantic_meta = metadata.get("pydantic", {})
-            model = pydantic_meta.get("model")
 
-            # Build MCP tool definition
+            # Build MCP tool definition. Both schemas come from the neutral
+            # node blocks (params/result), fetched once by genro-routes; the
+            # bridge never re-inspects the handler callable.
             tool = {
                 "name": tool_name.replace("/", "_"), # MCP likes flat names with underscores
                 "description": info.get("doc", "No description provided"),
-                "inputSchema": self._get_schema_from_model(model),
+                "inputSchema": self._input_schema(info),
             }
 
             # Add response schema if available
-            response_schema = pydantic_meta.get("response_schema")
-            if response_schema:
-                tool["outputSchema"] = response_schema
+            output_schema = (info.get("result") or {}).get("schema")
+            if output_schema:
+                tool["outputSchema"] = output_schema
 
             tools.append(tool)
 
@@ -49,10 +48,11 @@ class GenroMCPBridge:
 
         return tools
 
-    def _get_schema_from_model(self, model: Any) -> dict[str, Any]:
-        """Extracts JSON Schema from a Pydantic model (if available)."""
-        if model and hasattr(model, "model_json_schema"):
-            return model.model_json_schema()
+    def _input_schema(self, info: dict[str, Any]) -> dict[str, Any]:
+        """Extract the input JSON Schema from the neutral params block."""
+        schema = (info.get("params") or {}).get("schema")
+        if schema:
+            return schema
         return {
             "type": "object",
             "properties": {},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genro-routes"
-version = "0.24.0"
+version = "0.25.0"
 description = "Instance-scoped routing engine for Python with hierarchical handlers and composable plugins"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/genro_routes/core/router.py
+++ b/src/genro_routes/core/router.py
@@ -552,6 +552,9 @@ class Router(BaseRouter):
         result = self._describe_result(entry)
         if result:
             extra["result"] = result
+        params = self._describe_params(entry)
+        if params:
+            extra["params"] = params
         return extra
 
     def _describe_result(self, entry: MethodEntry) -> dict[str, Any]:
@@ -571,3 +574,26 @@ class Router(BaseRouter):
         if schema is None and media_type is None:
             return {}
         return {"schema": schema, "media_type": media_type}
+
+    def _describe_params(self, entry: MethodEntry) -> dict[str, Any]:
+        """Build the dialect-neutral input-params block for a handler.
+
+        Twin of the result block, for the input side: exposes the aggregate
+        input JSON Schema plus a per-parameter list (name, schema, required,
+        default, kind). Both are cached by the pydantic plugin at decoration
+        time; this only reads them, so nodes() never re-serializes a schema.
+        Present only when the pydantic plugin captured params for this entry.
+
+        Returns:
+            ``{"schema": <json schema | None>, "fields": [...],
+            "accepts_varargs": <bool>}`` when the plugin captured params,
+            else an empty dict.
+        """
+        pydantic_meta = entry.metadata.get("pydantic", {})
+        if "param_fields" not in pydantic_meta:
+            return {}
+        return {
+            "schema": pydantic_meta.get("request_schema"),
+            "fields": pydantic_meta["param_fields"],
+            "accepts_varargs": pydantic_meta.get("accepts_varargs", False),
+        }

--- a/src/genro_routes/core/router_node.py
+++ b/src/genro_routes/core/router_node.py
@@ -149,6 +149,34 @@ class RouterNode:
             return {}
         return dict(self._entry.metadata.get("meta", {}))
 
+    @property
+    def params(self) -> dict[str, Any]:
+        """Return the neutral input-params block for this entry.
+
+        Twin of the nodes() ``params`` block: the input JSON Schema plus a
+        per-parameter list. Delegates to the router's ``_describe_params`` so
+        the two stay in sync. Empty dict if there is no entry or the router
+        has no plugin pipeline (e.g. a plain BaseRouter). Never touches func.
+        """
+        if self._entry is None:
+            return {}
+        describe = getattr(self._router, "_describe_params", None)
+        return describe(self._entry) if describe is not None else {}
+
+    def accepts(self, name: str) -> bool:
+        """Return True if the handler declares a parameter named ``name``.
+
+        Reads parameter names from the pydantic-captured signature; falls back
+        to inspecting func only when no signature info is available (no
+        pydantic plugin). Bound methods never expose ``self``.
+        """
+        if self._entry is None:
+            return False
+        sig = self._entry.metadata.get("pydantic", {}).get("signature")
+        if sig is None:
+            sig = inspect.signature(self._entry.func)
+        return name in sig.parameters
+
     def _assign_partial(self, entry: Any) -> bool:
         """Assign partial path values to kwargs and extra_args.
 
@@ -158,7 +186,8 @@ class RouterNode:
         if not self._partial:
             return True
 
-        sig = inspect.signature(entry.func)
+        pydantic_meta = entry.metadata.get("pydantic", {})
+        sig = pydantic_meta.get("signature") or inspect.signature(entry.func)
 
         param_names = [
             name
@@ -166,10 +195,12 @@ class RouterNode:
             if p.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
         ]
 
-        has_var_positional = any(
-            p.kind == inspect.Parameter.VAR_POSITIONAL
-            for p in sig.parameters.values()
-        )
+        has_var_positional = pydantic_meta.get("accepts_varargs")
+        if has_var_positional is None:
+            has_var_positional = any(
+                p.kind == inspect.Parameter.VAR_POSITIONAL
+                for p in sig.parameters.values()
+            )
 
         for i, value in enumerate(self._partial):
             if i < len(param_names):

--- a/src/genro_routes/plugins/pydantic.py
+++ b/src/genro_routes/plugins/pydantic.py
@@ -173,6 +173,33 @@ class PydanticPlugin(BasePlugin):
 
             pydantic_meta["model"] = create_model(f"{func.__name__}_Model", **fields)  # type: ignore
 
+        # Cache the neutral input-params description once (read by nodes()/node().
+        # params). The heavy model_json_schema() must never run per-call.
+        model = pydantic_meta.get("model")
+        props: dict[str, Any] = {}
+        if model is not None:
+            request_schema = model.model_json_schema()
+            props = request_schema.get("properties", {})
+            pydantic_meta["request_schema"] = request_schema
+        param_fields = []
+        for param_name, param in sig.parameters.items():
+            if param.kind in (
+                inspect.Parameter.VAR_POSITIONAL,
+                inspect.Parameter.VAR_KEYWORD,
+            ):
+                continue
+            required = param.default is inspect.Parameter.empty
+            param_fields.append(
+                {
+                    "name": param_name,
+                    "schema": props.get(param_name),
+                    "required": required,
+                    "default": None if required else param.default,
+                    "kind": param.kind.name.lower(),
+                }
+            )
+        pydantic_meta["param_fields"] = param_fields
+
         entry.metadata["pydantic"] = pydantic_meta
 
     def wrap_handler(self, route: Router, entry: MethodEntry, call_next: Callable):

--- a/tests/test_params_description.py
+++ b/tests/test_params_description.py
@@ -1,0 +1,158 @@
+# Copyright 2025 Softwell S.r.l.
+# Licensed under the Apache License, Version 2.0
+
+"""Tests for the dialect-neutral params block in nodes() and on RouterNode.
+
+The params block is the input-side twin of the result block. Per entry it
+exposes the aggregate input JSON Schema plus a per-parameter list (name,
+schema, required, default, kind) and an accepts_varargs flag. It is produced
+once by the pydantic plugin at decoration time and only read at runtime, so
+nodes()/node().params never re-serialize a schema. It is present only when the
+pydantic plugin captured params for the entry.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from genro_routes import RoutingClass, route
+
+
+class _Item(BaseModel):
+    id: int
+    tag: str
+
+
+class ParamsService(RoutingClass):
+    def __init__(self):
+        self.route.plug("pydantic")
+
+    @route()
+    def search(self, user_id: int, limit: int = 20):
+        return None
+
+    @route()
+    def mixed(self, user_id: int, note, *tags, flag: bool = False, **opts):
+        return None
+
+    @route()
+    def create(self, item: _Item):
+        return None
+
+    @route()
+    def noargs(self):
+        return None
+
+
+def _entries():
+    return ParamsService().route.nodes()["entries"]
+
+
+def _field(params, name):
+    return next(f for f in params["fields"] if f["name"] == name)
+
+
+def test_aggregate_schema_required_and_type():
+    params = _entries()["search"]["params"]
+    schema = params["schema"]
+    assert schema["properties"]["user_id"]["type"] == "integer"
+    assert schema["required"] == ["user_id"]
+
+
+def test_fields_required_vs_default():
+    params = _entries()["search"]["params"]
+    user_id = _field(params, "user_id")
+    limit = _field(params, "limit")
+    assert user_id["required"] is True
+    assert user_id["default"] is None
+    assert limit["required"] is False
+    assert limit["default"] == 20
+    assert user_id["kind"] == "positional_or_keyword"
+    assert limit["kind"] == "positional_or_keyword"
+
+
+def test_unannotated_param_has_no_schema():
+    params = _entries()["mixed"]["params"]
+    note = _field(params, "note")
+    assert note["schema"] is None
+    assert note["required"] is True
+    # unannotated param is absent from the aggregate model schema
+    assert "note" not in params["schema"]["properties"]
+
+
+def test_varargs_excluded_and_flagged():
+    params = _entries()["mixed"]["params"]
+    names = {f["name"] for f in params["fields"]}
+    assert names == {"user_id", "note", "flag"}  # *tags / **opts excluded
+    assert params["accepts_varargs"] is True
+
+
+def test_keyword_only_kind():
+    params = _entries()["mixed"]["params"]
+    assert _field(params, "flag")["kind"] == "keyword_only"
+
+
+def test_nested_model_param_has_defs():
+    params = _entries()["create"]["params"]
+    schema = params["schema"]
+    # pydantic emits $defs for the nested model, referenced from the property
+    assert "$defs" in schema
+    assert "_Item" in schema["$defs"]
+    assert "$ref" in schema["properties"]["item"]
+
+
+def test_self_not_in_params():
+    params = _entries()["search"]["params"]
+    assert "self" not in params["schema"]["properties"]
+    assert not any(f["name"] == "self" for f in params["fields"])
+
+
+def test_noargs_block_present_but_empty():
+    params = _entries()["noargs"]["params"]
+    assert params["fields"] == []
+    assert params["schema"] is None
+    assert params["accepts_varargs"] is False
+
+
+def test_no_params_block_without_pydantic_plugin():
+    class NoPlugin(RoutingClass):
+        @route()
+        def handler(self, x: int):
+            return None
+
+    entries = NoPlugin().route.nodes()["entries"]
+    assert "params" not in entries["handler"]
+
+
+def test_params_at_runtime_via_node():
+    svc = ParamsService()
+    node = svc.route.node("search")
+    assert {f["name"] for f in node.params["fields"]} == {"user_id", "limit"}
+
+
+def test_node_params_empty_without_plugin():
+    class NoPlugin(RoutingClass):
+        @route()
+        def handler(self, x: int):
+            return None
+
+    assert NoPlugin().route.node("handler").params == {}
+
+
+def test_node_accepts():
+    node = ParamsService().route.node("search")
+    assert node.accepts("user_id") is True
+    assert node.accepts("limit") is True
+    assert node.accepts("nope") is False
+    assert node.accepts("self") is False
+
+
+def test_node_accepts_without_plugin_falls_back():
+    class NoPlugin(RoutingClass):
+        @route()
+        def handler(self, item_id):
+            return None
+
+    node = NoPlugin().route.node("handler")
+    assert node.accepts("item_id") is True
+    assert node.accepts("nope") is False


### PR DESCRIPTION
Closes #37. Follow-up of #35.

## Principle

A node — both the `nodes()` introspection tree and the live `RouterNode` — must be the complete, self-sufficient description of an entry. A consumer must never have to reach into the handler (`entry.func`) or re-run `inspect`/`get_type_hints` to recover what the node already knows. #35 solved the **output** side (neutral `result` block). This PR adds the **input** twin.

## What changed

- **`params` block in `nodes()`** — per entry: the aggregate input JSON Schema plus a per-parameter list (`name`, `schema`, `required`, `default`, `kind`) and an `accepts_varargs` flag. Present only when the pydantic plugin captured params for the entry (twin of `result` absent without the plugin).
- **`RouterNode.params` property and `RouterNode.accepts(name)` method** — the live node exposes the same input description at dispatch time, without touching `entry.func`.
- **Caching** — the pydantic plugin builds and caches `request_schema` and `param_fields` once in `on_decore`; `nodes()` and `RouterNode.params` only read them. The heavy `model_json_schema()` runs once per handler, never per call (verified: 100× `nodes()`+`params` → zero recomputations).
- **`_assign_partial`** now reads the cached signature (falling back to `inspect` only without the plugin), removing the last per-dispatch inspect on the hot path.
- **`examples/mcp_bridge/bridge.py`** updated to read `params.schema` for `inputSchema` (and `result.schema` for `outputSchema`) — no more callable re-inspection.

## Notes

- **Purely additive**: nothing removed or renamed → not breaking. Version bumped to 0.25.0.
- **Bound methods**: `entry.func` is always bound, so `self` never appears in `params` — no special handling needed.
- **genro-asgi not touched**: the downstream consumers (OpenAPI translator, MCP application) will migrate to read `params` separately, once 0.25.0 is published.

## Verification

- Suite: **328 passed** (315 baseline + 13 new in `tests/test_params_description.py`), zero regressions.
- `ruff check src/ tests/`: clean. mypy (advisory): no new issues.
- Dispatch path-positional (`_assign_partial`) green with and without the pydantic plugin.