### PR TITLE
feat!: params fields describe var-parameters; drop accepts_varargs from block

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genro-routes"
-version = "0.25.1"
+version = "0.26.0"
 description = "Instance-scoped routing engine for Python with hierarchical handlers and composable plugins"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/genro_routes/core/router.py
+++ b/src/genro_routes/core/router.py
@@ -579,15 +579,19 @@ class Router(BaseRouter):
         """Build the dialect-neutral input-params block for a handler.
 
         Twin of the result block, for the input side: exposes the aggregate
-        input JSON Schema plus a per-parameter list (name, schema, required,
-        default, kind). Both are cached by the pydantic plugin at decoration
-        time; this only reads them, so nodes() never re-serializes a schema.
-        Present only when the pydantic plugin captured params for this entry.
+        input JSON Schema plus a per-parameter list. ``fields`` is the complete
+        parameter description in declaration order, each entry being
+        ``{name, schema, required, default, kind}``; the var-parameters are
+        included with kind ``var_positional`` (``*args``) and ``var_keyword``
+        (``**kwargs``), so a consumer knows the handler accepts arbitrary
+        arguments from ``fields`` alone. Both are cached by the pydantic plugin
+        at decoration time; this only reads them, so nodes() never
+        re-serializes a schema. Present only when the pydantic plugin captured
+        params for this entry.
 
         Returns:
-            ``{"schema": <json schema | None>, "fields": [...],
-            "accepts_varargs": <bool>}`` when the plugin captured params,
-            else an empty dict.
+            ``{"schema": <json schema | None>, "fields": [...]}`` when the
+            plugin captured params, else an empty dict.
         """
         pydantic_meta = entry.metadata.get("pydantic", {})
         if "param_fields" not in pydantic_meta:
@@ -595,5 +599,4 @@ class Router(BaseRouter):
         return {
             "schema": pydantic_meta.get("request_schema"),
             "fields": pydantic_meta["param_fields"],
-            "accepts_varargs": pydantic_meta.get("accepts_varargs", False),
         }

--- a/src/genro_routes/plugins/pydantic.py
+++ b/src/genro_routes/plugins/pydantic.py
@@ -181,12 +181,26 @@ class PydanticPlugin(BasePlugin):
             request_schema = model.model_json_schema()
             props = request_schema.get("properties", {})
             pydantic_meta["request_schema"] = request_schema
+        # fields is the complete parameter description, in declaration order,
+        # including the var-parameters (*args -> var_positional, **kwargs ->
+        # var_keyword) so a consumer knows the handler accepts arbitrary
+        # positional/keyword arguments without re-inspecting the callable.
+        var_kinds = (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        )
         param_fields = []
         for param_name, param in sig.parameters.items():
-            if param.kind in (
-                inspect.Parameter.VAR_POSITIONAL,
-                inspect.Parameter.VAR_KEYWORD,
-            ):
+            if param.kind in var_kinds:
+                param_fields.append(
+                    {
+                        "name": param_name,
+                        "schema": None,
+                        "required": False,
+                        "default": None,
+                        "kind": param.kind.name.lower(),
+                    }
+                )
                 continue
             required = param.default is inspect.Parameter.empty
             param_fields.append(

--- a/tests/test_params_description.py
+++ b/tests/test_params_description.py
@@ -5,10 +5,11 @@
 
 The params block is the input-side twin of the result block. Per entry it
 exposes the aggregate input JSON Schema plus a per-parameter list (name,
-schema, required, default, kind) and an accepts_varargs flag. It is produced
-once by the pydantic plugin at decoration time and only read at runtime, so
-nodes()/node().params never re-serialize a schema. It is present only when the
-pydantic plugin captured params for the entry.
+schema, required, default, kind) in declaration order. fields is complete: it
+includes the var-parameters with kind var_positional (*args) and var_keyword
+(**kwargs). It is produced once by the pydantic plugin at decoration time and
+only read at runtime, so nodes()/node().params never re-serialize a schema. It
+is present only when the pydantic plugin captured params for the entry.
 """
 
 from __future__ import annotations
@@ -80,16 +81,26 @@ def test_unannotated_param_has_no_schema():
     assert "note" not in params["schema"]["properties"]
 
 
-def test_varargs_excluded_and_flagged():
+def test_var_parameters_included_with_kind():
     params = _entries()["mixed"]["params"]
-    names = {f["name"] for f in params["fields"]}
-    assert names == {"user_id", "note", "flag"}  # *tags / **opts excluded
-    assert params["accepts_varargs"] is True
+    # fields is complete and in declaration order, var-params included
+    ordered = [(f["name"], f["kind"]) for f in params["fields"]]
+    assert ordered == [
+        ("user_id", "positional_or_keyword"),
+        ("note", "positional_or_keyword"),
+        ("tags", "var_positional"),
+        ("flag", "keyword_only"),
+        ("opts", "var_keyword"),
+    ]
 
 
-def test_keyword_only_kind():
+def test_var_parameters_shape():
     params = _entries()["mixed"]["params"]
-    assert _field(params, "flag")["kind"] == "keyword_only"
+    for name in ("tags", "opts"):
+        field = _field(params, name)
+        assert field["schema"] is None
+        assert field["required"] is False
+        assert field["default"] is None
 
 
 def test_nested_model_param_has_defs():
@@ -111,7 +122,6 @@ def test_noargs_block_present_but_empty():
     params = _entries()["noargs"]["params"]
     assert params["fields"] == []
     assert params["schema"] is None
-    assert params["accepts_varargs"] is False
 
 
 def test_no_params_block_without_pydantic_plugin():


### PR DESCRIPTION
Follow-up of #37. Makes the params block `fields` the complete, single source for an entry's parameter description.

## Why

`fields` used to skip the var-parameters (`*args` and `**kwargs`). The only signal about var-args was the `accepts_varargs` flag — and there was **no** signal at all about `**kwargs`. A consumer reading `fields` could not tell that a handler accepts arbitrary keyword arguments without re-inspecting the callable, defeating the purpose of #37.

## What changed

- `fields` is now complete and in declaration order: `*args` and `**kwargs` are emitted as fields with `kind` `var_positional` / `var_keyword` (`schema=None`, `required=False`, `default=None`, real parameter name).
- Removed the now-redundant `accepts_varargs` flag **from the params block** — `*args` is a field with `kind=var_positional`, so the flag was a lossy parallel to `fields`.
- `accepts_varargs` **stays** in the pydantic plugin metadata (`entry_metadata`) and in dispatch (`_assign_partial`), where it serves a different purpose (introspection / path-segment handling), unchanged.

A consumer derives everything from `fields`: `accepts_kwargs = any(f["kind"] == "var_keyword")`, and the normal parameter names are the fields with kind `positional_or_keyword` / `keyword_only` / `positional_only`.

## Not touched

- The aggregate input `schema` (JSON Schema for OpenAPI/MCP) is unchanged.
- The `result` block (#35) is unchanged.
- No runtime `inspect`: read from the signature cached at decoration time.

## Breaking

- **BREAKING**: `params` no longer carries `accepts_varargs`; `fields` now includes var-parameters. Version bumped to **0.26.0**.

## Verification

- `def h(self, a, b=1, *args, c=2, **kw)` → `fields` = `[(a, positional_or_keyword), (b, positional_or_keyword), (args, var_positional), (c, keyword_only), (kw, var_keyword)]`; `self` excluded.
- Suite: **326 passed** (`test_coverage_gaps` still green — `entry_metadata.accepts_varargs` untouched). ruff clean, mypy advisory no new issues.