### PR TITLE
Release 0.27.0 — lazy branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,42 @@ info = app.route.nodes()
 print(info["routers"].keys())  # dict_keys(['users'])
 ```
 
+## Branches: Lazy Subtrees and Aliases
+
+On large trees (thousands of leaves), building every child instance at startup
+is wasteful. **Branches** declare subtrees as factory specs — nothing is
+constructed until actually needed:
+
+```python
+class Application(RoutingClass):
+    def __init__(self):
+        self.add_branches([
+            {"name": "users",  "cls": UsersAPI},                    # eager: built at first tree access
+            {"name": "sales",  "cls": SalesAPI,  "lazy": True},     # lazy: built at first traversal
+            {"name": "shop",   "alias": "sales"},                   # alias: symlink to another branch
+        ])
+
+app = Application()
+app.route.node("sales/report")()   # first traversal builds SalesAPI here
+app.route.node("shop/report")()    # same subtree via the alias (target's plugins)
+```
+
+- **Eager** branches materialize at the first tree access; **lazy** ones only
+  when a path first traverses them. Constructor errors surface at that moment.
+- `add_branches` accepts one dict, a list, or a generator — so a discovery
+  function can `yield` thousands of specs with zero construction cost.
+- **Aliases** are transparent symlinks by absolute path from the tree root:
+  the whole target subtree is reachable, with the *target's* plugins.
+- Introspection never builds implicitly: `nodes()` shows lazy branches and
+  aliases as unresolved markers (with their class-declared `@route` leaves,
+  read without instantiating). Use `nodes(_eager=True)` to expand everything
+  (e.g. to generate a full OpenAPI document) or `nodes(basepath="sales")` to
+  open one branch explicitly.
+- `attach_instance(child, name=...)` remains supported for attaching an
+  already-built instance; `add_branches` is the recommended declarative form.
+
+See the [Branches Guide](docs/guide/branches.md) for the full lifecycle.
+
 ## Learn by Example
 
 We provide a comprehensive gallery of examples in the [examples/](https://github.com/genropy/genro-routes/tree/main/examples) directory:
@@ -226,7 +262,7 @@ Supported types: `TypedDict`, `dict[str, int]`, `list[...]`, `str`, `int`, `bool
 - **`Section`** - Empty `RoutingClass` used as a grouping node: `svc.attach_instance(Section("Admin area"), name="admin")`
 - **`RoutingContext`** - Extensible execution context with parent chain delegation. Attach any attribute (`ctx.db`, `ctx.user`, `ctx.session`); missing lookups walk up `RoutingContext(parent=...)`. Stored in a `_ctx` slot on each instance — children inherit via `_routing_parent` chain. See [Execution Context Guide](docs/guide/context.md).
 - **`BasePlugin`** - Base class for creating plugins with `on_decore` and `wrap_handler` hooks
-- **`obj.routing`** - Proxy exposed by every RoutingClass that provides helpers like `get_router(...)` and `configure(...)` for managing routers/plugins without polluting the instance namespace.
+- **`obj.routing`** - Proxy exposed by every RoutingClass that provides `configure(...)` for managing plugin settings without polluting the instance namespace.
 - **`RouterNode`** - Callable wrapper returned by `node()`, with `path`, `error`, `doc`, `metadata` properties.
 - **`NotFound` / `NotAuthenticated` / `NotAuthorized` / `NotAvailable`** - Exceptions for routing errors (not found, auth required, auth denied, capabilities missing)
 
@@ -241,7 +277,9 @@ See [Why One Name Per Operation](docs/guide/why-one-name-per-operation.md) for t
 ## Pattern Highlights
 
 - **Explicit naming + prefixes** - `@route(name="detail")` and `self.route.prefix = "handle_"` separate method names from public route names.
