### PR TITLE
genro-asgi-core audit fixes: unify bad-argument errors, single env filter key, batch plug()

### DIFF
--- a/docs/guide/basic-usage.md
+++ b/docs/guide/basic-usage.md
@@ -398,7 +398,7 @@ except HTTPForbidden:
 | `not_authenticated` | `NotAuthenticated` | 401 | Auth required, none provided |
 | `not_authorized` | `NotAuthorized` | 403 | Auth provided, insufficient |
 | `not_available` | `NotAvailable` | 501 | Capability missing |
-| `validation_error` | `ValidationError` | 422 | Pydantic validation failed |
+| `validation_error` | `ValidationError` | 422 | Bad arguments: pydantic validation failed or arguments unbindable (`TypeError`) |
 
 **Use cases**:
 

--- a/docs/guide/plugin-configuration.md
+++ b/docs/guide/plugin-configuration.md
@@ -4,8 +4,10 @@ Configure plugins at runtime through a unified API with support for global setti
 
 ## Overview
 
-Genro Routes provides `routing.configure()` for runtime plugin configuration with:
+Genro Routes provides `route.plug()` to attach plugins (single or in batch)
+and `routing.configure()` for runtime plugin configuration with:
 
+- **Batch attach**: Attach several plugins from a list of `{"name", ...}` dicts
 - **Target syntax**: `<plugin>/<selector>` format
 - **Global configuration**: Apply to all handlers with `_all_`
 - **Handler-specific overrides**: Target individual handlers
@@ -139,6 +141,38 @@ assert svc.route.logging.configuration("bar")["before"] is False
 - `enabled` - Enable/disable plugin for handler(s)
 - `flags` - Boolean options as comma-separated string
 - `before`, `after`, `print` - Plugin-specific settings (here: LoggingPlugin)
