### PR TITLE
refactor: drop RouterNode.accepts(); params property covers issue #37

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genro-routes"
-version = "0.25.0"
+version = "0.25.1"
 description = "Instance-scoped routing engine for Python with hierarchical handlers and composable plugins"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/genro_routes/core/router_node.py
+++ b/src/genro_routes/core/router_node.py
@@ -163,20 +163,6 @@ class RouterNode:
         describe = getattr(self._router, "_describe_params", None)
         return describe(self._entry) if describe is not None else {}
 
-    def accepts(self, name: str) -> bool:
-        """Return True if the handler declares a parameter named ``name``.
-
-        Reads parameter names from the pydantic-captured signature; falls back
-        to inspecting func only when no signature info is available (no
-        pydantic plugin). Bound methods never expose ``self``.
-        """
-        if self._entry is None:
-            return False
-        sig = self._entry.metadata.get("pydantic", {}).get("signature")
-        if sig is None:
-            sig = inspect.signature(self._entry.func)
-        return name in sig.parameters
-
     def _assign_partial(self, entry: Any) -> bool:
         """Assign partial path values to kwargs and extra_args.
 

--- a/tests/test_params_description.py
+++ b/tests/test_params_description.py
@@ -137,22 +137,3 @@ def test_node_params_empty_without_plugin():
             return None
 
     assert NoPlugin().route.node("handler").params == {}
-
-
-def test_node_accepts():
-    node = ParamsService().route.node("search")
-    assert node.accepts("user_id") is True
-    assert node.accepts("limit") is True
-    assert node.accepts("nope") is False
-    assert node.accepts("self") is False
-
-
-def test_node_accepts_without_plugin_falls_back():
-    class NoPlugin(RoutingClass):
-        @route()
-        def handler(self, item_id):
-            return None
-
-    node = NoPlugin().route.node("handler")
-    assert node.accepts("item_id") is True
-    assert node.accepts("nope") is False


### PR DESCRIPTION
Follow-up cleanup of #37 (released in 0.25.0 earlier today).

## Why

Issue #37 asked for a way to know an entry's accepted parameters on the live node — *"a params property OR an accepts(name) method"*. 0.25.0 shipped both. The `params` property already exposes the full per-parameter list (`fields`), so `accepts(name)` was redundant.

## What changed

- Removed `RouterNode.accepts(name)` and its two tests.
- The `params` property is unchanged and still satisfies the issue requirement.
- No consumer had migrated to `accepts()` (0.25.0 was published the same day; genro-asgi not yet migrated).

## Notes

- Version bumped to **0.25.1** (patch): trims a public symbol from a same-day release that was never consumed.
- Suite: **326 passed** (down from 328: the two accepts tests removed). ruff clean, mypy advisory no new issues.