-- **Explicit instance hierarchies** - `self.attach_instance(child, name="alias")` connects RoutingClass instances. Retrieve children later with `routing.instance("alias")`.
+- **Explicit instance hierarchies** - `self.attach_instance(child, name="alias")` connects RoutingClass instances. Navigate with `route.node("alias/handler")` or inspect with `route.nodes(basepath="alias")`.
+- **Declarative branches (lazy/eager)** - `self.add_branches({"name": "sales", "cls": Sales, "lazy": True})` declares subtrees as factory specs, built only when traversed. See [Branches](#branches-lazy-subtrees-and-aliases).
+- **Branch aliases** - `{"name": "fake", "alias": "real/path"}` exposes an existing subtree under a second name, like a filesystem symlink.
 - **Endpoint ID** - `@route(endpoint_id="USR-001")` assigns a stable identifier for reverse lookup via `router.node("@USR-001")`.
 - **Grouping nodes** - `attach_instance(Section("Admin area"), name="admin")` creates pure organizational nodes without handlers.
 - **Built-in and custom plugins** - `self.route.plug("logging")`, `self.route.plug("pydantic")`, or custom plugins.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,10 +20,44 @@ graph TD
 ```
 
 - Every `RoutingClass` owns exactly one `Router`, created lazily on first access of the read-only `route` property. User code never instantiates `Router` directly; router options (`description`, `prefix`, `default_entry`) are set on `self.route` in `__init__`.
-- Hierarchies are built via `attach_instance(child, name=alias)` (method on `RoutingClass`), which links `child.route` into the parent's router under the alias, and torn down via `detach_instance` (method on `Router`).
+- Hierarchies are built via `attach_instance(child, name=alias)` (method on `RoutingClass`), which links `child.route` into the parent's router under the alias, and torn down via `detach_instance` (method on `Router`). The declarative equivalent is `add_branches` (see Branches below).
 - `Section` (an empty `RoutingClass`) provides pure grouping nodes without handlers: `svc.attach_instance(Section("Admin area"), name="admin")`.
 - `default_entry` (default: `"index"`) specifies which handler to use for catch-all routing (best-match resolution).
 - Introspection: `nodes()` is the sole API; it returns router/instance, handlers (with metadata, doc, signature, plugins, params), children, and `plugin_info`.
+
+## Branches (declarative subtrees: eager, lazy, alias)
+
+A **branch** is a child subtree declared as a factory spec and materialized on
+demand. Specs live in `router._branches`; materialized children move to
+`router._children`. One mechanism, two timing policies, plus symlinks:
+
+```mermaid
+graph LR
+  Spec["branch spec {name, lazy, cls, params}"] -->|"first tree access (eager) / first traversal (lazy)"| Child["child router in _children"]
+  Alias["alias spec {name, alias: path}"] -->|"path rewrite from root"| Target["target subtree"]
+```
+
+- `add_branches(spec | list | generator)` stores specs — nothing is constructed
+  at declaration. `remove_branch(name)` drops a spec (detaching the child if
+  already materialized). The `branches` property lists declared, not-yet-built
+  specs only.
+- **Materialization** (single point): construct `cls(**params)`, wire
+  `_routing_parent`, `include()` the child router (triggering plugin
+  inheritance), then drop the spec. The spec is popped only after a successful
+  build: a failing constructor is repeatable, never silently lost.
+- **Eager** specs materialize at the first tree access (guard set after a fully
+  successful pass); **lazy** specs at the first path traversal through their
+  segment (`_find_candidate_node` / `router_at_path`).
+- **Alias** specs are transparent symlinks by absolute path from the tree root:
+  navigation rewrites the path and resolves from the root, so the target's
+  whole subtree is served with the target's plugins. Cycle-guarded
+  (`ValueError`); broken targets resolve to `not_found`. A node reached through
+  an alias reports the target's path (realpath semantics).
+- **Introspection never builds**: `nodes()` shows lazy branches with their
+  class-declared `@route` leaves (scanned from the class MRO, no instance) and
+  aliases as unresolved markers. `nodes(_eager=True)` expands everything;
+  `nodes(basepath=...)` opens one subtree. `node("@endpoint_id")` skips
+  non-materialized lazy branches.
 
 ## Plugin store
 

--- a/docs/CODE_READING_GUIDE.md
+++ b/docs/CODE_READING_GUIDE.md
@@ -524,11 +524,13 @@ without polluting the class namespace:
 
 | Proxy method | Purpose |
 |--------------|---------|
-| `get_router(path=None)` | The owner's router, or a child router at path |
-| `instance(path)` | The RoutingClass instance owning the child router at path |
 | `configure(target, **opts)` | Plugin configuration via target syntax |
 | `configure("?")` | Introspection: returns the router description dict |
 | `attach_instance(child, name=...)` | Delegates to the owner's `attach_instance` |
+
+For navigation and introspection use the router directly: `route.node(path)`
+resolves (and executes) a path, `route.nodes(basepath=...)` inspects and opens
+a subtree.
 
 **Target syntax for configure**: `"plugin/selector"`
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -114,8 +114,9 @@ def handle_create(self): ...  # Registered as "create" (strips prefix)
 **Answer**: **Yes**. `RoutingClass` is the mixin that binds a class to its router:
 
 - `obj.route` — the instance's single router, created lazily (read-only property)
-- `obj.routing` — proxy for configuration and lookup (`configure()`, `get_router()`, `instance()`)
+- `obj.routing` — proxy for plugin configuration (`configure()`)
 - `obj.attach_instance(child, name=...)` — connects child instances into a hierarchy
+- `obj.add_branches(specs)` — declares child subtrees as factory specs (eager/lazy/alias)
 - `obj.ctx` — execution context with parent-chain lookup
 
 A `Router` can only be owned by a `RoutingClass` instance.

--- a/docs/concepts_to_add/lazy-branches.md
+++ b/docs/concepts_to_add/lazy-branches.md
@@ -123,11 +123,13 @@ self.add_branches([
 Implementation: `_find_candidate_node` / `router_at_path` / `nodes()` detect an
 alias spec and rewrite via `_root_router()` + `_resolve_alias` (cycle-guarded).
 
-### Sharing a single leaf — deferred
+### Sharing a single leaf — NOT SUPPORTED (decided)
 
 Reusing a single leaf under a new name *with its own plugins* (own plugins +
-delegated body) is a separate case, deferred. It is a normal `@route` def whose
-body delegates to another node's callable — not an alias branch.
+delegated body) is **explicitly out of scope** — it will not be implemented.
+Sharing is only a whole-branch alias (above). If a caller needs to expose one
+handler elsewhere, they write a normal `@route` method and call the target
+themselves in its body; the framework offers no dedicated leaf-alias mechanism.
 
 ## Separation of responsibility
 

--- a/docs/concepts_to_add/lazy-branches.md
+++ b/docs/concepts_to_add/lazy-branches.md
@@ -1,0 +1,165 @@
+# Lazy Branches — declarative subrouters, materialized on demand
+
+**Status**: 🔴 DA REVISIONARE
+**Version**: 0.1
+**Last Updated**: 2026-07-15
+
+## Summary
+
+Introduce **branches**: subrouters declared as a factory (`cls + params`) and
+**materialized only when needed**. A `RoutingClass` populates a `_branches`
+dictionary of self-describing entries; each branch is **eager** (built at first
+tree access) or **lazy** (built on-demand at first traversal). This lets trees
+with thousands of leaves start cheaply — nothing is instantiated until walked.
+
+This proposal also **removes** two things: the `attach_instance` API (replaced by
+a single factory-based `add_branches`) and the object-identity "secondary link"
+sharing mechanism (replaced by an ordinary route method that reuses another
+node's callable).
+
+## Rationale
+
+Today a subtree is attached with `attach_instance(child_instance, name=...)`
+([routing.py:169](../../src/genro_routes/core/routing.py)): the child must be
+**already constructed**. On large trees this instantiates everything at boot —
+expensive and usually wasteful, since most branches are never walked.
+
+A factory (`cls + params`) can be **deferred**; a pre-built instance cannot. One
+factory path is the single source of truth and is what enables lazy timing.
+
+## Vocabulary
+
+A branch has three views across its lifecycle — this is the mental model:
+
+| Term | Phase | Where |
+|------|-------|-------|
+| **branch** | declared (factory spec) | `_branches` dict |
+| **child** | materialized (real router) | `_children` dict |
+| **node** | traversed | `RouterNode` from `node()` |
+
+`branch` names the phase that today has no name: the lazy/factory declaration.
+An `entry` remains a single leaf (handler method); a `branch` is a subtree.
+
+## Model
+
+| Axis | Decision |
+|------|----------|
+| Declaration | `_branches` dict **per instance**, populated by `add_branches` |
+| Entry shape | self-describing **dict**: `{"name", "lazy", "cls", "params"}` |
+| Add API | `add_branches(dict \| list[dict] \| generator)` — one method, singular or plural |
+| Remove API | `remove_branch(name)` |
+| Read | `self.branches` (inspection) |
+| Params | dict, applied as `cls(**params)` at materialization |
+| Eager | materialized at **first tree access** (`.route`/`nodes()`/`node()`) |
+| Lazy | materialized **on-demand** at first traversal of the branch |
+| `nodes()` | describes non-materialized lazy branches **without building them**, including their class-declared leaves |
+| `node("@id")` | reverse lookup **only** over eager + already-materialized (skips lazy) |
+| Sharing | a route method reusing another node's callable (not a framework feature) |
+
+### Lifecycle
+
+1. `Alfa.__init__` → `add_branches(...)` populates **only** `_branches`. No
+   instance constructed.
+2. First tree access → materialize **all** eager branches (idempotent guard).
+   Lazy branches untouched.
+3. Request for a lazy branch → materialize **that single** branch on-demand; it
+   becomes a `child` in `_children`.
+
+### Two distinct laziness levels
+
+- **Spec enumeration** → at the `add_branches` call (a generator is consumed
+  immediately, inside `__init__`). Light metadata only.
+- **Instance construction** → at materialization (eager at first access, lazy
+  on-demand). This is where the real saving lives.
+
+A generator yielding only specs + lazy branches = end-to-end laziness.
+
+### Materialization (single point, reuses existing machinery)
+
+Construct `cls(**params)` → set `_routing_parent` → `include()` → apply plugins
+(`_on_attached_to_parent` / `_propagate_plugin_to_children`,
+[router.py:438](../../src/genro_routes/core/router.py), [router.py:477]) → replace
+the branch with the real `child` router in `_children`. No new propagation
+mechanism — moved from attach-time to materialization-time. The plugin layer
+already defers work for a "declared but not yet bound" child (`child._bound`
+guard, [router.py:470]).
+
+### `nodes()` on a lazy branch
+
+Shows: alias + `lazy` flag + the class's **declared leaves**, read from the
+class-level `@route` markers **without instantiating**. Verified feasible: in
+`_iter_marked_methods` ([base_router.py:417-447](../../src/genro_routes/core/base_router.py))
+only `cls = type(self.instance)` (line 424) depends on the instance; the whole
+scan operates on the class via `cls.__mro__` / `vars(base)` /
+`_route_decorator_kw` ([decorators.py:90](../../src/genro_routes/core/decorators.py)).
+
+### Sharing — callable reuse, not object sharing
+
+The old "secondary link" (same router object under two names, built on
+object-identity `is` / `_routing_parent` primary-vs-secondary in
+`_include_router` [base_router.py:571-585]) is **removed** — incompatible with
+factory-only.
+
+Sharing becomes an ordinary route method that takes another node's **callable**
+and registers it as its own:
+
+```python
+class Alfa(RoutingClass):
+    @route()          # 'sales' is a normal entry, with ITS OWN plugins
+    def sales(self, ...):
+        ...           # its callable is child's, taken via get_node("child")
+```
+
+- **Common factor = only the callable.** Plugins are NOT shared: `sales` runs its
+  own plugins, then executes child's method.
+- The reused callable is a **bound method** ([base_router.py:407]) — stays bound
+  to child's instance (operates on child's data); only the plugin context is
+  sales's.
+- Reusing the callable of a **lazy** branch **forces its materialization** at that
+  moment. Accepted.
+
+## Separation of responsibility
+
+- **framework** → provides the mechanism (`add_branches` + materialization)
+- **RoutingClass author** → decides which branches are lazy (e.g. an `if lazy:`
+  in the class's own `__init__`)
+- **end user** → activates via an application flag (e.g. `Alfa(lazy=True)`),
+  without knowing the internals. The `lazy` flag is an application convention,
+  not something the framework imposes.
+
+## Illustrative usage (not final)
+
+```python
+class Alfa(RoutingClass):
+    def __init__(self, lazy=False):
+        self.add_branches([
+            {"name": "beta",  "lazy": lazy,  "cls": Beta,  "params": {"x": 56}},
+            {"name": "gamma", "lazy": False, "cls": Gamma, "params": {}},
+        ])
+
+    # or from a discovery function the author writes however they like
+    def discover(self):
+        for name, cls, params in self.scan_somewhere():
+            yield {"name": name, "lazy": True, "cls": cls, "params": params}
+```
+
+## Scope — files to modify (implementation phase)
+
+| File | Change |
+|------|--------|
+| `core/routing.py` | `RoutingClass`: `_branches` slot, `add_branches`, `remove_branch`, `branches` property; **remove** `attach_instance`; eager-materialization guard |
+| `core/base_router.py` | `_find_candidate_node` (lazy materialization on descent); `nodes()` (describe lazy branches + class leaves); `_search_endpoint_id` (skip lazy); **remove** secondary-link logic in `_include_router`; callable-reuse helper |
+| `core/router.py` | materialization applies plugins (reuse existing hooks) |
+| `tests/` | migrate ~89 `attach_instance` call-sites to `add_branches`; new exhaustive suite for lazy/eager, materialization, `nodes()`, `@endpoint_id`, add/remove runtime, callable reuse, deferred errors, guard idempotency |
+| `docs/` | update guides referencing `attach_instance` (e.g. `guide/attach-instance-visual-guide.md`) |
+
+## Open questions
+
+- Exact API for the callable-reuse helper (argument / `ctx` forwarding semantics).
+- Slot count on `RoutingClass` `__slots__` ([routing.py:116]): new slot(s) for
+  `_branches` and the eager-materialization idempotent guard.
+
+## Out of scope
+
+- This document is a **proposal**, not source of truth, until approved.
+- Implementation follows tests-first, one block at a time, suite green at each step.

--- a/docs/concepts_to_add/lazy-branches.md
+++ b/docs/concepts_to_add/lazy-branches.md
@@ -116,7 +116,9 @@ self.add_branches([
   "own plugins" idea once discussed.)
 - Resolution is lazy: the alias is a string; navigating it materializes lazy
   branches along the target path.
-- `nodes()` shows the target's subtree under the alias name with an `alias` marker.
+- `nodes()` shows the alias as an unresolved marker `{"name", "alias": target}`
+  without building anything; `nodes(_eager=True)` expands everything (materializes
+  lazy branches, resolves aliases); `nodes(basepath=alias)` opens one explicitly.
 - Broken alias → `not_found`; alias cycle → `ValueError`. Reached from the **root**
   (absolute), not from the declaring router.
 

--- a/docs/concepts_to_add/lazy-branches.md
+++ b/docs/concepts_to_add/lazy-branches.md
@@ -1,8 +1,8 @@
 # Lazy Branches — declarative subrouters, materialized on demand
 
-**Status**: 🔴 DA REVISIONARE
-**Version**: 0.1
-**Last Updated**: 2026-07-15
+**Status**: 🟢 IMPLEMENTED (0.27) — kept as design record
+**Version**: 1.0
+**Last Updated**: 2026-07-16
 
 ## Summary
 
@@ -12,10 +12,15 @@ dictionary of self-describing entries; each branch is **eager** (built at first
 tree access) or **lazy** (built on-demand at first traversal). This lets trees
 with thousands of leaves start cheaply — nothing is instantiated until walked.
 
-This proposal also **removes** two things: the `attach_instance` API (replaced by
-a single factory-based `add_branches`) and the object-identity "secondary link"
-sharing mechanism (replaced by an ordinary route method that reuses another
-node's callable).
+**Transition note (0.27)**: this release is **additive**. `attach_instance`
+(attaching an already-built instance) and `include()` remain fully supported;
+`add_branches` is the recommended declarative form. The removal of
+`attach_instance` and of the object-identity "secondary link" is deferred to a
+later, breaking release. Whole-branch sharing is covered today by **alias
+branches** (below); single-leaf sharing is explicitly out of scope.
+
+User documentation: [Branches Guide](../guide/branches.md) and the Branches
+section of [ARCHITECTURE](../ARCHITECTURE.md).
 
 ## Rationale
 
@@ -158,23 +163,17 @@ class Alfa(RoutingClass):
             yield {"name": name, "lazy": True, "cls": cls, "params": params}
 ```
 
-## Scope — files to modify (implementation phase)
+## Implemented (0.27)
 
 | File | Change |
 |------|--------|
-| `core/routing.py` | `RoutingClass`: `_branches` slot, `add_branches`, `remove_branch`, `branches` property; **remove** `attach_instance`; eager-materialization guard |
-| `core/base_router.py` | `_find_candidate_node` (lazy materialization on descent); `nodes()` (describe lazy branches + class leaves); `_search_endpoint_id` (skip lazy); **remove** secondary-link logic in `_include_router`; callable-reuse helper |
-| `core/router.py` | materialization applies plugins (reuse existing hooks) |
-| `tests/` | migrate ~89 `attach_instance` call-sites to `add_branches`; new exhaustive suite for lazy/eager, materialization, `nodes()`, `@endpoint_id`, add/remove runtime, callable reuse, deferred errors, guard idempotency |
-| `docs/` | update guides referencing `attach_instance` (e.g. `guide/attach-instance-visual-guide.md`) |
+| `core/base_router.py` | `_branches`/`_eager_done` slots; `add_branches`, `remove_branch`, `branches`; materialization (`_materialize_branch`/`_materialize_eager`, spec popped after successful build); lazy descent in `_find_candidate_node`/`router_at_path`; alias resolution (`_root_router`/`_resolve_alias`, cycle-guarded); `nodes()` markers + `_eager=True` expansion + class-leaf scan; `_search_endpoint_id` skips lazy |
+| `core/routing.py` | `RoutingClass.add_branches`/`remove_branch`/`branches` delegating to the router; module docstring (Branches + Alias sections); proxy `get_router`/`instance`/`_navigate_router` removed |
+| `tests/` | `test_lazy_branches.py` + `test_branch_alias.py` (exhaustive, behavioral); Pattern-A call-sites migrated to `add_branches` |
+| `docs/` | `guide/branches.md`; README, ARCHITECTURE, FAQ, hierarchies/best-practices updated |
 
-## Open questions
+## Deferred to a later breaking release
 
-- Exact API for the callable-reuse helper (argument / `ctx` forwarding semantics).
-- Slot count on `RoutingClass` `__slots__` ([routing.py:116]): new slot(s) for
-  `_branches` and the eager-materialization idempotent guard.
-
-## Out of scope
-
-- This document is a **proposal**, not source of truth, until approved.
-- Implementation follows tests-first, one block at a time, suite green at each step.
+- Removal of `attach_instance` and of the secondary-link logic in
+  `_include_router`; migration of the remaining instance-based test call-sites.
+- Single-leaf sharing stays out of scope (see above).

--- a/docs/concepts_to_add/lazy-branches.md
+++ b/docs/concepts_to_add/lazy-branches.md
@@ -93,30 +93,41 @@ only `cls = type(self.instance)` (line 424) depends on the instance; the whole
 scan operates on the class via `cls.__mro__` / `vars(base)` /
 `_route_decorator_kw` ([decorators.py:90](../../src/genro_routes/core/decorators.py)).
 
-### Sharing — callable reuse, not object sharing
+### Sharing a whole branch — alias branch (symlink) — IMPLEMENTED
 
 The old "secondary link" (same router object under two names, built on
-object-identity `is` / `_routing_parent` primary-vs-secondary in
-`_include_router` [base_router.py:571-585]) is **removed** — incompatible with
-factory-only.
-
-Sharing becomes an ordinary route method that takes another node's **callable**
-and registers it as its own:
+object-identity) is replaced by an **alias branch**: a symlink to another branch,
+addressed by an **absolute path** from the tree root.
 
 ```python
-class Alfa(RoutingClass):
-    @route()          # 'sales' is a normal entry, with ITS OWN plugins
-    def sales(self, ...):
-        ...           # its callable is child's, taken via get_node("child")
+self.add_branches([
+    {"name": "real", "cls": Leaf},
+    {"name": "fake", "alias": "real"},          # symlink to the 'real' branch
+])
 ```
 
-- **Common factor = only the callable.** Plugins are NOT shared: `sales` runs its
-  own plugins, then executes child's method.
-- The reused callable is a **bound method** ([base_router.py:407]) — stays bound
-  to child's instance (operates on child's data); only the plugin context is
-  sales's.
-- Reusing the callable of a **lazy** branch **forces its materialization** at that
-  moment. Accepted.
+- Spec: `{"name", "alias": "<absolute path>"}`; `alias` and `cls` are mutually
+  exclusive (ValueError otherwise).
+- Navigating into an alias **rewrites the path** to the target and resolves from
+  the root: `node("fake/x")` → `real/x`. The whole subtree (branches + leaves,
+  recursive) is reachable through it.
+- **Plugins are the target's** — a transparent symlink; the alias adds none and
+  they are not redefinable. (This is the old `include(router)` semantics, not the
+  "own plugins" idea once discussed.)
+- Resolution is lazy: the alias is a string; navigating it materializes lazy
+  branches along the target path.
+- `nodes()` shows the target's subtree under the alias name with an `alias` marker.
+- Broken alias → `not_found`; alias cycle → `ValueError`. Reached from the **root**
+  (absolute), not from the declaring router.
+
+Implementation: `_find_candidate_node` / `router_at_path` / `nodes()` detect an
+alias spec and rewrite via `_root_router()` + `_resolve_alias` (cycle-guarded).
+
+### Sharing a single leaf — deferred
+
+Reusing a single leaf under a new name *with its own plugins* (own plugins +
+delegated body) is a separate case, deferred. It is a normal `@route` def whose
+body delegates to another node's callable — not an alias branch.
 
 ## Separation of responsibility
 

--- a/docs/genro-routes-for-dummies.html
+++ b/docs/genro-routes-for-dummies.html
@@ -815,7 +815,7 @@ print(tree[<span class="str">"routers"</span>].keys())  <span class="cmt"># dict
   <li><code class="il">self.route.prefix = "handle_"</code> &mdash; strip method prefixes (<code class="il">handle_list</code> &rarr; entry <code class="il">list</code>)</li>
   <li>Auto-detach on attribute replacement &mdash; swap child services at runtime</li>
   <li>Dotted path resolution &mdash; <code class="il">"users/list_users"</code> walks the tree</li>
-  <li><code class="il">routing.instance("users")</code> &mdash; retrieve any attached child instance without storing it as an attribute</li>
+  <li><code class="il">route.nodes(basepath="users")["instance"]</code> &mdash; retrieve any attached child instance without storing it as an attribute</li>
 </ul>
 
 </div>
@@ -1080,7 +1080,7 @@ cli = RoutingCli(svc)</code></pre>
 <table>
   <tr><th>I want to...</th><th>Code</th></tr>
   <tr><td>Attach a child service</td><td><code class="il">parent.attach_instance(child, name="x")</code></td></tr>
-  <tr><td>Retrieve attached child instance</td><td><code class="il">parent.routing.instance("x")</code></td></tr>
+  <tr><td>Retrieve attached child instance</td><td><code class="il">parent.route.nodes(basepath="x")["instance"]</code></td></tr>
   <tr><td>Call through hierarchy</td><td><code class="il">parent.route.node("x/handler")()</code></td></tr>
   <tr><td>Resolve by endpoint_id</td><td><code class="il">parent.route.node("@MY-EP")()</code></td></tr>
   <tr><td>Create a pure grouping node (no handlers)</td><td><code class="il">parent.attach_instance(Section("Admin"), name="admin")</code></td></tr>