+
+## Attaching Plugins in Batch
+
+<!-- test: test_router_runtime_extras.py::test_plug_list_of_dicts_attaches_all -->
+
+`route.plug()` attaches a plugin. Besides the single form `plug("logging")`,
+it accepts a **list of plugin dicts** to attach several plugins in one call —
+the natural shape for a config-driven arming layer:
+
+```python
+route.plug([
+    {"name": "logging", "before": False},   # attach with options
+    {"name": "pydantic"},                    # attach with defaults
+])
+```
+
+**Each dictionary must have**:
+
+- `name` key - the plugin name (validated against `Router.available_plugins()`)
+- Additional keys - options passed to that plugin
+
+Notes:
+
+- Shared kwargs are **not** allowed with a list (`plug([...], x=1)` raises
+  `ValueError`) — options live inside each dict.
+- Attaching an already-attached plugin raises `ValueError` (use
+  `routing.configure()` to change a live plugin's settings) — the batch form
+  does not soften this.
+
+Attaching (`plug`) and configuring (`routing.configure`) stay distinct:
+`plug` brings a plugin onto the router; `configure` tunes a plugin already
+attached, down to individual handlers.
 
 ## Batch Updates
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genro-routes"
-version = "0.27.0"
+version = "0.28.0"
 description = "Instance-scoped routing engine for Python with hierarchical handlers and composable plugins"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/genro_routes/core/base_router.py
+++ b/src/genro_routes/core/base_router.py
@@ -1044,13 +1044,12 @@ class BaseRouter(RouterInterface):
                 self._materialize_branch(branch_name)
         # Compile pattern once if provided
         pattern_re = re.compile(pattern) if pattern else None
-        router_caps = self.current_capabilities
 
         entries: dict[str, Any] = {}
         for entry in self._entries.values():
             if pattern_re is not None and not pattern_re.search(entry.name):
                 continue
-            allow_result = self._entry_invalid_reason(entry, env_router_capabilities=router_caps, **kwargs)
+            allow_result = self._entry_invalid_reason(entry, **kwargs)
             if allow_result == "":
                 entries[entry.name] = self._entry_node_info(entry)
             elif forbidden:

--- a/src/genro_routes/core/base_router.py
+++ b/src/genro_routes/core/base_router.py
@@ -1150,7 +1150,8 @@ class BaseRouter(RouterInterface):
                     - ``not_found``: Path not found or varargs_required
                     - ``not_authorized``: Auth tags don't match (403)
                     - ``not_authenticated``: Auth required but not provided (401)
-                    - ``validation_error``: Pydantic validation failed
+                    - ``validation_error``: Bad arguments - pydantic validation
+                      failed or arguments were unbindable (TypeError)
 
                     Example::
 

--- a/src/genro_routes/core/router.py
+++ b/src/genro_routes/core/router.py
@@ -146,20 +146,39 @@ class Router(BaseRouter):
         """Return a copy of the global plugin registry."""
         return dict(_PLUGIN_REGISTRY)
 
-    def plug(self, plugin: str, **config: Any) -> Router:
-        """Attach a plugin by name (previously registered globally).
+    def plug(self, plugin: str | list[dict[str, Any]], **config: Any) -> Router:
+        """Attach one or more plugins by name (previously registered globally).
 
         Args:
-            plugin: Name of the plugin to attach.
-            **config: Configuration options passed to the plugin.
+            plugin: Either a plugin name (single attach) or a list of plugin
+                dicts ``{"name": ..., <options>}`` (batch attach). Each dict
+                carries the plugin name plus its own options; shared kwargs are
+                not allowed with a list.
+            **config: Configuration options passed to the plugin (single form only).
 
         Returns:
             self (for method chaining).
 
         Raises:
-            TypeError: If plugin is not a string.
-            ValueError: If plugin is not registered or already attached.
+            TypeError: If plugin is not a string or a list of dicts.
+            ValueError: If a plugin is not registered, already attached, a list
+                is mixed with shared kwargs, or a dict lacks 'name'.
         """
+        if isinstance(plugin, (list, tuple)):
+            if config:
+                raise ValueError("Do not mix shared kwargs with a list of plugins")
+            for item in plugin:
+                if not isinstance(item, dict):
+                    raise TypeError(
+                        f"Each plugin spec must be a dict, got {type(item).__name__}"
+                    )
+                options = dict(item)
+                try:
+                    name = options.pop("name")
+                except KeyError as err:
+                    raise ValueError("Plugin dict must include 'name'") from err
+                self.plug(name, **options)
+            return self
         if not isinstance(plugin, str):
             raise TypeError(
                 f"Plugin must be referenced by name string, got {type(plugin).__name__}"

--- a/src/genro_routes/core/router_node.py
+++ b/src/genro_routes/core/router_node.py
@@ -120,6 +120,8 @@ class RouterNode:
             errors: Optional dict mapping error codes to custom exception classes.
                     Available codes: 'not_found', 'not_authorized', 'not_authenticated',
                     'validation_error'. Custom exceptions override the defaults.
+                    'validation_error' covers every bad-argument path: pydantic
+                    validation failures and unbindable arguments (TypeError).
             entry_name: Name of the entry to resolve (if this is an entry node).
             path: Full path to this node.
             partial: Path segments not yet resolved.
@@ -254,7 +256,11 @@ class RouterNode:
         Raises:
             Exception mapped to error code: If error is set (not_found,
                 not_authenticated, not_authorized, not_available).
-            Exception mapped to 'validation_error': If pydantic validation fails.
+            Exception mapped to 'validation_error': For any bad-argument error
+                raised while calling the handler - both pydantic validation
+                failures and unbindable arguments (TypeError from signature
+                binding). Note: a TypeError raised inside the handler body is
+                indistinguishable from a binding error and is mapped too.
         """
         path = self.path or ""
 
@@ -272,7 +278,8 @@ class RouterNode:
         try:
             return self._entry.handler(*all_args, **merged_kwargs)  # type: ignore[attr-defined, union-attr]
         except Exception as e:
-            if ValidationError is not None and isinstance(e, ValidationError):
+            is_validation = ValidationError is not None and isinstance(e, ValidationError)
+            if is_validation or isinstance(e, TypeError):
                 custom_exc = self._exceptions.get("validation_error")
                 if custom_exc is not None and custom_exc is not ValidationError:
                     selector = f"{self._router.name}:{path}" if path else self._router.name

--- a/src/genro_routes/plugins/env.py
+++ b/src/genro_routes/plugins/env.py
@@ -177,15 +177,15 @@ class EnvPlugin(BasePlugin):
         """Filter entries based on capability requirements.
 
         Capabilities are accumulated from:
-        1. Router capabilities (``router_capabilities`` if pre-computed, else from router)
+        1. Router capabilities (walked from the router's parent chain)
         2. Request capabilities (``capabilities`` parameter)
 
         The combined set is checked against the entry's ``env_requires``.
 
         Args:
             entry: MethodEntry being checked.
-            **filters: May contain ``router_capabilities`` (pre-computed) and/or
-                      ``capabilities`` (from request).
+            **filters: May contain ``capabilities`` (from request), the only
+                      public env filter key.
 
         Returns:
             "": Access allowed (no reason to deny).
@@ -198,10 +198,7 @@ class EnvPlugin(BasePlugin):
         if not entry_rule:
             return ""
 
-        # Use pre-computed router capabilities or compute them
-        router_caps = filters.get("router_capabilities")
-        if router_caps is None:
-            router_caps = self._router.current_capabilities
+        router_caps = self._router.current_capabilities
 
         # Parse request capabilities
         request_caps_str = filters.get("capabilities")

--- a/tests/test_pydantic_plugin.py
+++ b/tests/test_pydantic_plugin.py
@@ -124,3 +124,48 @@ def test_pydantic_plugin_config_merge_base_and_handler():
         svc.route.node("handler_a")(123, "oops")
 
     assert svc.route.node("handler_b")(123, "oops") == "123:oops"
+
+
+class BadArgError(Exception):
+    """Custom exception used to check the unified bad-argument contract."""
+
+    def __init__(self, selector: str) -> None:
+        self.selector = selector
+        super().__init__(selector)
+
+
+def test_binding_error_maps_to_validation_error_with_pydantic():
+    """Extra positional args (TypeError from sig.bind) map to validation_error."""
+    svc = ValidateService()
+    node = svc.route.node("concat", errors={"validation_error": BadArgError})
+    with pytest.raises(BadArgError):
+        node("a", 1, "extra")  # too many positional args for concat(text, number)
+
+
+def test_binding_error_unknown_keyword_maps_to_validation_error():
+    """An unexpected keyword (TypeError from sig.bind) maps to validation_error."""
+    svc = ValidateService()
+    node = svc.route.node("concat", errors={"validation_error": BadArgError})
+    with pytest.raises(BadArgError):
+        node("a", nope=1)  # 'nope' is not a parameter of concat
+
+
+def test_binding_error_maps_without_pydantic():
+    """Without the pydantic plugin, the native TypeError maps too."""
+
+    class PlainService(RoutingClass):
+        @route()
+        def concat(self, text: str, number: int = 1) -> str:
+            return f"{text}:{number}"
+
+    svc = PlainService()
+    node = svc.route.node("concat", errors={"validation_error": BadArgError})
+    with pytest.raises(BadArgError):
+        node("a", 1, "extra")
+
+
+def test_binding_error_propagates_typeerror_without_custom():
+    """With no custom exception registered, the TypeError propagates unchanged."""
+    svc = ValidateService()
+    with pytest.raises(TypeError):
+        svc.route.node("concat")("a", 1, "extra")

--- a/tests/test_router_runtime_extras.py
+++ b/tests/test_router_runtime_extras.py
@@ -120,6 +120,48 @@ def test_plug_rejects_duplicate_plugin():
         svc.route.plug("logging")
 
 
+def test_plug_list_of_dicts_attaches_all():
+    """A list of plugin dicts attaches every plugin in one call."""
+    svc = ManualService()
+    result = svc.route.plug([
+        {"name": "stamp_extra"},
+        {"name": "logging", "before": False},
+    ])
+    assert result is svc.route  # returns self for chaining
+    assert "stamp_extra" in svc.route._plugins_by_name
+    assert "logging" in svc.route._plugins_by_name
+    # per-plugin option reached the logging plugin config
+    assert svc.route.logging.configuration()["before"] is False
+
+
+def test_plug_list_rejects_shared_kwargs():
+    """Mixing shared kwargs with a list of plugins raises ValueError."""
+    svc = ManualService()
+    with pytest.raises(ValueError, match="shared kwargs"):
+        svc.route.plug([{"name": "logging"}], level="debug")
+
+
+def test_plug_list_dict_requires_name():
+    """A plugin dict without 'name' raises ValueError."""
+    svc = ManualService()
+    with pytest.raises(ValueError, match="must include 'name'"):
+        svc.route.plug([{"level": "debug"}])
+
+
+def test_plug_list_rejects_non_dict_element():
+    """A non-dict element in the list raises TypeError."""
+    svc = ManualService()
+    with pytest.raises(TypeError, match="must be a dict"):
+        svc.route.plug(["logging"])  # type: ignore[list-item]
+
+
+def test_plug_list_rejects_duplicate():
+    """A duplicate plugin inside the batch raises 'already attached'."""
+    svc = ManualService()
+    with pytest.raises(ValueError, match="already attached"):
+        svc.route.plug([{"name": "logging"}, {"name": "logging"}])
+
+
 def test_add_entry_variants_and_wildcards():
     svc = ManualService()
     svc.route.add_entry(["first", "second"])


### PR DESCRIPTION
## Summary

Three additive, non-breaking fixes from the **genro-asgi-core (1c) foundation
audit** (2026-07-20). No lazy-branches Phase B involvement. Released as **0.28.0**.

- **#46** — `refactor: make env_capabilities the only public env filter key`
  Drops the internal `env_router_capabilities` precompute that leaked into the
  public filter namespace. `deny_reason` now always derives router capabilities
  from `self._router.current_capabilities`, so `env_capabilities` is the only
  public env filter. The parent-chain walk is recomputed per entry instead of
  once per router (negligible for shallow hierarchies; the fallback path was
  already the only one used by single `node()` and is fully tested).

- **#45** — `fix: unify bad-argument error contract on RouterNode calls`
  `RouterNode.__call__` now channels the `TypeError` from unbindable arguments
  (pydantic `sig.bind`, or the native call without the plugin) through the same
  `validation_error` custom-exception mapping used for pydantic
  `ValidationError`. A single `errors={"validation_error": ...}` mapping covers
  every bad-argument path. With no custom registered, the `TypeError` propagates
  unchanged. Documented limitation: a `TypeError` raised inside the handler body
  is mapped too (single interception point).

- **#47** — `feat: accept a list of plugin dicts in plug()`
  `plug()` accepts either a plugin name (single attach, unchanged) or a list of
  plugin dicts `{"name": ..., <options>}` for batch attach, mirroring the
  declarative grammar of `configure`. Shared kwargs are rejected with a list;
  each dict must carry `name`; the list branch recurses so every spec passes the
  same single-attach validation. Attach vs configure stay distinct; no
  re-plug/idempotency.

## Cross-repo impact (Sourcerer self-review)

- `env_router_capabilities`/`router_capabilities`: used only inside genro-routes.
  No external consumer — safe to remove.
- `.plug(...)`: all downstream call-sites (genro-asgi, smartpublisher,
  smartswitch) use the single-string form only; the batch form is purely
  additive, single form unchanged.
- The error-contract change affects only the path where a custom
  `validation_error` exception is registered; no downstream registers one there.

## Test plan

- Full suite green: **406 passed** (397 baseline from 0.27.0 + 9 new).
- #45: new bad-argument tests (too many args / unknown keyword, with and without
  the pydantic plugin, with and without a custom exception) in
  `tests/test_pydantic_plugin.py`.
- #46: `tests/test_env_plugin.py` all green; no `env_router_capabilities`
  residue in `src/`.
- #47: batch-attach tests + single-`plug` regression in
  `tests/test_router_runtime_extras.py`.
- `ruff check .` clean; `mypy src/` advisory clean.

Closes #45
Closes #46
Closes #47