--- a/docs/guide/best-practices.md
+++ b/docs/guide/best-practices.md
@@ -123,7 +123,7 @@ class Parent(RoutingClass):
         self.attach_instance(ChildService(), name="child")
 
 # Retrieve the child instance later if needed
-child = parent.routing.instance("child")
+child = parent.route.nodes(basepath="child")["instance"]
 ```
 
 ## Plugin Usage
@@ -369,7 +369,7 @@ svc.routing.configure("logging/debug_*", print=True)
 |----|-------|
 | Keep services focused | Mix unrelated handlers |
 | Use meaningful names | Use vague names |
-| Use `routing.instance()` to retrieve children | Rely on global variables for child access |
+| Use `nodes(basepath=...)` to retrieve children | Rely on global variables for child access |
 | Apply plugins at right level | Over-apply plugins |
 | Let errors propagate | Swallow exceptions |
 | Test handlers in isolation | Only test via HTTP |

--- a/docs/guide/branches.md
+++ b/docs/guide/branches.md
@@ -1,0 +1,206 @@
+# Branches: Lazy Subtrees and Aliases
+
+Declare subtrees as factory specs and build them only when needed. On trees
+with thousands of leaves, branches let the application start instantly:
+nothing is constructed until a path is actually traversed.
+
+## Overview
+
+A **branch** is a child subtree declared as a self-describing spec instead of
+an already-built instance. The same object has three views across its
+lifecycle:
+
+| Term | Phase | Where |
+|------|-------|-------|
+| **branch** | declared (factory spec) | the router's declared branches |
+| **child** | materialized (real router) | the router's children |
+| **node** | traversed | `RouterNode` from `node()` |
+
+The mental model is a file explorer: declaring a branch puts a closed folder
+in the tree; opening it (traversing a path through it) builds its content;
+sub-folders stay closed until you open them too.
+
+## Declaring Branches
+
+`add_branches` accepts one spec dict, a list, or any iterable/generator:
+
+```python
+from genro_routes import RoutingClass, route
+
+class UsersAPI(RoutingClass):
+    @route()
+    def list(self):
+        return ["alice", "bob"]
+
+class SalesAPI(RoutingClass):
+    def __init__(self, region: str = "eu"):
+        self.region = region
+
+    @route()
+    def report(self):
+        return f"sales:{self.region}"
+
+class Application(RoutingClass):
+    def __init__(self):
+        self.add_branches([
+            {"name": "users", "cls": UsersAPI},                              # eager
+            {"name": "sales", "cls": SalesAPI, "params": {"region": "us"},
+             "lazy": True},                                                  # lazy
+        ])
+
+app = Application()
+assert app.route.node("sales/report")() == "sales:us"
+```
+
+A **factory spec** has these fields:
+
+| Field | Required | Meaning |
+|-------|----------|---------|
+| `name` | yes | alias under which the child is reachable (path segment) |
+| `cls` | yes | the `RoutingClass` subclass to instantiate |
+| `params` | no (default `{}`) | kwargs applied as `cls(**params)` at materialization |
+| `lazy` | no (default `False`) | when the instance is built (see below) |
+
+Declaring **never constructs anything** — specs are stored, instances come
+later. A generator can therefore yield thousands of specs at zero cost:
+
+```python
+class Application(RoutingClass):
+    def __init__(self):
+        self.add_branches(self.discover())
+
+    def discover(self):
+        for name, cls, params in self.scan_catalog():
+            yield {"name": name, "lazy": True, "cls": cls, "params": params}
+```
+
+Note the **two distinct laziness levels**: spec *enumeration* happens at the
+`add_branches` call (the generator is consumed immediately — light metadata
+only); instance *construction* happens at materialization. The real saving on
+large trees is the second one.
+
+## Eager vs Lazy
+
+- **Eager** (`lazy: False`, the default): materialized at the **first tree
+  access** (`nodes()`, `node()`, …). Equivalent in effect to attaching the
+  instance up front, but deferred to when the tree is first touched.
+- **Lazy** (`lazy: True`): materialized **on demand**, the first time a path
+  traverses that segment. Once built, the branch is a normal child — the
+  folder stays open.
+
+```python
+class Application(RoutingClass):
+    def __init__(self):
+        self.add_branches({"name": "sales", "cls": SalesAPI, "lazy": True})
+
+app = Application()
+app.route.nodes()                  # sales NOT built (introspection never builds)
+app.route.node("sales/report")()   # first traversal: SalesAPI() is built HERE
+```
+
+**Materialization** is the single point where an instance is born: the
+framework constructs `cls(**params)`, wires the parent chain
+(`_routing_parent`), links the child router, and applies **plugin
+inheritance** — exactly as an explicit `attach_instance` would have done.
+Plugins plugged on the parent *after* the declaration reach the branch too,
+at materialization time.
+
+## Aliases: Symlinks to Branches
+
+An **alias branch** exposes an existing subtree under a second name — a
+transparent symlink, addressed by **absolute path from the tree root**:
+
+```python
+class Application(RoutingClass):
+    def __init__(self):
+        self.add_branches([
+            {"name": "sales", "cls": SalesAPI},
+            {"name": "shop", "alias": "sales"},        # symlink to the sales branch
+        ])
+
+app = Application()
+assert app.route.node("shop/report")() == app.route.node("sales/report")()
+```
+
+- The spec has `alias` and **no** `cls`/`params` (mutually exclusive —
+  `ValueError` otherwise).
+- Navigating into the alias **rewrites the path**: `shop/report` resolves
+  `sales/report` from the root. The whole target subtree (branches and
+  leaves, recursively) is reachable through it.
+- **Plugins are the target's.** The alias adds none and cannot redefine them
+  — it is a link, not a wrapper.
+- The alias target may be (or cross) a lazy branch: navigating the alias
+  materializes whatever the target path needs.
+- A **broken alias** (target does not resolve) yields `not_found`, like a
+  dangling symlink. An **alias cycle** (`a → b → a`) raises `ValueError`.
+- **Realpath semantics**: a node resolved through an alias reports the
+  *target's* path — `app.route.node("shop/report").path == "sales/report"`.
+  This is the path used by `get_url` and error messages.
+
+## Introspection: nodes() Never Builds
+
+`nodes()` describes declared branches **without constructing them**:
+
+- a **lazy branch** appears with its name, a `lazy: True` flag, and the
+  `@route` leaves *declared by its class* — read from the class itself, no
+  instance involved;
+- an **alias** appears as an unresolved marker: `{"name": ..., "alias": target}`.
+
+To expand, you opt in explicitly:
+
+```python
+app.route.nodes()                    # markers only, zero construction
+app.route.nodes(basepath="sales")    # open ONE branch (materializes it)
+app.route.nodes(_eager=True)         # open EVERYTHING: materialize all lazy
+                                     # branches, resolve all aliases (e.g. to
+                                     # generate a full OpenAPI document)
+```
+
+`nodes(_eager=True)` raises `ValueError` if an alias cycle exists anywhere in
+the expansion.
+
+## Reverse Lookup and Lazy Branches
+
+`node("@endpoint_id")` searches eager and already-materialized branches only:
+it **skips** lazy branches that were never opened (searching them would force
+the whole tree to build, defeating laziness). An endpoint inside a lazy
+branch becomes findable after the branch materializes.
+
+## Errors Are Deferred and Repeatable
+
+A constructor that raises does so **when the branch is built**, not at
+declaration:
+
+- **lazy** branch: the error surfaces at the first traversal — and at every
+  retry, until the branch is fixed or removed. The spec is never lost.
+- **eager** branch: the error surfaces at the first tree access and repeats
+  on every access — the tree is loudly broken until the branch is fixed or
+  removed with `remove_branch`.
+
+## Runtime Management
+
+```python
+app.add_branches({"name": "extra", "cls": ExtraAPI, "lazy": True})  # add at runtime
+app.remove_branch("extra")     # drop a declared branch; if already
+                               # materialized, its child is detached
+app.branches                   # dict of DECLARED specs — a branch leaves this
+                               # view once materialized (it is a child then)
+```
+
+Note the `branches` property semantics: it lists what is *declared and not
+yet built*. After materialization the branch appears among the router's
+children (e.g. in `nodes()`), not in `branches`.
+
+## Relation to attach_instance
+
+`attach_instance(child, name=...)` (attaching an already-built instance)
+remains fully supported. `add_branches` is the **recommended declarative
+form**: it enables lazy construction, keeps `__init__` free of instantiation
+order concerns, and scales to generated trees. Both wire the same parent
+chain and plugin inheritance.
+
+## Next Steps
+
+- **[Hierarchies Guide](hierarchies.md)** - Instance attachment and navigation
+- **[Plugin Configuration](plugin-configuration.md)** - Configure plugins across hierarchies
+- **[API Reference](../api/reference.md)** - Complete API documentation

--- a/docs/guide/hierarchies.md
+++ b/docs/guide/hierarchies.md
@@ -53,8 +53,8 @@ assert parent.route.node("sales/list")() == "child:list"
 child_node = parent.route.node("sales")
 assert child_node.path == "sales"
 
-# Retrieve the child instance later via routing.instance()
-child = parent.routing.instance("sales")
+# Retrieve the child instance later via nodes(basepath=...)
+child = parent.route.nodes(basepath="sales")["instance"]
 assert child._routing_parent is parent
 ```
 
@@ -62,7 +62,7 @@ assert child._routing_parent is parent
 
 - The `name` parameter provides the alias under which the child's router is linked into the parent's router
 - Storing the child as an attribute is **optional** — the router tree keeps a strong reference to the child instance via `router.instance`
-- Use `routing.instance("child")` to retrieve a child instance at any time
+- `nodes(basepath="child")` returns the child subtree; its `"instance"` key is the child RoutingClass instance
 - Parent tracking is handled automatically
 
 **`node()` return values**:
@@ -351,9 +351,8 @@ result = app.service.route.node("process")()
 
 ## Path Navigation
 
-<!-- test: test_router_edge_cases.py::test_routed_proxy_get_router_handles_dotted_path -->
-
-Navigate the hierarchy with path separator `/` via `routing.get_router()`:
+Navigate the hierarchy with path separator `/` directly on the router, using
+`router_at_path()`:
 
 ```python
 class Child(RoutingClass):
@@ -366,39 +365,19 @@ class Parent(RoutingClass):
 
 parent = Parent()
 
-# The instance's own router
-assert parent.routing.get_router() is parent.route
-
-# Get child router directly
-child_router = parent.routing.get_router("child")
-assert child_router.name == "route"
+# Find a child router by path
+child_router = parent.route.router_at_path("child")
 assert child_router.instance is parent.child
 ```
 
 **Navigation features**:
 
-- `get_router()` with no arguments returns the instance's own router
-- `get_router("child/grandchild")` traverses the hierarchy
-- Returns the target router instance
-- Enables programmatic router access
-- Useful for dynamic configuration
-
-### Direct Router Lookup with `router_at_path`
-
-You can also navigate the hierarchy directly from any router using `router_at_path()`:
-
-```python
-# From a router, find a child router by path
-child_router = parent.route.router_at_path("child/grandchild")
-if child_router is not None:
-    print(child_router.name)
-```
-
-**Differences from `routing.get_router()`**:
-
-- `router_at_path(path)` is called directly on a `Router` instance and navigates its children
-- Returns `None` if the path doesn't resolve (instead of raising `KeyError`)
-- Does not require `RoutingClass` — works on any `BaseRouter`
+- `router_at_path("child/grandchild")` traverses the hierarchy
+- Returns `None` if the path doesn't resolve
+- Opens declared branches along the way (lazy branches materialize, aliases
+  are followed) — see the [Branches Guide](branches.md)
+- For handler resolution use `node(path)`; for subtree inspection use
+  `nodes(basepath=path)`
 
 ## Introspection
 
@@ -682,8 +661,8 @@ admin.attach_instance(report_admin, name="reports")
 ### Retrieve Child Instances
 
 ```python
-# Retrieve attached child instances via routing.instance()
-child = parent.routing.instance("child")  # returns the RoutingClass instance
+# Retrieve attached child instances via nodes(basepath=...)
+child = parent.route.nodes(basepath="child")["instance"]  # the RoutingClass instance
 ```
 
 ### Explicit Detachment
@@ -748,12 +727,15 @@ class AdminOrders(RoutingClass):
         return "admin data"
 
 # Compose: one class per surface, attached where needed
-app.routing.instance("api").attach_instance(PublicOrders(), name="orders")
-app.routing.instance("admin").attach_instance(AdminOrders(), name="orders")
+api = app.route.nodes(basepath="api")["instance"]
+admin = app.route.nodes(basepath="admin")["instance"]
+api.attach_instance(PublicOrders(), name="orders")
+admin.attach_instance(AdminOrders(), name="orders")
 ```
 
 ## Next Steps
 
+- **[Branches Guide](branches.md)** - Lazy/eager subtrees and aliases (declarative hierarchies)
 - **[Visual Guide](attach-instance-visual-guide.md)** - Mermaid diagrams for all connection scenarios
 - **[Plugin Configuration](plugin-configuration.md)** - Configure plugins across hierarchies
 - **[Best Practices](best-practices.md)** - Production-ready patterns

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,6 +82,7 @@ guide/basic-usage
 guide/plugins
 guide/plugin-configuration
 guide/hierarchies
+guide/branches
 guide/best-practices
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genro-routes"
-version = "0.26.3"
+version = "0.27.0"
 description = "Instance-scoped routing engine for Python with hierarchical handlers and composable plugins"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/genro_routes/core/base_router.py
+++ b/src/genro_routes/core/base_router.py
@@ -898,7 +898,11 @@ class BaseRouter(RouterInterface):
         parts = [p for p in path.strip("/").split("/") if p]
         router: BaseRouter | None = self
         while parts and router:
-            router = router._children.get(parts.pop(0))
+            head = parts.pop(0)
+            # Navigating into a branch materializes it (open the folder).
+            if head not in router._children and head in router._branches:
+                router._materialize_branch(head)
+            router = router._children.get(head)
         return router
 
     def nodes(

--- a/src/genro_routes/core/base_router.py
+++ b/src/genro_routes/core/base_router.py
@@ -647,19 +647,28 @@ class BaseRouter(RouterInterface):
         existing = self._children.get(name)
         if existing is not None:
             return existing
-        spec = self._branches.pop(name)
+        spec = self._branches[name]
         instance = spec["cls"](**spec["params"])
         self._include_router(instance.route, name)
+        # Pop only after a successful build: a failing constructor leaves the
+        # spec declared, so the error is repeatable instead of the branch
+        # silently disappearing.
+        self._branches.pop(name, None)
         return self._children[name]
 
     def _materialize_eager(self) -> None:
-        """Materialize all eager branches once (idempotent guard)."""
+        """Materialize all eager branches once (idempotent guard).
+
+        The guard is set only after the whole pass succeeds: a failing eager
+        constructor keeps the tree loudly broken (every access retries and
+        re-raises) until the branch is fixed or removed.
+        """
         if self._eager_done:
             return
-        self._eager_done = True
         eager = [n for n, s in self._branches.items() if not s.get("lazy") and "alias" not in s]
         for name in eager:
             self._materialize_branch(name)
+        self._eager_done = True
 
     def _root_router(self) -> BaseRouter:
         """Return the tree's root router by walking up the _routing_parent chain."""
@@ -934,11 +943,14 @@ class BaseRouter(RouterInterface):
     # ------------------------------------------------------------------
     # Introspection helpers
     # ------------------------------------------------------------------
-    def router_at_path(self, path: str) -> BaseRouter | None:
+    def router_at_path(
+        self, path: str, _alias_seen: frozenset[int] | None = None
+    ) -> BaseRouter | None:
         """Find the router at the given path.
 
         Args:
             path: Path to navigate (e.g., "child/grandchild").
+            _alias_seen: Internal — alias spec ids already followed (cycle guard).
 
         Returns:
             The router at the path, or None if not found.
@@ -950,9 +962,15 @@ class BaseRouter(RouterInterface):
             # Alias branch: rewrite to the absolute target + rest, from root.
             alias_spec = router._alias_spec(head)
             if alias_spec is not None:
+                spec_id = id(alias_spec)
+                seen = _alias_seen or frozenset()
+                if spec_id in seen:
+                    raise ValueError(
+                        f"Alias cycle detected at '{alias_spec['name']}' -> '{alias_spec['alias']}'"
+                    )
                 target = alias_spec["alias"].strip("/")
                 full = "/".join([target, *parts]) if parts else target
-                return router._root_router().router_at_path(full)
+                return router._root_router().router_at_path(full, _alias_seen=seen | {spec_id})
             # Navigating into a real branch materializes it (open the folder).
             if head not in router._children and head in router._branches:
                 router._materialize_branch(head)
@@ -965,6 +983,8 @@ class BaseRouter(RouterInterface):
         lazy: bool = False,
         pattern: str | None = None,
         forbidden: bool = False,
+        _eager: bool = False,
+        _alias_seen: frozenset[int] | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         """Return a tree of routers/entries/metadata respecting filters.
@@ -988,6 +1008,11 @@ class BaseRouter(RouterInterface):
                        due to authorization or capability requirements). These
                        entries will have a ``forbidden`` field with the reason
                        (e.g., "not_authorized", "not_available"). Default False.
+            _eager: If True, expand EVERYTHING: materialize all declared lazy
+                    branches and resolve alias branches to their target subtree.
+                    Default False: lazy branches and aliases appear as
+                    unresolved markers, nothing is constructed.
+            _alias_seen: Internal — alias spec ids already expanded (cycle guard).
             **kwargs: Filter arguments passed to plugins via deny_reason().
 
         Returns:
@@ -1005,11 +1030,18 @@ class BaseRouter(RouterInterface):
         if basepath:
             router = self.router_at_path(basepath)
             if router:
-                return router.nodes(lazy=lazy, pattern=pattern, forbidden=forbidden, **kwargs)
+                return router.nodes(
+                    lazy=lazy, pattern=pattern, forbidden=forbidden, _eager=_eager, **kwargs
+                )
             return {}
         # Eager branches materialize on first tree access; lazy branches stay
         # declared and are described (not built) further down.
         self._materialize_eager()
+        if _eager:
+            # Full expansion requested: materialize every declared factory
+            # branch (lazy included). Aliases stay as specs, resolved below.
+            for branch_name in [n for n, s in list(self._branches.items()) if "alias" not in s]:
+                self._materialize_branch(branch_name)
         # Compile pattern once if provided
         pattern_re = re.compile(pattern) if pattern else None
         router_caps = self.current_capabilities
@@ -1032,27 +1064,44 @@ class BaseRouter(RouterInterface):
             routers = dict(self._children)
         else:
             routers = {
-                child_name: child.nodes(pattern=pattern, forbidden=forbidden, **kwargs)
+                child_name: child.nodes(
+                    pattern=pattern,
+                    forbidden=forbidden,
+                    _eager=_eager,
+                    _alias_seen=_alias_seen,
+                    **kwargs,
+                )
                 for child_name, child in self._children.items()
             }
             # Remove empty routers only in non-lazy mode (unless forbidden=True)
             if not forbidden:
                 routers = {k: v for k, v in routers.items() if v}
 
-        # Describe declared branches not yet in _children:
-        # - alias branches: resolve the target and show its subtree + marker
-        # - lazy factory branches: name/lazy flag + class-declared @route leaves
-        for branch_name, spec in self._branches.items():
+        # Describe declared branches not yet in _children. Default: unresolved
+        # markers — nothing is constructed (describe != build). With _eager=True
+        # (non-lazy mode) aliases are resolved and expanded, cycle-guarded.
+        for branch_name, spec in list(self._branches.items()):
             if "alias" in spec:
-                target_router = self.router_at_path(spec["alias"])
-                info = (
-                    target_router.nodes(pattern=pattern, forbidden=forbidden, **kwargs)
-                    if target_router is not None
-                    else {}
-                )
-                info["alias"] = spec["alias"]
-                info["name"] = branch_name
-                routers[branch_name] = info
+                marker: dict[str, Any] = {"name": branch_name, "alias": spec["alias"]}
+                if _eager and not lazy:
+                    spec_id = id(spec)
+                    seen = _alias_seen or frozenset()
+                    if spec_id in seen:
+                        raise ValueError(
+                            f"Alias cycle detected at '{branch_name}' -> '{spec['alias']}'"
+                        )
+                    target_router = self.router_at_path(spec["alias"])
+                    if target_router is not None:
+                        marker = target_router.nodes(
+                            pattern=pattern,
+                            forbidden=forbidden,
+                            _eager=True,
+                            _alias_seen=seen | {spec_id},
+                            **kwargs,
+                        )
+                        marker["alias"] = spec["alias"]
+                        marker["name"] = branch_name
+                routers[branch_name] = marker
             else:
                 routers[branch_name] = self._lazy_branch_node_info(spec)
 

--- a/src/genro_routes/core/base_router.py
+++ b/src/genro_routes/core/base_router.py
@@ -604,10 +604,17 @@ class BaseRouter(RouterInterface):
             self._add_branch_spec(spec)
 
     def _add_branch_spec(self, spec: dict[str, Any]) -> None:
-        """Validate and store a single branch spec."""
+        """Validate and store a single branch spec (factory or alias)."""
         name = spec["name"]
         if name in self._branches or name in self._children:
             raise ValueError(f"Branch name collision: {name}")
+        if "alias" in spec:
+            if "cls" in spec:
+                raise ValueError(f"Branch '{name}': 'alias' and 'cls' are mutually exclusive")
+            # Alias branch: a symlink to an absolute path from the tree root.
+            # No instance is ever built for it; navigation rewrites the path.
+            self._branches[name] = {"name": name, "alias": spec["alias"]}
+            return
         self._branches[name] = {
             "name": name,
             "lazy": bool(spec.get("lazy", False)),
@@ -650,9 +657,27 @@ class BaseRouter(RouterInterface):
         if self._eager_done:
             return
         self._eager_done = True
-        eager = [n for n, s in self._branches.items() if not s["lazy"]]
+        eager = [n for n, s in self._branches.items() if not s.get("lazy") and "alias" not in s]
         for name in eager:
             self._materialize_branch(name)
+
+    def _root_router(self) -> BaseRouter:
+        """Return the tree's root router by walking up the _routing_parent chain."""
+        router = self
+        instance = router.instance
+        parent = getattr(instance, "_routing_parent", None)
+        while parent is not None:
+            router = parent.route
+            instance = parent
+            parent = getattr(instance, "_routing_parent", None)
+        return router
+
+    def _alias_spec(self, name: str) -> dict[str, Any] | None:
+        """Return the branch spec for ``name`` if it is an alias, else None."""
+        spec = self._branches.get(name)
+        if spec is not None and "alias" in spec:
+            return spec
+        return None
 
     def _lazy_branch_node_info(self, spec: dict[str, Any]) -> dict[str, Any]:
         """Build the ``nodes()`` description of a non-materialized lazy branch."""
@@ -794,7 +819,9 @@ class BaseRouter(RouterInterface):
     # ------------------------------------------------------------------
     # Node resolution
     # ------------------------------------------------------------------
-    def _find_candidate_node(self, path: str) -> RouterNode:
+    def _find_candidate_node(
+        self, path: str, _alias_seen: frozenset[int] | None = None
+    ) -> RouterNode:
         """Resolve path to a candidate RouterNode without permission checks.
 
         Pure path resolution: walks through children, finds entry or falls back
@@ -827,6 +854,11 @@ class BaseRouter(RouterInterface):
             if not router._eager_done:
                 router._materialize_eager()
             head = parts.pop(0)
+            # Alias branch: rewrite the path to the target (absolute, from root)
+            # and resolve from there. Guard against alias cycles.
+            alias_spec = router._alias_spec(head)
+            if alias_spec is not None:
+                return router._resolve_alias(alias_spec, parts, _alias_seen)
             pathlist.append(head)
             if head in router._entries:
                 return RouterNode(router, entry_name=head, partial=parts, path="/".join(pathlist))
@@ -838,6 +870,22 @@ class BaseRouter(RouterInterface):
             return RouterNode(router, path="/".join(pathlist))
 
         return RouterNode(last_router, partial=[head] + parts, path="/".join(pathlist[:-1]))
+
+    def _resolve_alias(
+        self, spec: dict[str, Any], rest: list[str], seen: frozenset[int] | None
+    ) -> RouterNode:
+        """Resolve an alias branch: rewrite to its absolute target + rest, from root.
+
+        ``seen`` tracks alias spec ids already followed in this resolution to
+        detect cycles (a -> b -> a).
+        """
+        spec_id = id(spec)
+        seen = seen or frozenset()
+        if spec_id in seen:
+            raise ValueError(f"Alias cycle detected at '{spec['name']}' -> '{spec['alias']}'")
+        target = spec["alias"].strip("/")
+        full = "/".join([target, *rest]) if rest else target
+        return self._root_router()._find_candidate_node(full, _alias_seen=seen | {spec_id})
 
     def _find_by_endpoint_id(self, endpoint_id: str) -> RouterNode:
         """Resolve an endpoint_id to a RouterNode by recursive search.
@@ -899,7 +947,13 @@ class BaseRouter(RouterInterface):
         router: BaseRouter | None = self
         while parts and router:
             head = parts.pop(0)
-            # Navigating into a branch materializes it (open the folder).
+            # Alias branch: rewrite to the absolute target + rest, from root.
+            alias_spec = router._alias_spec(head)
+            if alias_spec is not None:
+                target = alias_spec["alias"].strip("/")
+                full = "/".join([target, *parts]) if parts else target
+                return router._root_router().router_at_path(full)
+            # Navigating into a real branch materializes it (open the folder).
             if head not in router._children and head in router._branches:
                 router._materialize_branch(head)
             router = router._children.get(head)
@@ -985,10 +1039,22 @@ class BaseRouter(RouterInterface):
             if not forbidden:
                 routers = {k: v for k, v in routers.items() if v}
 
-        # Describe still-lazy branches WITHOUT materializing them: name, lazy
-        # flag, and the class-declared @route leaves read from the class alone.
+        # Describe declared branches not yet in _children:
+        # - alias branches: resolve the target and show its subtree + marker
+        # - lazy factory branches: name/lazy flag + class-declared @route leaves
         for branch_name, spec in self._branches.items():
-            routers[branch_name] = self._lazy_branch_node_info(spec)
+            if "alias" in spec:
+                target_router = self.router_at_path(spec["alias"])
+                info = (
+                    target_router.nodes(pattern=pattern, forbidden=forbidden, **kwargs)
+                    if target_router is not None
+                    else {}
+                )
+                info["alias"] = spec["alias"]
+                info["name"] = branch_name
+                routers[branch_name] = info
+            else:
+                routers[branch_name] = self._lazy_branch_node_info(spec)
 
         # If nothing, return empty dict
         if not entries and not routers:

--- a/src/genro_routes/core/base_router.py
+++ b/src/genro_routes/core/base_router.py
@@ -119,6 +119,8 @@ class BaseRouter(RouterInterface):
         "default_entry",
         "__entries_raw",
         "_children",
+        "_branches",
+        "_eager_done",
         "_get_defaults",
         "_bound",
     )
@@ -148,6 +150,8 @@ class BaseRouter(RouterInterface):
         self._bound = False
         self.__entries_raw: dict[str, MethodEntry] = {}
         self._children: dict[str, BaseRouter] = {}
+        self._branches: dict[str, dict[str, Any]] = {}
+        self._eager_done: bool = False
         defaults: dict[str, Any] = dict(get_kwargs or {})
         if get_default_handler is not None:
             defaults.setdefault("default_handler", get_default_handler)
@@ -584,6 +588,116 @@ class BaseRouter(RouterInterface):
             source._on_attached_to_parent(self)
             object.__setattr__(owner, "_routing_parent", self.instance)
 
+    # ------------------------------------------------------------------
+    # Branches: declarative factory-based subrouters (lazy/eager)
+    # ------------------------------------------------------------------
+    def add_branches(self, specs: Any) -> None:
+        """Declare one or more child branches as factory specs.
+
+        Accepts a single spec dict, a list of dicts, or any iterable/generator
+        of dicts. Each spec is ``{"name", "lazy", "cls", "params"}``. Nothing is
+        constructed here — specs are stored in ``_branches`` and materialized
+        later (eager at first tree access, lazy on first traversal).
+        """
+        items = [specs] if isinstance(specs, dict) else list(specs)
+        for spec in items:
+            self._add_branch_spec(spec)
+
+    def _add_branch_spec(self, spec: dict[str, Any]) -> None:
+        """Validate and store a single branch spec."""
+        name = spec["name"]
+        if name in self._branches or name in self._children:
+            raise ValueError(f"Branch name collision: {name}")
+        self._branches[name] = {
+            "name": name,
+            "lazy": bool(spec.get("lazy", False)),
+            "cls": spec["cls"],
+            "params": dict(spec.get("params") or {}),
+        }
+        if not self._branches[name]["lazy"] and self._eager_done:
+            # Added eager after eager pass already ran: materialize now.
+            self._materialize_branch(name)
+
+    def remove_branch(self, name: str) -> None:
+        """Remove a declared branch. If already materialized, detach its child."""
+        self._branches.pop(name, None)
+        child = self._children.get(name)
+        if child is not None:
+            self.detach_instance(child.instance)
+
+    @property
+    def branches(self) -> dict[str, dict[str, Any]]:
+        """Read-only view of declared (not-yet-materialized) branch specs."""
+        return dict(self._branches)
+
+    def _materialize_branch(self, name: str) -> BaseRouter:
+        """Construct the branch's instance and link it as a child.
+
+        Single point where a branch instance is built: pop the spec, construct
+        ``cls(**params)``, and include its router (which wires ``_routing_parent``
+        and triggers plugin inheritance). Idempotent per name.
+        """
+        existing = self._children.get(name)
+        if existing is not None:
+            return existing
+        spec = self._branches.pop(name)
+        instance = spec["cls"](**spec["params"])
+        self._include_router(instance.route, name)
+        return self._children[name]
+
+    def _materialize_eager(self) -> None:
+        """Materialize all eager branches once (idempotent guard)."""
+        if self._eager_done:
+            return
+        self._eager_done = True
+        eager = [n for n, s in self._branches.items() if not s["lazy"]]
+        for name in eager:
+            self._materialize_branch(name)
+
+    def _lazy_branch_node_info(self, spec: dict[str, Any]) -> dict[str, Any]:
+        """Build the ``nodes()`` description of a non-materialized lazy branch."""
+        cls = spec["cls"]
+        info: dict[str, Any] = {
+            "name": spec["name"],
+            "lazy": True,
+            "owner_doc": cls.__doc__,
+        }
+        leaves = self._branch_class_leaves(cls)
+        if leaves:
+            info["entries"] = leaves
+        return info
+
+    def _branch_class_leaves(self, cls: type) -> dict[str, Any]:
+        """Collect a lazy branch's ``@route`` leaves from the CLASS alone.
+
+        Reads the class-level ``_route_decorator_kw`` markers without building an
+        instance, so ``nodes()`` can describe a lazy branch's leaves cheaply.
+        """
+        entries: dict[str, Any] = {}
+        seen_names: set[str] = set()
+        seen_funcs: set[int] = set()
+        for base in cls.__mro__:
+            for attr_name, value in vars(base).items():
+                if not inspect.isfunction(value) or attr_name in seen_names:
+                    continue
+                seen_names.add(attr_name)
+                func_id = id(value)
+                if func_id in seen_funcs:
+                    continue
+                seen_funcs.add(func_id)
+                markers = getattr(value, "_route_decorator_kw", None)
+                if not markers:
+                    continue
+                for marker in markers:
+                    entry_name = marker.get("entry_name") or attr_name
+                    entries[entry_name] = {
+                        "name": entry_name,
+                        "callable": value,
+                        "metadata": {},
+                        "doc": inspect.getdoc(value) or "",
+                    }
+        return entries
+
     def _include_node(self, source: Any, name: str | None) -> None:
         """Create an entry alias from a RouterNode."""
         if name is None:
@@ -710,10 +824,14 @@ class BaseRouter(RouterInterface):
 
         while parts and router:
             last_router = router
+            if not router._eager_done:
+                router._materialize_eager()
             head = parts.pop(0)
             pathlist.append(head)
             if head in router._entries:
                 return RouterNode(router, entry_name=head, partial=parts, path="/".join(pathlist))
+            if head not in router._children and head in router._branches:
+                router._materialize_branch(head)
             router = router._children.get(head)
 
         if router:
@@ -754,6 +872,9 @@ class BaseRouter(RouterInterface):
         for entry_name, entry in self._entries.items():
             if entry.endpoint_id == endpoint_id:
                 return self, entry_name, [*path_parts, entry_name]
+        # Eager branches are part of the tree: open them so the search reaches
+        # them. Lazy branches stay in _branches and are intentionally skipped.
+        self._materialize_eager()
         for child_alias, child_router in self._children.items():
             result = child_router._search_endpoint_id(
                 endpoint_id, [*path_parts, child_alias]
@@ -828,6 +949,9 @@ class BaseRouter(RouterInterface):
             if router:
                 return router.nodes(lazy=lazy, pattern=pattern, forbidden=forbidden, **kwargs)
             return {}
+        # Eager branches materialize on first tree access; lazy branches stay
+        # declared and are described (not built) further down.
+        self._materialize_eager()
         # Compile pattern once if provided
         pattern_re = re.compile(pattern) if pattern else None
         router_caps = self.current_capabilities
@@ -856,6 +980,11 @@ class BaseRouter(RouterInterface):
             # Remove empty routers only in non-lazy mode (unless forbidden=True)
             if not forbidden:
                 routers = {k: v for k, v in routers.items() if v}
+
+        # Describe still-lazy branches WITHOUT materializing them: name, lazy
+        # flag, and the class-declared @route leaves read from the class alone.
+        for branch_name, spec in self._branches.items():
+            routers[branch_name] = self._lazy_branch_node_info(spec)
 
         # If nothing, return empty dict
         if not entries and not routers:

--- a/src/genro_routes/core/routing.py
+++ b/src/genro_routes/core/routing.py
@@ -69,10 +69,13 @@ exclusive). Navigating into it rewrites the path to the target and resolves from
 the root — ``node("fake_sales/x")`` resolves ``alfa/beta/gamma/x`` — so the
 target's whole subtree (branches + leaves, recursive) is reachable through the
 alias, with the **target's** plugins (a transparent symlink; the alias adds
-none). ``nodes()`` shows the target's subtree under the alias name with an
-``alias`` marker. Resolution is lazy: the alias is just a string; navigating it
-materializes lazy branches along the target path. A broken alias resolves to
-``not_found``; an alias cycle raises ``ValueError``.
+none). ``nodes()`` shows the alias as an unresolved marker
+``{"name": ..., "alias": target}`` without building anything; pass
+``_eager=True`` to expand everything (materialize lazy branches and resolve
+aliases), or use ``nodes(basepath=alias)`` to open one branch explicitly.
+Resolution is lazy: the alias is just a string; navigating it materializes lazy
+branches along the target path. A broken alias resolves to ``not_found``; an
+alias cycle raises ``ValueError``.
 
 Router configuration happens on the existing router in ``__init__`` (binding
 is lazy, so this is race-free)::

--- a/src/genro_routes/core/routing.py
+++ b/src/genro_routes/core/routing.py
@@ -57,9 +57,22 @@ building it, including the class-declared ``@route`` leaves read from the class
 (no instance). Reverse lookup (``node("@endpoint_id")``) searches only eager and
 already-materialized branches; it skips non-materialized lazy branches.
 
-Sharing a handler across paths is NOT a framework feature: it is an ordinary
-route method that reuses another node's callable (its own plugins, child's
-callable). Reusing a lazy branch's callable forces that branch's materialization.
+Alias branches (symlink to a branch)
+------------------------------------
+A branch spec may be an **alias** instead of a factory::
+
+    {"name": "fake_sales", "alias": "alfa/beta/gamma"}
+
+An alias branch is a symlink to another branch, addressed by an **absolute path**
+from the tree root. It has ``alias`` and no ``cls``/``params`` (mutually
+exclusive). Navigating into it rewrites the path to the target and resolves from
+the root — ``node("fake_sales/x")`` resolves ``alfa/beta/gamma/x`` — so the
+target's whole subtree (branches + leaves, recursive) is reachable through the
+alias, with the **target's** plugins (a transparent symlink; the alias adds
+none). ``nodes()`` shows the target's subtree under the alias name with an
+``alias`` marker. Resolution is lazy: the alias is just a string; navigating it
+materializes lazy branches along the target path. A broken alias resolves to
+``not_found``; an alias cycle raises ``ValueError``.
 
 Router configuration happens on the existing router in ``__init__`` (binding
 is lazy, so this is race-free)::

--- a/src/genro_routes/core/routing.py
+++ b/src/genro_routes/core/routing.py
@@ -85,10 +85,9 @@ _RoutingProxy
 -------------
 Bound to the owning ``RoutingClass`` instance.
 
-Router lookup:
-    - ``get_router(path=None)`` returns the owner's router, optionally
-      navigating child routers along ``path`` (e.g. ``"users/detail"``).
-      Raises ``KeyError`` if a path segment does not resolve.
+Router navigation and introspection use the router's own ``node(path)`` (to
+resolve/execute) and ``nodes(basepath=...)`` (to inspect and open a subtree,
+materializing lazy branches on the way).
 
 Configuration entrypoint:
     - ``configure(target, **options)`` accepts string, dict, or list targets.
@@ -382,13 +381,13 @@ class Section(RoutingClass):
 
 
 class _RoutingProxy:
-    """Proxy for accessing and configuring the router of a RoutingClass instance.
+    """Proxy for configuring the router of a RoutingClass instance.
 
-    Provides a unified interface for router lookup and plugin configuration.
-    Access via the ``routing`` property on any RoutingClass instance.
+    Provides plugin configuration for the owner's router. Access via the
+    ``routing`` property on any RoutingClass instance. For navigation and
+    introspection use the router's ``node(path)`` / ``nodes(basepath=...)``.
 
     Main operations:
-        - ``get_router(path=None)``: The owner's router, or a child at path
         - ``configure(target, **options)``: Configure plugin settings
         - ``attach_instance(child, name=...)``: Delegates to owner's attach_instance
 
@@ -409,58 +408,7 @@ class _RoutingProxy:
     def __init__(self, owner: RoutingClass):
         object.__setattr__(self, "_owner", owner)
 
-    def get_router(self, path: str | None = None):
-        """Return the owner's router, optionally navigating child routers.
-
-        Args:
-            path: Optional "child/grandchild" path to navigate.
-
-        Returns:
-            The owner's Router, or the child router at path.
-
-        Raises:
-            KeyError: If child path navigation fails.
-
-        Example:
-            >>> svc.routing.get_router()
-            >>> svc.routing.get_router("users")  # child router
-            >>> svc.routing.get_router("users/detail")
-        """
-        router = self._owner.route
-        if not path:
-            return router
-        return self._navigate_router(router, path)
-
-    def instance(self, path: str) -> RoutingClass:
-        """Return the RoutingClass instance that owns the child router at path.
-
-        Args:
-            path: Router path in "child" or "child/grandchild" notation.
-
-        Returns:
-            The RoutingClass instance owning the resolved child router.
-
-        Raises:
-            KeyError: If child path navigation fails.
-
-        Example:
-            >>> svc.routing.instance("users")  # → UsersModule instance
-            >>> svc.routing.instance("users/detail")  # → nested child instance
-        """
-        router = self.get_router(path)
-        return router.instance  # type: ignore[no-any-return]
-
     # Helpers -------------------------------------------------
-    def _navigate_router(self, root, path: str):
-        """Walk child routers following the path segments."""
-        node = root
-        for segment in path.split("/"):
-            segment = segment.strip()
-            if not segment:
-                continue
-            node = node._children[segment]
-        return node
-
     def _parse_target(self, target: str) -> tuple[str, str]:
         """Parse 'plugin/selector' into (plugin, selector)."""
         if "/" in target:

--- a/src/genro_routes/core/routing.py
+++ b/src/genro_routes/core/routing.py
@@ -10,12 +10,56 @@ RoutingClass
 A mixin class providing:
     - ``route`` property: the instance's Router, created lazily on first
       access. Assigning to it raises ``AttributeError`` (read-only).
-    - ``attach_instance(child, name=...)``: attaches a child RoutingClass
-      instance. Sets ``child._routing_parent = self`` and, when ``name`` is
-      given, links ``child.route`` into ``self.route`` under that alias.
+    - ``add_branches(specs)``: declare child subrouters as factory specs
+      (see Branches below). Accepts one dict, a list of dicts, or a generator.
+    - ``remove_branch(name)``: drop a declared branch; if already materialized,
+      detach its router.
+    - ``branches`` property: read-only view of the declared branch specs.
     - ``routing`` property: cached ``_RoutingProxy`` for configuration/lookup.
     - ``ctx`` property: execution context, walking up the parent chain.
     - ``capabilities`` property: CapabilitiesSet for runtime feature flags.
+
+Branches (declarative, factory-based subrouters)
+------------------------------------------------
+A branch is a child subrouter declared as a **factory spec** and materialized
+(constructed) only when needed. This lets trees with thousands of leaves start
+cheaply — nothing is instantiated until walked.
+
+A branch spec is a self-describing dict::
+
+    {"name": "beta", "lazy": True, "cls": Beta, "params": {"x": 56}}
+
+    name   -- alias under which the child is reachable (path segment)
+    lazy   -- True: materialize on first traversal; False (eager): materialize
+              at first tree access
+    cls    -- the RoutingClass subclass to instantiate
+    params -- kwargs applied as cls(**params) at materialization
+
+``add_branches`` populates the router's ``_branches`` dict; no instance is
+constructed at declaration time. Materialization is the single point where an
+instance is built: construct ``cls(**params)``, set ``_routing_parent``, link
+into ``_children`` (which triggers plugin inheritance), then drop the spec from
+``_branches``. Two timing policies share this one mechanism:
+
+    - eager  -- all eager branches materialize at first tree access
+                (idempotent guard on the router: runs once)
+    - lazy   -- a lazy branch materializes on-demand when a path first
+                traverses its segment
+
+Two distinct laziness levels must not be conflated:
+
+    - spec enumeration happens at the ``add_branches`` call (a generator is
+      consumed immediately). Light metadata only.
+    - instance construction happens at materialization. This is the real saving.
+
+Introspection (``nodes()``) describes a non-materialized lazy branch WITHOUT
+building it, including the class-declared ``@route`` leaves read from the class
+(no instance). Reverse lookup (``node("@endpoint_id")``) searches only eager and
+already-materialized branches; it skips non-materialized lazy branches.
+
+Sharing a handler across paths is NOT a framework feature: it is an ordinary
+route method that reuses another node's callable (its own plugins, child's
+callable). Reusing a lazy branch's callable forces that branch's materialization.
 
 Router configuration happens on the existing router in ``__init__`` (binding
 is lazy, so this is race-free)::
@@ -152,6 +196,24 @@ class RoutingClass:
         if router is None:
             router = Router(self)
         return router
+
+    def add_branches(self, specs: Any) -> None:
+        """Declare child branches (factory specs) on this instance's router.
+
+        Accepts one spec dict, a list of dicts, or a generator. Each spec is
+        ``{"name", "lazy", "cls", "params"}``. Delegates to the router; nothing
+        is constructed until materialization (see the Branches section above).
+        """
+        self.route.add_branches(specs)
+
+    def remove_branch(self, name: str) -> None:
+        """Remove a declared branch; detach its child if already materialized."""
+        self.route.remove_branch(name)
+
+    @property
+    def branches(self) -> dict[str, dict[str, Any]]:
+        """Read-only view of declared (not-yet-materialized) branch specs."""
+        return self.route.branches
 
     def _register_router(self, router: Router) -> None:
         """Register the router with this instance.

--- a/tests/test_async_nodes.py
+++ b/tests/test_async_nodes.py
@@ -85,7 +85,7 @@ def test_async_child_node_classified_through_hierarchy():
 
     class Parent(RoutingClass):
         def __init__(self):
-            self.attach_instance(Child(), name="c")
+            self.add_branches({"name": "c", "cls": Child})
 
     node = Parent().route.node("c/ping")
     assert asyncio.iscoroutinefunction(node) is True

--- a/tests/test_branch_alias.py
+++ b/tests/test_branch_alias.py
@@ -156,11 +156,12 @@ def test_alias_uses_target_plugins():
 
 
 # ---------------------------------------------------------------------------
-# 5-6. nodes() shows target subtree under the alias name, with a marker
+# 5-6. nodes() shows the alias as an UNRESOLVED marker (closed symlink);
+#      _eager=True expands everything; basepath opens one branch explicitly
 # ---------------------------------------------------------------------------
 
 
-def test_nodes_shows_alias_target_subtree():
+def test_nodes_shows_alias_as_marker():
     class Alfa(RoutingClass):
         def __init__(self):
             self.add_branches(
@@ -172,10 +173,106 @@ def test_nodes_shows_alias_target_subtree():
 
     alfa = Alfa()
     tree = alfa.route.nodes()
-    assert "fake" in tree["routers"]
     fake = tree["routers"]["fake"]
-    assert fake.get("alias") == "real"
+    assert fake == {"name": "fake", "alias": "real"}  # marker only, not expanded
+
+
+def test_nodes_alias_to_lazy_target_does_not_build(  # regression: B1 crash
+):
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches(
+                [
+                    {"name": "real", "lazy": True, "cls": Leaf, "params": {"tag": "lz"}},
+                    {"name": "fake", "alias": "real"},
+                ]
+            )
+
+    alfa = Alfa()
+    tree = alfa.route.nodes()  # must not crash, must not build
+    assert tree["routers"]["fake"] == {"name": "fake", "alias": "real"}
+    assert "Leaf:lz" not in BUILD_LOG
+    tree_lazy = alfa.route.nodes(lazy=True)  # same in lazy introspection mode
+    assert tree_lazy["routers"]["fake"] == {"name": "fake", "alias": "real"}
+    assert "Leaf:lz" not in BUILD_LOG
+
+
+def test_nodes_eager_expands_lazy_and_alias():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches(
+                [
+                    {"name": "real", "lazy": True, "cls": Leaf, "params": {"tag": "lz"}},
+                    {"name": "fake", "alias": "real"},
+                ]
+            )
+
+    alfa = Alfa()
+    tree = alfa.route.nodes(_eager=True)
+    # Lazy branch materialized and fully expanded.
+    assert set(tree["routers"]["real"]["entries"].keys()) == {"ping", "info"}
+    # Alias resolved and expanded, keeping the marker.
+    fake = tree["routers"]["fake"]
+    assert fake["alias"] == "real"
     assert set(fake["entries"].keys()) == {"ping", "info"}
+    assert "Leaf:lz" in BUILD_LOG
+
+
+def test_nodes_eager_expands_nested_lazy():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "sub", "lazy": True, "cls": Sub})
+
+    alfa = Alfa()
+    tree = alfa.route.nodes(_eager=True)
+    # Nested lazy branch inside the materialized subtree is expanded too.
+    assert set(tree["routers"]["sub"]["routers"]["leaf"]["entries"].keys()) == {"ping", "info"}
+
+
+def test_nodes_eager_alias_cycle_raises():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches(
+                [
+                    {"name": "a", "alias": "b"},
+                    {"name": "b", "alias": "a"},
+                ]
+            )
+
+    alfa = Alfa()
+    with pytest.raises(ValueError, match="cycle"):
+        alfa.route.nodes(_eager=True)
+
+
+def test_nodes_with_alias_cycle_markers_only_no_crash():  # regression: B2
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches(
+                [
+                    {"name": "a", "alias": "b"},
+                    {"name": "b", "alias": "a"},
+                ]
+            )
+
+    alfa = Alfa()
+    tree = alfa.route.nodes()  # markers only: no resolution, no RecursionError
+    assert tree["routers"]["a"] == {"name": "a", "alias": "b"}
+    assert tree["routers"]["b"] == {"name": "b", "alias": "a"}
+
+
+def test_router_at_path_alias_cycle_raises():  # regression: B2
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches(
+                [
+                    {"name": "a", "alias": "b"},
+                    {"name": "b", "alias": "a"},
+                ]
+            )
+
+    alfa = Alfa()
+    with pytest.raises(ValueError, match="cycle"):
+        alfa.route.router_at_path("a")
 
 
 def test_nodes_basepath_into_alias():

--- a/tests/test_branch_alias.py
+++ b/tests/test_branch_alias.py
@@ -1,0 +1,339 @@
+# Copyright 2025 Softwell S.r.l.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for branch aliases: a virtual branch that is a symlink to another branch.
+
+An alias branch has spec ``{"name": ..., "alias": "<absolute path>"}``. Navigating
+into it rewrites the path to the target (resolved from the tree root) and
+continues there. Plugins are the target's — the alias is a transparent symlink.
+"""
+
+import pytest
+
+from genro_routes import RoutingClass, route
+
+BUILD_LOG: list[str] = []
+
+
+class Leaf(RoutingClass):
+    """A leaf service."""
+
+    def __init__(self, tag: str = "leaf"):
+        self.tag = tag
+        BUILD_LOG.append(f"Leaf:{tag}")
+
+    @route()
+    def ping(self):
+        return f"leaf.ping:{self.tag}"
+
+    @route()
+    def info(self, x: int):
+        return f"leaf.info:{self.tag}:{x}"
+
+
+class Sub(RoutingClass):
+    """A branch that itself has a nested branch (for fractal tests)."""
+
+    def __init__(self):
+        BUILD_LOG.append("Sub")
+        self.add_branches({"name": "leaf", "cls": Leaf, "params": {"tag": "nested"}})
+
+    @route()
+    def top(self):
+        return "sub.top"
+
+
+@pytest.fixture(autouse=True)
+def _clear_build_log():
+    BUILD_LOG.clear()
+    yield
+    BUILD_LOG.clear()
+
+
+# ---------------------------------------------------------------------------
+# 1. Basic alias to a real branch
+# ---------------------------------------------------------------------------
+
+
+def test_alias_to_real_branch():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches(
+                [
+                    {"name": "real", "cls": Leaf, "params": {"tag": "r"}},
+                    {"name": "fake", "alias": "real"},
+                ]
+            )
+
+    alfa = Alfa()
+    assert alfa.route.node("fake/ping")() == "leaf.ping:r"
+    # Same target reachable under both names.
+    assert alfa.route.node("real/ping")() == "leaf.ping:r"
+
+
+# ---------------------------------------------------------------------------
+# 2. Alias exposes the whole subtree (fractal)
+# ---------------------------------------------------------------------------
+
+
+def test_alias_exposes_whole_subtree():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches(
+                [
+                    {"name": "real", "cls": Sub},
+                    {"name": "fake", "alias": "real"},
+                ]
+            )
+
+    alfa = Alfa()
+    assert alfa.route.node("fake/top")() == "sub.top"
+    # Nested branch under the target, reached through the alias.
+    assert alfa.route.node("fake/leaf/ping")() == "leaf.ping:nested"
+
+
+# ---------------------------------------------------------------------------
+# 3. Alias + lazy target: navigating the alias materializes the target
+# ---------------------------------------------------------------------------
+
+
+def test_alias_to_lazy_target_materializes_on_navigation():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches(
+                [
+                    {"name": "real", "lazy": True, "cls": Leaf, "params": {"tag": "lz"}},
+                    {"name": "fake", "alias": "real"},
+                ]
+            )
+
+    alfa = Alfa()
+    assert "Leaf:lz" not in BUILD_LOG  # nothing built at declaration
+    assert alfa.route.node("fake/ping")() == "leaf.ping:lz"
+    assert "Leaf:lz" in BUILD_LOG  # navigating the alias materialized the target
+
+
+# ---------------------------------------------------------------------------
+# 4. Plugins are the target's (transparent symlink)
+# ---------------------------------------------------------------------------
+
+
+def test_alias_uses_target_plugins():
+    class Target(RoutingClass):
+        def __init__(self):
+            self.route.plug("logging")
+
+        @route()
+        def act(self):
+            return "act"
+
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches(
+                [
+                    {"name": "real", "cls": Target},
+                    {"name": "fake", "alias": "real"},
+                ]
+            )
+
+    alfa = Alfa()
+    # Reached via the alias, the node is the target's node with the target's plugin.
+    node = alfa.route.node("fake/act")
+    assert node() == "act"
+    # Same node object as reaching it directly.
+    assert alfa.route.node("real/act")() == "act"
+
+
+# ---------------------------------------------------------------------------
+# 5-6. nodes() shows target subtree under the alias name, with a marker
+# ---------------------------------------------------------------------------
+
+
+def test_nodes_shows_alias_target_subtree():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches(
+                [
+                    {"name": "real", "cls": Leaf, "params": {"tag": "r"}},
+                    {"name": "fake", "alias": "real"},
+                ]
+            )
+
+    alfa = Alfa()
+    tree = alfa.route.nodes()
+    assert "fake" in tree["routers"]
+    fake = tree["routers"]["fake"]
+    assert fake.get("alias") == "real"
+    assert set(fake["entries"].keys()) == {"ping", "info"}
+
+
+def test_nodes_basepath_into_alias():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches(
+                [
+                    {"name": "real", "cls": Leaf, "params": {"tag": "r"}},
+                    {"name": "fake", "alias": "real"},
+                ]
+            )
+
+    alfa = Alfa()
+    sub = alfa.route.nodes(basepath="fake")
+    assert set(sub["entries"].keys()) == {"ping", "info"}
+
+
+# ---------------------------------------------------------------------------
+# 7-8. Deep path and trailing path
+# ---------------------------------------------------------------------------
+
+
+def test_alias_to_deep_path():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches(
+                [
+                    {"name": "real", "cls": Sub},
+                    {"name": "fake", "alias": "real/leaf"},  # deep target
+                ]
+            )
+
+    alfa = Alfa()
+    assert alfa.route.node("fake/ping")() == "leaf.ping:nested"
+
+
+def test_alias_with_trailing_path():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches(
+                [
+                    {"name": "real", "cls": Sub},
+                    {"name": "fake", "alias": "real"},
+                ]
+            )
+
+    alfa = Alfa()
+    # fake/leaf/info/... -> real/leaf/info
+    assert alfa.route.node("fake/leaf/info")(9) == "leaf.info:nested:9"
+
+
+# ---------------------------------------------------------------------------
+# 9. Broken alias (rotten symlink)
+# ---------------------------------------------------------------------------
+
+
+def test_broken_alias_not_found():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "fake", "alias": "does/not/exist"})
+
+    alfa = Alfa()
+    assert alfa.route.node("fake/ping").error == "not_found"
+
+
+# ---------------------------------------------------------------------------
+# 10. Alias cycle
+# ---------------------------------------------------------------------------
+
+
+def test_alias_cycle_raises():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches(
+                [
+                    {"name": "a", "alias": "b"},
+                    {"name": "b", "alias": "a"},
+                ]
+            )
+
+    alfa = Alfa()
+    with pytest.raises(ValueError, match="cycle"):
+        alfa.route.node("a/ping")()
+
+
+# ---------------------------------------------------------------------------
+# 11. alias + cls both present -> error
+# ---------------------------------------------------------------------------
+
+
+def test_alias_and_cls_both_present_raises():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "x", "alias": "real", "cls": Leaf})
+
+    with pytest.raises(ValueError, match="alias"):
+        Alfa()
+
+
+# ---------------------------------------------------------------------------
+# 12. Alias resolves from the ROOT (absolute), not the declaring router
+# ---------------------------------------------------------------------------
+
+
+def test_alias_resolves_from_root():
+    # Alias declared deep in the tree points to an absolute path from the root.
+    class Deep(RoutingClass):
+        def __init__(self):
+            # 'shortcut' points to 'target' which lives at the ROOT, not under Deep
+            self.add_branches({"name": "shortcut", "alias": "target"})
+
+    class Root(RoutingClass):
+        def __init__(self):
+            self.add_branches(
+                [
+                    {"name": "target", "cls": Leaf, "params": {"tag": "root"}},
+                    {"name": "deep", "cls": Deep},
+                ]
+            )
+
+    root = Root()
+    assert root.route.node("deep/shortcut/ping")() == "leaf.ping:root"
+
+
+# ---------------------------------------------------------------------------
+# 13. @endpoint_id unchanged: found in eager aliased target
+# ---------------------------------------------------------------------------
+
+
+def test_endpoint_id_still_works_with_alias_present():
+    class WithId(RoutingClass):
+        @route(endpoint_id="the-ep")
+        def act(self):
+            return "found"
+
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches(
+                [
+                    {"name": "real", "cls": WithId},
+                    {"name": "fake", "alias": "real"},
+                ]
+            )
+
+    alfa = Alfa()
+    assert alfa.route.node("@the-ep")() == "found"
+
+
+# ---------------------------------------------------------------------------
+# 14. Name collision
+# ---------------------------------------------------------------------------
+
+
+def test_alias_name_collision_raises():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "real", "cls": Leaf})
+
+    alfa = Alfa()
+    with pytest.raises(ValueError, match="collision"):
+        alfa.add_branches({"name": "real", "alias": "other"})

--- a/tests/test_lazy_branches.py
+++ b/tests/test_lazy_branches.py
@@ -1,0 +1,462 @@
+# Copyright 2025 Softwell S.r.l.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for lazy/eager branches: declarative, factory-based subrouters.
+
+A branch is a child subrouter declared as a factory spec
+``{"name", "lazy", "cls", "params"}`` and materialized (constructed) only when
+needed. Eager branches materialize at first tree access; lazy branches
+materialize on-demand at first traversal.
+"""
+
+import pytest
+
+from genro_routes import RoutingClass, route
+
+# ---------------------------------------------------------------------------
+# Test doubles: leaf classes that record their own construction
+# ---------------------------------------------------------------------------
+
+BUILD_LOG: list[str] = []
+
+
+class Beta(RoutingClass):
+    """Beta service (lazy-friendly leaf)."""
+
+    def __init__(self, tag: str = "beta"):
+        self.tag = tag
+        BUILD_LOG.append(f"Beta:{tag}")
+
+    @route()
+    def ping(self):
+        return f"beta.ping:{self.tag}"
+
+    @route()
+    def info(self, x: int):
+        return f"beta.info:{self.tag}:{x}"
+
+
+class Gamma(RoutingClass):
+    """Gamma service."""
+
+    def __init__(self, tag: str = "gamma"):
+        self.tag = tag
+        BUILD_LOG.append(f"Gamma:{tag}")
+
+    @route()
+    def ping(self):
+        return f"gamma.ping:{self.tag}"
+
+
+class Boom(RoutingClass):
+    """A leaf whose constructor raises — used for deferred-error tests."""
+
+    def __init__(self):
+        BUILD_LOG.append("Boom")
+        raise RuntimeError("boom in __init__")
+
+    @route()
+    def ping(self):  # pragma: no cover - never reached
+        return "never"
+
+
+@pytest.fixture(autouse=True)
+def _clear_build_log():
+    BUILD_LOG.clear()
+    yield
+    BUILD_LOG.clear()
+
+
+# ---------------------------------------------------------------------------
+# add_branches: single dict, list, generator
+# ---------------------------------------------------------------------------
+
+
+def test_add_branches_single_dict():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "beta", "lazy": False, "cls": Beta, "params": {}})
+
+    alfa = Alfa()
+    assert alfa.route.node("beta/ping")() == "beta.ping:beta"
+
+
+def test_add_branches_list():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches(
+                [
+                    {"name": "beta", "lazy": False, "cls": Beta, "params": {"tag": "b1"}},
+                    {"name": "gamma", "lazy": False, "cls": Gamma, "params": {}},
+                ]
+            )
+
+    alfa = Alfa()
+    assert alfa.route.node("beta/ping")() == "beta.ping:b1"
+    assert alfa.route.node("gamma/ping")() == "gamma.ping:gamma"
+
+
+def test_add_branches_generator():
+    def gen():
+        yield {"name": "beta", "lazy": True, "cls": Beta, "params": {}}
+        yield {"name": "gamma", "lazy": True, "cls": Gamma, "params": {}}
+
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches(gen())
+
+    alfa = Alfa()
+    assert alfa.route.node("beta/ping")() == "beta.ping:beta"
+    assert alfa.route.node("gamma/ping")() == "gamma.ping:gamma"
+
+
+def test_params_applied_to_constructor():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {"tag": "custom"}})
+
+    alfa = Alfa()
+    assert alfa.route.node("beta/info")(7) == "beta.info:custom:7"
+
+
+# ---------------------------------------------------------------------------
+# Lazy vs eager timing
+# ---------------------------------------------------------------------------
+
+
+def test_lazy_branch_not_built_until_traversed():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+
+    alfa = Alfa()
+    # Touching the tree must NOT build a lazy branch.
+    alfa.route.nodes()
+    assert "Beta:beta" not in BUILD_LOG
+    # First traversal builds it.
+    assert alfa.route.node("beta/ping")() == "beta.ping:beta"
+    assert "Beta:beta" in BUILD_LOG
+
+
+def test_eager_branch_built_at_first_tree_access():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "gamma", "lazy": False, "cls": Gamma, "params": {}})
+
+    alfa = Alfa()
+    assert BUILD_LOG == []  # declaration does not build
+    alfa.route.nodes()  # first tree access materializes eager branches
+    assert "Gamma:gamma" in BUILD_LOG
+
+
+def test_declaration_builds_nothing():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches(
+                [
+                    {"name": "beta", "lazy": True, "cls": Beta, "params": {}},
+                    {"name": "gamma", "lazy": False, "cls": Gamma, "params": {}},
+                ]
+            )
+
+    Alfa()  # __init__ only declares
+    assert BUILD_LOG == []
+
+
+def test_mixed_lazy_and_eager_same_list():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches(
+                [
+                    {"name": "beta", "lazy": True, "cls": Beta, "params": {}},
+                    {"name": "gamma", "lazy": False, "cls": Gamma, "params": {}},
+                ]
+            )
+
+    alfa = Alfa()
+    alfa.route.nodes()  # eager gamma built, lazy beta not
+    assert "Gamma:gamma" in BUILD_LOG
+    assert "Beta:beta" not in BUILD_LOG
+    alfa.route.node("beta/ping")()  # now beta builds
+    assert "Beta:beta" in BUILD_LOG
+
+
+def test_lazy_built_only_once():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+
+    alfa = Alfa()
+    alfa.route.node("beta/ping")()
+    alfa.route.node("beta/info")(1)
+    alfa.route.node("beta/ping")()
+    assert BUILD_LOG.count("Beta:beta") == 1
+
+
+def test_eager_guard_idempotent():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "gamma", "lazy": False, "cls": Gamma, "params": {}})
+
+    alfa = Alfa()
+    alfa.route.nodes()
+    alfa.route.nodes()
+    alfa.route.node("gamma/ping")()
+    assert BUILD_LOG.count("Gamma:gamma") == 1
+
+
+# ---------------------------------------------------------------------------
+# Introspection: nodes() describes lazy branches without building them
+# ---------------------------------------------------------------------------
+
+
+def test_nodes_lists_lazy_branch_without_building():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+
+    alfa = Alfa()
+    tree = alfa.route.nodes()
+    assert "beta" in tree["routers"]
+    assert "Beta:beta" not in BUILD_LOG
+
+
+def test_nodes_marks_branch_as_lazy():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+
+    alfa = Alfa()
+    tree = alfa.route.nodes()
+    beta_node = tree["routers"]["beta"]
+    assert beta_node.get("lazy") is True
+
+
+def test_nodes_shows_class_declared_leaves_without_building():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+
+    alfa = Alfa()
+    tree = alfa.route.nodes()
+    beta_node = tree["routers"]["beta"]
+    # Leaves read from the class @route markers, no instance built.
+    assert set(beta_node["entries"].keys()) == {"ping", "info"}
+    assert "Beta:beta" not in BUILD_LOG
+
+
+def test_nodes_eager_branch_is_fully_expanded():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "gamma", "lazy": False, "cls": Gamma, "params": {}})
+
+    alfa = Alfa()
+    tree = alfa.route.nodes()
+    assert "gamma" in tree["routers"]
+    assert set(tree["routers"]["gamma"]["entries"].keys()) == {"ping"}
+
+
+# ---------------------------------------------------------------------------
+# Reverse lookup: node("@id") skips non-materialized lazy branches
+# ---------------------------------------------------------------------------
+
+
+def test_endpoint_id_skips_lazy_branch():
+    class WithId(RoutingClass):
+        @route(endpoint_id="hidden-ep")
+        def action(self):
+            return "hidden"
+
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "child", "lazy": True, "cls": WithId, "params": {}})
+
+    alfa = Alfa()
+    node = alfa.route.node("@hidden-ep")
+    assert node.error == "not_found"  # lazy branch not searched
+
+
+def test_endpoint_id_found_after_materialization():
+    class WithId(RoutingClass):
+        @route(endpoint_id="visible-ep")
+        def action(self):
+            return "visible"
+
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "child", "lazy": True, "cls": WithId, "params": {}})
+
+    alfa = Alfa()
+    alfa.route.node("child/action")()  # materialize
+    node = alfa.route.node("@visible-ep")
+    assert node.error is None
+    assert node() == "visible"
+
+
+def test_endpoint_id_found_in_eager_branch():
+    class WithId(RoutingClass):
+        @route(endpoint_id="eager-ep")
+        def action(self):
+            return "eager"
+
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "child", "lazy": False, "cls": WithId, "params": {}})
+
+    alfa = Alfa()
+    assert alfa.route.node("@eager-ep")() == "eager"
+
+
+# ---------------------------------------------------------------------------
+# Materialization wires parent chain, ctx and plugins
+# ---------------------------------------------------------------------------
+
+
+def test_materialized_branch_has_routing_parent():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+
+    alfa = Alfa()
+    child_router = alfa.route.node("beta/ping")._router
+    assert child_router.instance._routing_parent is alfa
+
+
+def test_plugin_inherited_on_materialization():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.route.plug("logging")
+            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+
+    alfa = Alfa()
+    child_router = alfa.route.node("beta/ping")._router
+    assert "logging" in child_router._plugins_by_name
+
+
+def test_plug_after_declare_reaches_lazy_branch():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+            self.route.plug("logging")  # plugged after declaration
+
+    alfa = Alfa()
+    child_router = alfa.route.node("beta/ping")._router
+    assert "logging" in child_router._plugins_by_name
+
+
+# ---------------------------------------------------------------------------
+# Deferred construction errors
+# ---------------------------------------------------------------------------
+
+
+def test_lazy_constructor_error_deferred_to_traversal():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "boom", "lazy": True, "cls": Boom, "params": {}})
+
+    alfa = Alfa()  # no error at declaration
+    assert "Boom" not in BUILD_LOG
+    with pytest.raises(RuntimeError, match="boom in __init__"):
+        alfa.route.node("boom/ping")()
+
+
+# ---------------------------------------------------------------------------
+# branches property (read view) and remove_branch
+# ---------------------------------------------------------------------------
+
+
+def test_branches_property_lists_declared_specs():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches(
+                [
+                    {"name": "beta", "lazy": True, "cls": Beta, "params": {}},
+                    {"name": "gamma", "lazy": False, "cls": Gamma, "params": {}},
+                ]
+            )
+
+    alfa = Alfa()
+    assert set(alfa.branches) == {"beta", "gamma"}
+
+
+def test_remove_branch_before_materialization():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+
+    alfa = Alfa()
+    alfa.remove_branch("beta")
+    assert "beta" not in alfa.branches
+    node = alfa.route.node("beta/ping")
+    assert node.error == "not_found"
+    assert "Beta:beta" not in BUILD_LOG
+
+
+def test_remove_branch_after_materialization_detaches():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+
+    alfa = Alfa()
+    alfa.route.node("beta/ping")()  # materialize
+    alfa.remove_branch("beta")
+    node = alfa.route.node("beta/ping")
+    assert node.error == "not_found"
+
+
+def test_add_branch_runtime_after_init():
+    class Alfa(RoutingClass):
+        pass
+
+    alfa = Alfa()
+    alfa.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+    assert alfa.route.node("beta/ping")() == "beta.ping:beta"
+
+
+# ---------------------------------------------------------------------------
+# Nesting: a lazy branch that itself declares lazy branches
+# ---------------------------------------------------------------------------
+
+
+def test_nested_lazy_branches_expand_incrementally():
+    class Inner(RoutingClass):
+        def __init__(self):
+            BUILD_LOG.append("Inner")
+
+        @route()
+        def leaf(self):
+            return "inner.leaf"
+
+    class Mid(RoutingClass):
+        def __init__(self):
+            BUILD_LOG.append("Mid")
+            self.add_branches({"name": "inner", "lazy": True, "cls": Inner, "params": {}})
+
+        @route()
+        def midleaf(self):
+            return "mid.midleaf"
+
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "mid", "lazy": True, "cls": Mid, "params": {}})
+
+    alfa = Alfa()
+    assert BUILD_LOG == []
+    # Reach mid: builds Mid, not Inner.
+    assert alfa.route.node("mid/midleaf")() == "mid.midleaf"
+    assert "Mid" in BUILD_LOG
+    assert "Inner" not in BUILD_LOG
+    # Reach inner: now Inner builds.
+    assert alfa.route.node("mid/inner/leaf")() == "inner.leaf"
+    assert "Inner" in BUILD_LOG

--- a/tests/test_lazy_branches.py
+++ b/tests/test_lazy_branches.py
@@ -460,3 +460,244 @@ def test_nested_lazy_branches_expand_incrementally():
     # Reach inner: now Inner builds.
     assert alfa.route.node("mid/inner/leaf")() == "inner.leaf"
     assert "Inner" in BUILD_LOG
+
+
+# ---------------------------------------------------------------------------
+# Spec validation and defaults
+# ---------------------------------------------------------------------------
+
+
+def test_branch_name_collision_with_branch_raises():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+
+    alfa = Alfa()
+    with pytest.raises(ValueError, match="collision"):
+        alfa.add_branches({"name": "beta", "lazy": True, "cls": Gamma, "params": {}})
+
+
+def test_branch_name_collision_with_materialized_child_raises():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+
+    alfa = Alfa()
+    alfa.route.node("beta/ping")()  # materialize -> beta now in _children
+    with pytest.raises(ValueError, match="collision"):
+        alfa.add_branches({"name": "beta", "lazy": True, "cls": Gamma, "params": {}})
+
+
+def test_params_defaults_to_empty():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "beta", "lazy": True, "cls": Beta})  # no params
+
+    alfa = Alfa()
+    assert alfa.route.node("beta/ping")() == "beta.ping:beta"
+
+
+def test_lazy_defaults_to_eager_when_omitted():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "gamma", "cls": Gamma, "params": {}})  # no lazy
+
+    alfa = Alfa()
+    alfa.route.nodes()  # eager default -> built at first access
+    assert "Gamma:gamma" in BUILD_LOG
+
+
+# ---------------------------------------------------------------------------
+# remove_branch edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_remove_nonexistent_branch_is_noop():
+    class Alfa(RoutingClass):
+        pass
+
+    alfa = Alfa()
+    alfa.remove_branch("nope")  # must not raise
+
+
+def test_branches_property_drops_spec_after_materialization():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+
+    alfa = Alfa()
+    assert "beta" in alfa.branches
+    alfa.route.node("beta/ping")()  # materialize
+    # Spec leaves _branches once materialized (it's now a real child).
+    assert "beta" not in alfa.branches
+
+
+# ---------------------------------------------------------------------------
+# Reaching a branch without a sub-path
+# ---------------------------------------------------------------------------
+
+
+def test_lazy_branch_alone_matches_eager_branch_behavior():
+    # A branch reached without a sub-path has no callable entry of its own
+    # (no default_entry): both eager and lazy resolve the same way.
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches(
+                [
+                    {"name": "lz", "lazy": True, "cls": Beta, "params": {}},
+                    {"name": "eg", "lazy": False, "cls": Beta, "params": {}},
+                ]
+            )
+
+    alfa = Alfa()
+    assert alfa.route.node("lz").error == alfa.route.node("eg").error
+
+
+# ---------------------------------------------------------------------------
+# nodes(basepath=...) opens (materializes) a lazy branch
+# ---------------------------------------------------------------------------
+
+
+def test_nodes_basepath_materializes_lazy_branch():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+
+    alfa = Alfa()
+    sub = alfa.route.nodes(basepath="beta")
+    assert set(sub["entries"].keys()) == {"ping", "info"}
+    assert "Beta:beta" in BUILD_LOG  # opening via basepath built it
+
+
+def test_nodes_basepath_deep_into_nested_lazy():
+    class Inner(RoutingClass):
+        @route()
+        def leaf(self):
+            return "inner.leaf"
+
+    class Mid(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "inner", "lazy": True, "cls": Inner, "params": {}})
+
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "mid", "lazy": True, "cls": Mid, "params": {}})
+
+    alfa = Alfa()
+    sub = alfa.route.nodes(basepath="mid/inner")
+    assert set(sub["entries"].keys()) == {"leaf"}
+
+
+# ---------------------------------------------------------------------------
+# @route(name=...) alias shown in lazy nodes() (class-level scan)
+# ---------------------------------------------------------------------------
+
+
+def test_lazy_nodes_shows_route_name_alias():
+    class Aliased(RoutingClass):
+        @route(name="public_name")
+        def internal_name(self):
+            return "x"
+
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "child", "lazy": True, "cls": Aliased, "params": {}})
+
+    alfa = Alfa()
+    tree = alfa.route.nodes()
+    entries = tree["routers"]["child"]["entries"]
+    assert "public_name" in entries
+    assert "internal_name" not in entries
+
+
+# ---------------------------------------------------------------------------
+# Interaction with the existing nodes(lazy=True) introspection flag
+# ---------------------------------------------------------------------------
+
+
+def test_nodes_lazy_flag_still_describes_declared_branches():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+
+    alfa = Alfa()
+    tree = alfa.route.nodes(lazy=True)
+    assert "beta" in tree["routers"]
+    assert "Beta:beta" not in BUILD_LOG
+
+
+# ---------------------------------------------------------------------------
+# Double materialization is defended (idempotent per name)
+# ---------------------------------------------------------------------------
+
+
+def test_materialize_branch_idempotent_direct():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+
+    alfa = Alfa()
+    r1 = alfa.route._materialize_branch("beta")
+    r2 = alfa.route._materialize_branch("beta")
+    assert r1 is r2
+    assert BUILD_LOG.count("Beta:beta") == 1
+
+
+# ---------------------------------------------------------------------------
+# Inherited @route leaf is scanned from the class (MRO), no duplicates
+# ---------------------------------------------------------------------------
+
+
+def test_lazy_nodes_scans_inherited_route_leaves():
+    class Base(RoutingClass):
+        @route()
+        def base_leaf(self):
+            return "base"
+
+    class Derived(Base):
+        @route()
+        def own_leaf(self):
+            return "own"
+
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "child", "lazy": True, "cls": Derived, "params": {}})
+
+    alfa = Alfa()
+    tree = alfa.route.nodes()
+    entries = tree["routers"]["child"]["entries"]
+    assert set(entries.keys()) == {"base_leaf", "own_leaf"}
+
+
+def test_lazy_nodes_dedups_same_function_under_two_attrs():
+    # Same function object bound to two class attributes must be scanned once.
+    class Aliased(RoutingClass):
+        @route()
+        def real(self):
+            return "r"
+
+        alias = real  # second attribute -> same function id
+
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "child", "lazy": True, "cls": Aliased, "params": {}})
+
+    alfa = Alfa()
+    entries = alfa.route.nodes()["routers"]["child"]["entries"]
+    assert list(entries.keys()) == ["real"]
+
+
+def test_lazy_nodes_branch_with_no_leaves():
+    # A lazy branch whose class declares no @route leaves: described as lazy,
+    # with no "entries" key.
+    class Empty(RoutingClass):
+        """A leaf-less grouping class."""
+
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "child", "lazy": True, "cls": Empty, "params": {}})
+
+    alfa = Alfa()
+    child_info = alfa.route.nodes()["routers"]["child"]
+    assert child_info["lazy"] is True
+    assert "entries" not in child_info

--- a/tests/test_lazy_branches.py
+++ b/tests/test_lazy_branches.py
@@ -369,6 +369,36 @@ def test_lazy_constructor_error_deferred_to_traversal():
     assert "Boom" not in BUILD_LOG
     with pytest.raises(RuntimeError, match="boom in __init__"):
         alfa.route.node("boom/ping")()
+    # The failing spec is NOT lost: the branch stays declared and the error
+    # is repeatable on the next traversal (no silent disappearance).
+    assert "boom" in alfa.branches
+    with pytest.raises(RuntimeError, match="boom in __init__"):
+        alfa.route.node("boom/ping")()
+
+
+def test_eager_constructor_error_is_repeatable_not_lost():
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches(
+                [
+                    {"name": "boom", "cls": Boom, "params": {}},  # eager, raises
+                    {"name": "ok", "cls": Gamma, "params": {}},  # eager, after boom
+                ]
+            )
+
+    alfa = Alfa()
+    with pytest.raises(RuntimeError, match="boom in __init__"):
+        alfa.route.nodes()  # first tree access: eager pass hits the error
+    # The failing branch is still declared (spec not lost) and the error
+    # repeats on the next tree access — the tree is loudly broken until fixed.
+    assert "boom" in alfa.branches
+    with pytest.raises(RuntimeError, match="boom in __init__"):
+        alfa.route.nodes()
+    # Removing the broken branch unblocks the tree; 'ok' materializes eagerly.
+    alfa.remove_branch("boom")
+    tree = alfa.route.nodes()
+    assert "ok" in tree["routers"]
+    assert alfa.route.node("ok/ping")() == "gamma.ping:gamma"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_router_edge_cases.py
+++ b/tests/test_router_edge_cases.py
@@ -352,49 +352,6 @@ def test_routing_proxy_attach_instance():
     assert parent.route.node("child/hello")() == "hello from child"
 
 
-def test_routing_proxy_instance():
-    """Test routing.instance() returns child RoutingClass instance."""
-
-    class UsersModule(RoutingClass):
-        @route()
-        def list(self):
-            return "users:list"
-
-    class OrdersModule(RoutingClass):
-        @route()
-        def list(self):
-            return "orders:list"
-
-    class App(RoutingClass):
-        def __init__(self):
-            self.attach_instance(UsersModule(), name="users")
-            self.attach_instance(OrdersModule(), name="orders")
-
-    app = App()
-
-    # Retrieve child instances via routing.instance()
-    users = app.routing.instance("users")
-    orders = app.routing.instance("orders")
-
-    assert isinstance(users, UsersModule)
-    assert isinstance(orders, OrdersModule)
-
-    # Routing still works
-    assert app.route.node("users/list")() == "users:list"
-    assert app.route.node("orders/list")() == "orders:list"
-
-
-def test_routing_proxy_instance_not_found():
-    """Test routing.instance() raises KeyError for non-existent child."""
-
-    class App(RoutingClass):
-        pass
-
-    app = App()
-    with pytest.raises(KeyError):
-        app.routing.instance("nonexistent")
-
-
 def test_endpoint_id_basic_lookup():
     """Test @endpoint_id resolution via node()."""
 
@@ -1095,21 +1052,6 @@ def test_router_get_config_paths():
     assert merged["mode"] == "x" and merged["trace"] is True
     with pytest.raises(AttributeError):
         svc.route.get_config("missing")
-
-
-def test_routed_proxy_get_router_handles_dotted_path():
-    class Leaf(RoutingClass):
-        pass
-
-    class Parent(RoutingClass):
-        def __init__(self):
-            self.child = Leaf()
-            self.route._children["child"] = self.child.route  # direct attach for test
-
-    svc = Parent()
-    router = svc.routing.get_router("child")
-    assert router is svc.child.route
-    assert router.name == "route"
 
 
 def test_routed_configure_updates_plugins_global_and_local():

--- a/tests/test_router_edge_cases.py
+++ b/tests/test_router_edge_cases.py
@@ -389,7 +389,7 @@ def test_endpoint_id_in_child_router():
 
     class App(RoutingClass):
         def __init__(self):
-            self.attach_instance(UsersModule(), name="users")
+            self.add_branches({"name": "users", "cls": UsersModule})
 
     app = App()
 
@@ -1140,7 +1140,7 @@ def test_attach_then_plug_propagates_to_child():
 
     class Api(RoutingClass):
         def __init__(self):
-            self.attach_instance(_LeafChild(), name="srv")
+            self.add_branches({"name": "srv", "cls": _LeafChild})
 
     api = Api()
     api.route.plug("pydantic")
@@ -1156,7 +1156,7 @@ def test_plug_then_attach_still_ok():
     class Api(RoutingClass):
         def __init__(self):
             self.route.plug("pydantic")
-            self.attach_instance(_LeafChild(), name="srv")
+            self.add_branches({"name": "srv", "cls": _LeafChild})
 
     fields = Api().route.node("srv/health").params.get("fields")
     assert fields is not None
@@ -1173,11 +1173,11 @@ def test_attach_then_plug_multilevel():
 
     class Mid(RoutingClass):
         def __init__(self):
-            self.attach_instance(GrandChild(), name="gc")
+            self.add_branches({"name": "gc", "cls": GrandChild})
 
     class Top(RoutingClass):
         def __init__(self):
-            self.attach_instance(Mid(), name="mid")
+            self.add_branches({"name": "mid", "cls": Mid})
 
     top = Top()
     top.route.plug("pydantic")

--- a/tests/test_router_runtime_extras.py
+++ b/tests/test_router_runtime_extras.py
@@ -346,30 +346,12 @@ def test_configure_validates_inputs_and_targets():
     assert result["updated"] == ["_all_"]
 
 
-def test_configure_question_success_and_router_proxy_errors():
+def test_configure_question_success():
     svc = LoggingService()
     description = svc.routing.configure("?")
     assert description["name"] == "route"
     assert "hello" in description["entries"]
     assert any(plugin["name"] == "logging" for plugin in description["plugins"])
-    with pytest.raises(KeyError):
-        svc.routing.get_router("missing")
-    router = svc.routing.get_router()
-    assert router is svc.route
-
-
-def test_get_router_skips_empty_segments():
-    class Leaf(RoutingClass):
-        pass
-
-    class Parent(RoutingClass):
-        def __init__(self):
-            self.child = Leaf()
-            self.route._children["child"] = self.child.route  # direct attach for test
-
-    svc = Parent()
-    router = svc.routing.get_router("child//")
-    assert router is svc.child.route
 
 
 def test_is_routing_class_helper():


### PR DESCRIPTION
## Summary

Release 0.27.0: declarative branches (lazy/eager subtrees), alias branches
(symlinks by absolute path), hardened introspection contract, docs overhaul.
Additive: attach_instance and include() remain supported.

Full detail in #43.

## Test plan

- 397 tests green, ruff clean, mypy clean (local + pre-push hooks)
- CI matrix 3.11/3.12/3.13 runs on this PR