### PR TITLE
add_branches single entry point with instance form; drop attach_instance (breaking, 0.29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This separation enables:
 
 1. **One class, one router** - Every `RoutingClass` owns exactly one router with isolated state, auto-created and exposed as the `route` property.
 2. **Friendly registration** - `@route(...)` accepts explicit names, auto-strips prefixes, and supports custom metadata.
-3. **Simple hierarchies** - `attach_instance(child, name="alias")` (method on `RoutingClass`) connects instances with path access (`parent.route.node("child/method")`).
+3. **Simple hierarchies** - `add_branches({"name": "alias", "instance": child})` (method on `RoutingClass`) connects an already-built instance with path access (`parent.route.node("child/method")`).
 4. **Plugin pipeline** - `BasePlugin` provides `on_decore`/`wrap_handler` hooks and plugins inherit from parents automatically.
 5. **Runtime configuration** - `routing.configure()` applies global or per-handler overrides with wildcards and returns reports (`"?"`).
 6. **Built-in plugins** - `logging`, `pydantic`, `auth`, `env`, and `channel` plugins are included out of the box.
@@ -93,8 +93,8 @@ class Application(RoutingClass):
     def __init__(self):
         self.users = UsersAPI()
 
-        # Attach child service
-        self.attach_instance(self.users, name="users")
+        # Attach child service (instance form: eager, linked immediately)
+        self.add_branches({"name": "users", "instance": self.users})
 
 app = Application()
 print(app.route.node("users/list")())  # ["alice", "bob"]
@@ -114,8 +114,8 @@ constructed until actually needed:
 class Application(RoutingClass):
     def __init__(self):
         self.add_branches([
-            {"name": "users",  "cls": UsersAPI},                    # eager: built at first tree access
-            {"name": "sales",  "cls": SalesAPI,  "lazy": True},     # lazy: built at first traversal
+            {"name": "sales",  "cls": SalesAPI},                    # factory: lazy, built at first traversal
+            {"name": "users",  "instance": UsersAPI()},             # instance: eager, linked immediately
             {"name": "shop",   "alias": "sales"},                   # alias: symlink to another branch
         ])
 
@@ -124,19 +124,22 @@ app.route.node("sales/report")()   # first traversal builds SalesAPI here
 app.route.node("shop/report")()    # same subtree via the alias (target's plugins)
 ```
 
-- **Eager** branches materialize at the first tree access; **lazy** ones only
-  when a path first traverses them. Constructor errors surface at that moment.
+- Each spec is one of three mutually exclusive forms: a **factory**
+  (`{"cls": ...}`) is **lazy** — built the first time a path traverses it; an
+  **instance** (`{"instance": ...}`) is **eager** — already built, linked at
+  the `add_branches` call; an **alias** (`{"alias": ...}`) is a symlink.
+  Factory constructor errors surface at first traversal.
 - `add_branches` accepts one dict, a list, or a generator — so a discovery
-  function can `yield` thousands of specs with zero construction cost.
+  function can `yield` thousands of factory specs with zero construction cost.
 - **Aliases** are transparent symlinks by absolute path from the tree root:
   the whole target subtree is reachable, with the *target's* plugins.
-- Introspection never builds implicitly: `nodes()` shows lazy branches and
+- Introspection never builds implicitly: `nodes()` shows lazy factories and
   aliases as unresolved markers (with their class-declared `@route` leaves,
   read without instantiating). Use `nodes(_eager=True)` to expand everything
   (e.g. to generate a full OpenAPI document) or `nodes(basepath="sales")` to
   open one branch explicitly.
-- `attach_instance(child, name=...)` remains supported for attaching an
-  already-built instance; `add_branches` is the recommended declarative form.
+- `add_branches` is the single entry point: pass a class for lazy
+  construction, or an instance to attach an already-built child eagerly.
 
 See the [Branches Guide](docs/guide/branches.md) for the full lifecycle.
 
@@ -259,7 +262,7 @@ Supported types: `TypedDict`, `dict[str, int]`, `list[...]`, `str`, `int`, `bool
 - **`Router`** - Runtime router owned by a `RoutingClass` instance, auto-created lazily and exposed as the read-only `route` property (never instantiated by user code)
 - **`@route()`** - Decorator that marks bound methods for the class's single router (keyword-only options: `name`, `endpoint_id`, plugin flags)
 - **`RoutingClass`** - Mixin that binds a class to its single router and exposes the `routing` proxy
-- **`Section`** - Empty `RoutingClass` used as a grouping node: `svc.attach_instance(Section("Admin area"), name="admin")`
+- **`Section`** - Empty `RoutingClass` used as a grouping node: `svc.add_branches({"name": "admin", "instance": Section("Admin area")})`
 - **`RoutingContext`** - Extensible execution context with parent chain delegation. Attach any attribute (`ctx.db`, `ctx.user`, `ctx.session`); missing lookups walk up `RoutingContext(parent=...)`. Stored in a `_ctx` slot on each instance — children inherit via `_routing_parent` chain. See [Execution Context Guide](docs/guide/context.md).
 - **`BasePlugin`** - Base class for creating plugins with `on_decore` and `wrap_handler` hooks
 - **`obj.routing`** - Proxy exposed by every RoutingClass that provides `configure(...)` for managing plugin settings without polluting the instance namespace.
@@ -277,11 +280,11 @@ See [Why One Name Per Operation](docs/guide/why-one-name-per-operation.md) for t
 ## Pattern Highlights
 
 - **Explicit naming + prefixes** - `@route(name="detail")` and `self.route.prefix = "handle_"` separate method names from public route names.
-- **Explicit instance hierarchies** - `self.attach_instance(child, name="alias")` connects RoutingClass instances. Navigate with `route.node("alias/handler")` or inspect with `route.nodes(basepath="alias")`.
-- **Declarative branches (lazy/eager)** - `self.add_branches({"name": "sales", "cls": Sales, "lazy": True})` declares subtrees as factory specs, built only when traversed. See [Branches](#branches-lazy-subtrees-and-aliases).
+- **Explicit instance hierarchies** - `self.add_branches({"name": "alias", "instance": child})` connects an already-built RoutingClass instance eagerly. Navigate with `route.node("alias/handler")` or inspect with `route.nodes(basepath="alias")`.
+- **Declarative branches** - `self.add_branches({"name": "sales", "cls": Sales})` declares a factory subtree, built lazily at first traversal; `{"name": "users", "instance": UsersAPI()}` attaches an already-built instance eagerly. See [Branches](#branches-lazy-subtrees-and-aliases).
 - **Branch aliases** - `{"name": "fake", "alias": "real/path"}` exposes an existing subtree under a second name, like a filesystem symlink.
 - **Endpoint ID** - `@route(endpoint_id="USR-001")` assigns a stable identifier for reverse lookup via `router.node("@USR-001")`.
-- **Grouping nodes** - `attach_instance(Section("Admin area"), name="admin")` creates pure organizational nodes without handlers.
+- **Grouping nodes** - `add_branches({"name": "admin", "instance": Section("Admin area")})` creates pure organizational nodes without handlers.
 - **Built-in and custom plugins** - `self.route.plug("logging")`, `self.route.plug("pydantic")`, or custom plugins.
 - **Shorthand plugin syntax** - `@route(auth="admin")` instead of `@route(auth_rule="admin")`. Plugins declare their default parameter via `plugin_default_param`.
 - **Channel filtering** - `@route(channel="mcp,bot_.*")` controls which transport channels can access each handler. Supports regex patterns.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -14,50 +14,59 @@ graph TD
   RC -->|route property| Router
   RC -->|attribute| ChildRC
   ChildRC -->|route property| ChildRouter
-  RC -->|attach_instance(name)| ChildRC
+  RC -->|add_branches name+instance| ChildRC
   Router -->|include(child.route, name)| ChildRouter
   Router -->|nodes| M[Nodes tree]
 ```
 
 - Every `RoutingClass` owns exactly one `Router`, created lazily on first access of the read-only `route` property. User code never instantiates `Router` directly; router options (`description`, `prefix`, `default_entry`) are set on `self.route` in `__init__`.
-- Hierarchies are built via `attach_instance(child, name=alias)` (method on `RoutingClass`), which links `child.route` into the parent's router under the alias, and torn down via `detach_instance` (method on `Router`). The declarative equivalent is `add_branches` (see Branches below).
-- `Section` (an empty `RoutingClass`) provides pure grouping nodes without handlers: `svc.attach_instance(Section("Admin area"), name="admin")`.
+- Hierarchies are built via `add_branches` (method on `RoutingClass`): the instance form `{"name": alias, "instance": child}` links `child.route` into the parent's router under the alias eagerly, the factory form `{"name": alias, "cls": Child}` does so lazily at first traversal. Children are torn down via `detach_instance` (method on `Router`). See Branches below.
+- `Section` (an empty `RoutingClass`) provides pure grouping nodes without handlers: `svc.add_branches({"name": "admin", "instance": Section("Admin area")})`.
 - `default_entry` (default: `"index"`) specifies which handler to use for catch-all routing (best-match resolution).
 - Introspection: `nodes()` is the sole API; it returns router/instance, handlers (with metadata, doc, signature, plugins, params), children, and `plugin_info`.
 
-## Branches (declarative subtrees: eager, lazy, alias)
+## Branches (declarative subtrees: factory, instance, alias)
 
-A **branch** is a child subtree declared as a factory spec and materialized on
-demand. Specs live in `router._branches`; materialized children move to
-`router._children`. One mechanism, two timing policies, plus symlinks:
+`add_branches` is the single entry point for declaring a child subtree. Each
+spec is one of three mutually exclusive forms (`cls` / `instance` / `alias`
+cannot coexist). A **factory** spec is a self-describing subtree materialized
+on demand: it lives in `router._branches` until built, then moves to
+`router._children`. An **instance** spec attaches an already-built child
+directly. Timing is derived from the form, not from a flag:
 
 ```mermaid
 graph LR
-  Spec["branch spec {name, lazy, cls, params}"] -->|"first tree access (eager) / first traversal (lazy)"| Child["child router in _children"]
+  Factory["factory spec {name, cls, params}"] -->|"first traversal (lazy)"| Child["child router in _children"]
+  Instance["instance spec {name, instance}"] -->|"immediately (eager)"| Child
   Alias["alias spec {name, alias: path}"] -->|"path rewrite from root"| Target["target subtree"]
 ```
 
-- `add_branches(spec | list | generator)` stores specs — nothing is constructed
-  at declaration. `remove_branch(name)` drops a spec (detaching the child if
-  already materialized). The `branches` property lists declared, not-yet-built
-  specs only.
-- **Materialization** (single point): construct `cls(**params)`, wire
-  `_routing_parent`, `include()` the child router (triggering plugin
-  inheritance), then drop the spec. The spec is popped only after a successful
-  build: a failing constructor is repeatable, never silently lost.
-- **Eager** specs materialize at the first tree access (guard set after a fully
-  successful pass); **lazy** specs at the first path traversal through their
-  segment (`_find_candidate_node` / `router_at_path`).
+- `add_branches(spec | list | generator)` accepts all three forms. A factory
+  spec is stored — nothing is constructed at declaration; an instance spec is
+  linked as a child at once. `remove_branch(name)` drops a spec (detaching the
+  child if already materialized). The `branches` property lists declared
+  factory specs not yet built; instances (already children) do not appear.
+- **Factory** (lazy): materialized at the first path traversal through their
+  segment (`_find_candidate_node` / `router_at_path`). Materialization (single
+  point): construct `cls(**params)`, wire `_routing_parent`, `include()` the
+  child router (triggering plugin inheritance), then drop the spec. The spec is
+  popped only after a successful build: a failing constructor is repeatable,
+  never silently lost.
+- **Instance** (eager): the caller built the instance, so it is wired
+  immediately at declaration — `_routing_parent` set, child `include()`d,
+  plugin inheritance applied. `params` is rejected with an instance
+  (`ValueError`); the instance must be a `RoutingClass` (`TypeError`); an
+  instance already bound to another parent raises `ValueError`.
 - **Alias** specs are transparent symlinks by absolute path from the tree root:
   navigation rewrites the path and resolves from the root, so the target's
   whole subtree is served with the target's plugins. Cycle-guarded
   (`ValueError`); broken targets resolve to `not_found`. A node reached through
   an alias reports the target's path (realpath semantics).
-- **Introspection never builds**: `nodes()` shows lazy branches with their
-  class-declared `@route` leaves (scanned from the class MRO, no instance) and
-  aliases as unresolved markers. `nodes(_eager=True)` expands everything;
-  `nodes(basepath=...)` opens one subtree. `node("@endpoint_id")` skips
-  non-materialized lazy branches.
+- **Introspection never builds**: `nodes()` shows lazy factory branches with
+  their class-declared `@route` leaves (scanned from the class MRO, no
+  instance) and aliases as unresolved markers. `nodes(_eager=True)` expands
+  everything; `nodes(basepath=...)` opens one subtree. `node("@endpoint_id")`
+  skips non-traversed factory branches.
 
 ## Plugin store
 
@@ -103,7 +112,7 @@ plugin_info
 
 ## Plugin Inheritance
 
-When a child instance is attached to a parent via `attach_instance()` (on `RoutingClass`), plugins may be inherited.
+When a child is attached to a parent via `add_branches` (on `RoutingClass`) — at declaration for an instance spec, at first traversal for a factory spec — plugins may be inherited.
 The inheritance behavior is **delegated to the plugin** via hooks, allowing each plugin to
 decide how to handle parent-child relationships.
 

--- a/docs/CODE_READING_GUIDE.md
+++ b/docs/CODE_READING_GUIDE.md
@@ -58,7 +58,7 @@ Two fundamental consequences:
 - **One class, one router.** Every `RoutingClass` owns exactly one `Router`,
   created lazily and exposed as the read-only property `route`. Hierarchy and
   multiple "surfaces" are expressed by **composing instances**
-  (`attach_instance`), never by adding routers to a class.
+  (`add_branches`), never by adding routers to a class.
 
 ---
 
@@ -325,7 +325,7 @@ that match the handler's positional parameters as path segments.
 `detach_instance(child)` removes every alias whose router belongs to the child
 instance and clears `child._routing_parent`.
 
-User code normally calls neither directly: `RoutingClass.attach_instance`
+User code normally calls neither directly: `RoutingClass.add_branches`
 (chapter 7) sets the parent relation and delegates the link to `include()`.
 
 ### 5.6 Introspection — `nodes()`
@@ -480,26 +480,30 @@ without a manual `detach_instance()` call.
 custom `__setattr__` when the auto-detach check is not wanted (e.g. during
 internal initialization).
 
-### 7.4 `attach_instance` — hierarchical composition
+### 7.4 `add_branches` — hierarchical composition
 
-`attach_instance` is a method of **RoutingClass** (not of Router or the proxy).
-There is a single calling style:
+`add_branches` is a method of **RoutingClass** (not of Router or the proxy).
+Each branch is a dict; two forms are accepted:
 
 ```python
-self.attach_instance(child, name="sales")
+# instance form — eager: attach an already-built child instance now
+self.add_branches({"name": "sales", "instance": child})
+
+# factory form — lazy: the child is created on first access
+self.add_branches({"name": "sales", "cls": SalesService, "params": {...}})
 ```
 
-It sets `child._routing_parent = self` and, when `name` is given, delegates the
-routing link to `self.route.include(child.route, name=name)` (which triggers
-plugin inheritance on the primary attachment). Without `name`, only the parent
-relationship is set — useful for `ctx` propagation without routing.
+The instance form sets `child._routing_parent = self` and delegates the routing
+link to `self.route.include(child.route, name=name)` (which triggers plugin
+inheritance on the primary attachment). The factory form records the class and
+params and materializes the child lazily on first resolution of the branch.
 
 `detach_instance` stays on **Router**.
 
 ### 7.5 `Section` — the grouping node
 
 ```python
-svc.attach_instance(Section("Admin area"), name="admin")
+svc.add_branches({"name": "admin", "instance": Section("Admin area")})
 ```
 
 `Section` is a minimal concrete RoutingClass carrying an empty router. It is
@@ -526,7 +530,7 @@ without polluting the class namespace:
 |--------------|---------|
 | `configure(target, **opts)` | Plugin configuration via target syntax |
 | `configure("?")` | Introspection: returns the router description dict |
-| `attach_instance(child, name=...)` | Delegates to the owner's `attach_instance` |
+| `add_branches(*branches)` | Delegates to the owner's `add_branches` |
 
 For navigation and introspection use the router directly: `route.node(path)`
 resolves (and executes) a path, `route.nodes(basepath=...)` inspects and opens
@@ -961,7 +965,7 @@ The `selector` has the format `"router_name:path"` (e.g. `"route:admin/create"`)
 
 Used to **bypass** RoutingClass's custom `__setattr__` when setting internal
 attributes that must not trigger the auto-detach. You will see it in:
-`attach_instance`, `_register_router`, the `ctx` and `capabilities` setters,
+`add_branches`, `_register_router`, the `ctx` and `capabilities` setters,
 `_RoutingProxy.__init__`, and in `base_router.py` inside `_include_router` and
 `detach_instance` (which set/clear `_routing_parent` on the owner).
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -37,7 +37,7 @@ orders.route.node("create")({"name": "order-3"})  # Calls create()
 **Answer**: Genro Routes offers:
 
 - **Plugin system**: add logging, validation, audit without touching handlers
-- **Hierarchies**: organize routers in trees with `attach_instance()` (method on `RoutingClass`)
+- **Hierarchies**: organize routers in trees with `add_branches()` (instance form, method on `RoutingClass`)
 - **Metadata**: each handler can have tags, channels, configurations
 - **Introspection**: `router.nodes()` to explore structure
 - **Isolation**: each instance has its own router with independent plugins
@@ -115,8 +115,7 @@ def handle_create(self): ...  # Registered as "create" (strips prefix)
 
 - `obj.route` — the instance's single router, created lazily (read-only property)
 - `obj.routing` — proxy for plugin configuration (`configure()`)
-- `obj.attach_instance(child, name=...)` — connects child instances into a hierarchy
-- `obj.add_branches(specs)` — declares child subtrees as factory specs (eager/lazy/alias)
+- `obj.add_branches(specs)` — declares child subtrees; the instance form `{"name": ..., "instance": child}` connects an already-built child instance eagerly, other forms declare factory specs (lazy/alias)
 - `obj.ctx` — execution context with parent-chain lookup
 
 A `Router` can only be owned by a `RoutingClass` instance.
@@ -127,7 +126,7 @@ A `Router` can only be owned by a `RoutingClass` instance.
 
 **Question**: I have an application with modules (sales, finance, admin) that I want to organize hierarchically. How?
 
-**Answer**: Use `attach_instance()` (a method on `RoutingClass`) to connect child instances:
+**Answer**: Use the instance form of `add_branches()` (a method on `RoutingClass`) to connect an already-built child instance eagerly:
 
 ```python
 class Dashboard(RoutingClass):
@@ -136,8 +135,8 @@ class Dashboard(RoutingClass):
         self.finance = FinanceModule()
 
         # Attach child instances — each child's router is linked under the alias
-        self.attach_instance(self.sales, name="sales")
-        self.attach_instance(self.finance, name="finance")
+        self.add_branches({"name": "sales", "instance": self.sales})
+        self.add_branches({"name": "finance", "instance": self.finance})
 
 dashboard = Dashboard()
 # Access with path separator
@@ -150,7 +149,7 @@ For a pure grouping level without a dedicated class, attach a `Section`:
 ```python
 from genro_routes import Section
 
-dashboard.attach_instance(Section("Admin area"), name="admin")
+dashboard.add_branches({"name": "admin", "instance": Section("Admin area")})
 ```
 
 ### How do I access child routers?
@@ -187,7 +186,7 @@ class Parent(RoutingClass):
     def __init__(self):
         self.route.plug("logging")
         self.child_obj = Child()
-        self.attach_instance(self.child_obj, name="child")
+        self.add_branches({"name": "child", "instance": self.child_obj})
 
 # Child automatically inherits logging plugin
 parent = Parent()
@@ -499,10 +498,10 @@ def handle_create_order(self): ...
 ```python
 # CORRECT
 self.route.plug("logging")
-self.attach_instance(child, name="child")  # Child inherits logging
+self.add_branches({"name": "child", "instance": child})  # Child inherits logging
 
 # WRONG
-self.attach_instance(child, name="child")
+self.add_branches({"name": "child", "instance": child})
 self.route.plug("logging")  # Child does NOT inherit
 ```
 

--- a/docs/concepts_to_add/lazy-branches.md
+++ b/docs/concepts_to_add/lazy-branches.md
@@ -1,8 +1,9 @@
 # Lazy Branches — declarative subrouters, materialized on demand
 
-**Status**: 🟢 IMPLEMENTED (0.27) — kept as design record
-**Version**: 1.0
-**Last Updated**: 2026-07-16
+**Status**: 🟢 IMPLEMENTED (0.27) — kept as design record.
+Section "Phase B — instance form (0.29)" below is 🔴 DA REVISIONARE.
+**Version**: 1.1
+**Last Updated**: 2026-07-22
 
 ## Summary
 
@@ -172,8 +173,48 @@ class Alfa(RoutingClass):
 | `tests/` | `test_lazy_branches.py` + `test_branch_alias.py` (exhaustive, behavioral); Pattern-A call-sites migrated to `add_branches` |
 | `docs/` | `guide/branches.md`; README, ARCHITECTURE, FAQ, hierarchies/best-practices updated |
 
-## Deferred to a later breaking release
+## Phase B — instance form (0.29) 🔴 DA REVISIONARE
 
-- Removal of `attach_instance` and of the secondary-link logic in
-  `_include_router`; migration of the remaining instance-based test call-sites.
-- Single-leaf sharing stays out of scope (see above).
+Phase B makes `add_branches` the **single entry point** for declaring a
+subtree, in three mutually exclusive spec forms, and **removes**
+`attach_instance`. The timing is derived from *what you pass*, so the `lazy`
+flag is dropped:
+
+| Form | Keys | Timing |
+|------|------|--------|
+| factory | `cls` (+ `params`) | **lazy** — built on first traversal |
+| instance | `instance` | **eager** — already built, linked as a child now |
+| alias | `alias` | never (symlink) |
+
+Rules:
+
+- **`cls` ⇒ always lazy.** A class is a promise: it is constructed on first
+  traversal. The 0.27 eager-factory (a class built at first tree access) is
+  gone — to build a subtree up front, pass a pre-built **instance** instead.
+- **`instance` ⇒ always eager.** An instance already exists; it is linked
+  immediately via the same `_include_router` path a factory uses at
+  materialization, and lands directly in `_children` — it never appears in the
+  `branches` view (that view lists declared-not-built specs only).
+- The three key groups are **mutually exclusive**: `cls`/`params`, `instance`,
+  `alias`. Any mix (e.g. `instance` + `cls`, `instance` + `lazy`) is a
+  `ValueError`.
+- **`lazy` flag removed** everywhere. Timing is `cls`→lazy, `instance`→eager.
+
+This resolves the "child as attribute" friction: instead of
+`self.commander = Commander(self)` + `attach_instance`, write
+
+```python
+self.commander = Commander(self)
+self.add_branches({"name": "commander", "instance": self.commander})
+```
+
+`attach_instance` (owner and proxy) is removed. `detach_instance` stays as the
+internal inverse of "remove a child" (used by `remove_branch`), not as a public
+attach counterpart.
+
+**Breaking, by design.** The project is in prototyping: no compatibility shim,
+no deprecation. Existing `add_branches({"cls": ...})` call-sites change timing
+silently (eager → lazy); every `lazy=` is removed; every `attach_instance(...)`
+becomes `add_branches({"name": ..., "instance": ...})`.
+
+Single-leaf sharing stays out of scope (see above).

--- a/docs/genro-routes-for-dummies.html
+++ b/docs/genro-routes-for-dummies.html
@@ -755,7 +755,7 @@ svc.route.logging.configure(print=<span class="kw">True</span>)                 
 
 <h2>Service Composition</h2>
 
-<p>Real applications are built from independent modules. Each module is a <code class="il">RoutingClass</code> with its own router. Connect them with <code class="il">self.attach_instance(child, ...)</code> on the parent RoutingClass.</p>
+<p>Real applications are built from independent modules. Each module is a <code class="il">RoutingClass</code> with its own router. Connect them with <code class="il">self.add_branches({"name": ..., "instance": child})</code> on the parent RoutingClass.</p>
 
 <div class="diagram">
 <svg viewBox="0 0 680 280" xmlns="http://www.w3.org/2000/svg" font-family="Inter, sans-serif">
@@ -793,9 +793,9 @@ svc.route.logging.configure(print=<span class="kw">True</span>)                 
         self.orders = <span class="cls">OrdersService</span>()
         self.notify = <span class="cls">NotifyService</span>()
 
-        self.attach_instance(self.users, name=<span class="str">"users"</span>)
-        self.attach_instance(self.orders, name=<span class="str">"orders"</span>)
-        self.attach_instance(self.notify, name=<span class="str">"notify"</span>)
+        self.add_branches({<span class="str">"name"</span>: <span class="str">"users"</span>, <span class="str">"instance"</span>: self.users})
+        self.add_branches({<span class="str">"name"</span>: <span class="str">"orders"</span>, <span class="str">"instance"</span>: self.orders})
+        self.add_branches({<span class="str">"name"</span>: <span class="str">"notify"</span>, <span class="str">"instance"</span>: self.notify})
 
 app = <span class="cls">App</span>()
 app.route.node(<span class="str">"users/list_users"</span>)()
@@ -979,7 +979,7 @@ Usage: ordersapi retrieve [OPTIONS] IDENT
   <tr><td><code class="il">Literal["a","b"]</code></td><td><code class="il">--choice {a,b}</code></td></tr>
   <tr><td><code class="il">Enum</code></td><td><code class="il">--choice {NAME,...}</code></td></tr>
   <tr><td><code class="il">list[str]</code></td><td><code class="il">--items a --items b</code> (multiple)</td></tr>
-  <tr><td>Child router (self.attach_instance)</td><td>Nested sub-group</td></tr>
+  <tr><td>Child router (self.add_branches instance form)</td><td>Nested sub-group</td></tr>
   <tr><td>Handler docstring</td><td>Command help text</td></tr>
 </table>
 
@@ -1079,11 +1079,11 @@ cli = RoutingCli(svc)</code></pre>
 <h3>Composition</h3>
 <table>
   <tr><th>I want to...</th><th>Code</th></tr>
-  <tr><td>Attach a child service</td><td><code class="il">parent.attach_instance(child, name="x")</code></td></tr>
+  <tr><td>Attach a child service</td><td><code class="il">parent.add_branches({"name": "x", "instance": child})</code></td></tr>
   <tr><td>Retrieve attached child instance</td><td><code class="il">parent.route.nodes(basepath="x")["instance"]</code></td></tr>
   <tr><td>Call through hierarchy</td><td><code class="il">parent.route.node("x/handler")()</code></td></tr>
   <tr><td>Resolve by endpoint_id</td><td><code class="il">parent.route.node("@MY-EP")()</code></td></tr>
-  <tr><td>Create a pure grouping node (no handlers)</td><td><code class="il">parent.attach_instance(Section("Admin"), name="admin")</code></td></tr>
+  <tr><td>Create a pure grouping node (no handlers)</td><td><code class="il">parent.add_branches({"name": "admin", "instance": Section("Admin")})</code></td></tr>
   <tr><td>Strip method name prefixes</td><td><code class="il">self.route.prefix = "handle_"</code> (in <code class="il">__init__</code>)</td></tr>
   <tr><td>Auto-propagate db to children</td><td>Set <code class="il">ctx.db = conn</code> on <code class="il">RoutingContext</code> — parent chain handles propagation</td></tr>
   <tr><td>Filter by user permissions</td><td><code class="il">svc.route.nodes(auth_tags="admin")</code></td></tr>

--- a/docs/guide/attach-instance-visual-guide.md
+++ b/docs/guide/attach-instance-visual-guide.md
@@ -1,11 +1,14 @@
-# attach_instance Visual Guide
+# Instance Attachment Visual Guide
 
-How to connect RoutingClass instances into hierarchies.
+How to connect RoutingClass instances into hierarchies with the instance form
+of `add_branches`.
 
 ## Core Concept
 
-`attach_instance` lives on **RoutingClass** (not on Router). Every RoutingClass
-owns exactly one router (`self.route`). Attaching does two things:
+`add_branches` lives on **RoutingClass** (not on Router). Every RoutingClass
+owns exactly one router (`self.route`). Its **instance form**
+(`{"name": alias, "instance": child}`) attaches an already-built child eagerly
+and does two things:
 
 1. Sets the parent-child relationship (`child._routing_parent = self`)
 2. Links the child's router into the parent's router (`parent.route._children[alias] = child.route`, via `include()`)
@@ -57,7 +60,7 @@ graph TB
 **Syntax:**
 
 ```python
-self.attach_instance(vendite, name="sales")
+self.add_branches({"name": "sales", "instance": vendite})
 ```
 
 **Access paths:**
@@ -68,8 +71,8 @@ self.route.node("sales/ordini")()   # child entry
 self.route.node("sales/fatture")()  # child entry
 ```
 
-**Rule:** `name=` is the alias in the parent's router. This is the only calling
-style — every RoutingClass has exactly one router, so there is nothing else to map.
+**Rule:** the `"name"` key is the alias in the parent's router. Every
+RoutingClass has exactly one router, so there is nothing else to map.
 
 ---
 
@@ -108,8 +111,8 @@ graph TB
 **Syntax:**
 
 ```python
-vendite.attach_instance(statistiche, name="statistiche")
-self.attach_instance(vendite, name="sales")
+vendite.add_branches({"name": "statistiche", "instance": statistiche})
+self.add_branches({"name": "sales", "instance": vendite})
 ```
 
 **Access paths:**
@@ -172,10 +175,10 @@ from genro_routes import Section
 
 api = Section("Public API")
 admin = Section("Admin area")
-self.attach_instance(api, name="api")
-self.attach_instance(admin, name="admin")
-api.attach_instance(OrdersApi(), name="orders")
-admin.attach_instance(OrdersAdmin(), name="orders")
+self.add_branches({"name": "api", "instance": api})
+self.add_branches({"name": "admin", "instance": admin})
+api.add_branches({"name": "orders", "instance": OrdersApi()})
+admin.add_branches({"name": "orders", "instance": OrdersAdmin()})
 ```
 
 **Access paths:**
@@ -186,33 +189,25 @@ self.route.node("admin/orders/manage")()   # admin surface
 ```
 
 > **Note:** earlier versions supported multiple routers per class with a
-> `router_*` cross-mapping DSL in `attach_instance`. That feature was removed:
-> composition (one class per surface, `Section` for grouping) covers the same
-> use cases with a single calling style.
+> `router_*` cross-mapping DSL. That feature was removed: composition (one
+> class per surface, `Section` for grouping) covers the same use cases with a
+> single calling style.
 
 ---
 
 ## Syntax Reference
 
-### `attach_instance(child, name=...)`
+### `add_branches({"name": alias, "instance": child})`
 
 ```python
-self.attach_instance(child, name="alias")
+self.add_branches({"name": "alias", "instance": child})
 ```
 
-- The child's router is linked under `alias` in the parent's router
+- The child's router is linked under `alias` in the parent's router (eager: at the call)
 - Sets `child._routing_parent = self`
+- `params` is not allowed together with `instance` (`ValueError`)
+- `instance` must be a `RoutingClass` (`TypeError` otherwise)
 - Raises `ValueError` on alias collision or if the child is already bound to another parent
-
-### Attach only (no routing)
-
-```python
-self.attach_instance(child)
-```
-
-- Sets `child._routing_parent = self` only
-- No routers are linked
-- Useful when you plan to link routers later or only need the parent chain for `ctx` propagation
 
 ### `include` (on Router — low level)
 
@@ -304,9 +299,9 @@ flowchart TD
     A --> D["Several surfaces\n(api, admin, ...)"]
     A --> E["Make one entry visible\nfrom another tree"]
 
-    B --> F["attach_instance(child, name='alias')"]
-    C --> G["attach_instance(Section('...'), name='group')"]
-    D --> H["One RoutingClass per surface,\ncomposed with attach_instance"]
+    B --> F["add_branches(name='alias', instance=child)"]
+    C --> G["add_branches(name='group', instance=Section('...'))"]
+    D --> H["One RoutingClass per surface,\ncomposed with add_branches"]
     E --> I["router.include(node, name='alias')"]
 
     style F fill:#c8e6c9,stroke:#2e7d32
@@ -338,8 +333,8 @@ class Application(RoutingClass):
         self.auth = AuthService()
         self.users = UserService()
 
-        self.attach_instance(self.auth, name="auth")
-        self.attach_instance(self.users, name="users")
+        self.add_branches({"name": "auth", "instance": self.auth})
+        self.add_branches({"name": "users", "instance": self.users})
 
 app = Application()
 

--- a/docs/guide/basic-usage.md
+++ b/docs/guide/basic-usage.md
@@ -169,8 +169,8 @@ class App(RoutingClass):
     def __init__(self):
         self.api = PublicAPI()
         self.admin = AdminAPI()
-        self.attach_instance(self.api, name="api")
-        self.attach_instance(self.admin, name="admin")
+        self.add_branches({"name": "api", "instance": self.api})
+        self.add_branches({"name": "admin", "instance": self.admin})
 
 app = App()
 assert app.route.node("api/ping")() == "pong"
@@ -178,7 +178,7 @@ assert app.route.node("admin/reset")() == "reset done"
 ```
 
 For a grouping level without a dedicated class, attach a `Section` (an empty
-`RoutingClass`): `app.attach_instance(Section("Admin area"), name="admin")`.
+`RoutingClass`): `app.add_branches({"name": "admin", "instance": Section("Admin area")})`.
 
 ## Calling Handlers
 
@@ -466,8 +466,8 @@ class RootAPI(RoutingClass):
         self.users = SubService("users")
         self.products = SubService("products")
 
-        self.attach_instance(self.users, name="users")
-        self.attach_instance(self.products, name="products")
+        self.add_branches({"name": "users", "instance": self.users})
+        self.add_branches({"name": "products", "instance": self.products})
 
 root = RootAPI()
 
@@ -478,8 +478,8 @@ assert root.route.node("products/detail")(5) == "products:detail:5"
 
 **Key points**:
 
-- `attach_instance` is a method on `RoutingClass`, not on `Router`
-- `name="alias"` links the child's router into the parent's router under that alias
+- `add_branches` (instance form) is a method on `RoutingClass`, not on `Router`
+- the `"name"` key links the child's router into the parent's router under that alias
 - For grouping levels without handlers, attach a `Section` (see [Hierarchies Guide](hierarchies.md))
 
 **Hierarchies enable**:
@@ -498,7 +498,7 @@ Inspect router structure and registered handlers:
 class Inspectable(RoutingClass):
     def __init__(self):
         self.child_service = SubService("child")
-        self.attach_instance(self.child_service, name="sub")
+        self.add_branches({"name": "sub", "instance": self.child_service})
 
     @route()
     def action(self):

--- a/docs/guide/best-practices.md
+++ b/docs/guide/best-practices.md
@@ -105,11 +105,11 @@ class Application(RoutingClass):
     def __init__(self):
         # Section as a namespace container
         admin = Section("Admin area")
-        self.attach_instance(admin, name="admin")
+        self.add_branches({"name": "admin", "instance": admin})
 
         # Attach actual services under the section
-        admin.attach_instance(UserAdmin(), name="users")
-        admin.attach_instance(OrderAdmin(), name="orders")
+        admin.add_branches({"name": "users", "instance": UserAdmin()})
+        admin.add_branches({"name": "orders", "instance": OrderAdmin()})
 ```
 
 ### Attaching Child Instances
@@ -120,7 +120,7 @@ Child instances can be attached directly — storing as an attribute is optional
 class Parent(RoutingClass):
     def __init__(self):
         # Both approaches work — the router tree keeps a strong reference
-        self.attach_instance(ChildService(), name="child")
+        self.add_branches({"name": "child", "instance": ChildService()})
 
 # Retrieve the child instance later if needed
 child = parent.route.nodes(basepath="child")["instance"]
@@ -141,8 +141,8 @@ class Application(RoutingClass):
         self.public = PublicAPI()  # No validation needed
         self.admin = AdminAPI()    # Has its own pydantic plugin
 
-        self.attach_instance(self.public, name="public")
-        self.attach_instance(self.admin, name="admin")
+        self.add_branches({"name": "public", "instance": self.public})
+        self.add_branches({"name": "admin", "instance": self.admin})
 
 
 class AdminAPI(RoutingClass):
@@ -339,12 +339,12 @@ Avoid circular attachments:
 class A(RoutingClass):
     def __init__(self, b):
         self.b = b
-        self.attach_instance(b, name="b")
+        self.add_branches({"name": "b", "instance": b})
 
 class B(RoutingClass):
     def __init__(self, a):
         self.a = a
-        self.attach_instance(a, name="a")  # Circular!
+        self.add_branches({"name": "a", "instance": a})  # Circular!
 ```
 
 ### Over-Configuration

--- a/docs/guide/branches.md
+++ b/docs/guide/branches.md
@@ -43,14 +43,25 @@ class SalesAPI(RoutingClass):
 class Application(RoutingClass):
     def __init__(self):
         self.add_branches([
-            {"name": "users", "cls": UsersAPI},                              # eager
-            {"name": "sales", "cls": SalesAPI, "params": {"region": "us"},
-             "lazy": True},                                                  # lazy
+            {"name": "sales", "cls": SalesAPI, "params": {"region": "us"}},  # factory (lazy)
+            {"name": "users", "instance": UsersAPI()},                       # instance (eager)
         ])
 
 app = Application()
 assert app.route.node("sales/report")() == "sales:us"
+assert app.route.node("users/list")() == ["alice", "bob"]
 ```
+
+`add_branches` is the **single entry point** for declaring a subtree. Each
+spec is exactly **one of three mutually exclusive forms** — the keys `cls`,
+`instance`, and `alias` cannot coexist (`ValueError` otherwise):
+
+- **factory** `{"name", "cls", "params"}` — always **lazy**: the instance is
+  built at the first traversal of the branch (see below);
+- **instance** `{"name", "instance"}` — **eager**: an already-built instance,
+  linked as a child immediately;
+- **alias** `{"name", "alias"}` — a symlink to an absolute path (see
+  [Aliases](#aliases-symlinks-to-branches)).
 
 A **factory spec** has these fields:
 
@@ -59,7 +70,6 @@ A **factory spec** has these fields:
 | `name` | yes | alias under which the child is reachable (path segment) |
 | `cls` | yes | the `RoutingClass` subclass to instantiate |
 | `params` | no (default `{}`) | kwargs applied as `cls(**params)` at materialization |
-| `lazy` | no (default `False`) | when the instance is built (see below) |
 
 Declaring **never constructs anything** — specs are stored, instances come
 later. A generator can therefore yield thousands of specs at zero cost:
@@ -71,7 +81,7 @@ class Application(RoutingClass):
 
     def discover(self):
         for name, cls, params in self.scan_catalog():
-            yield {"name": name, "lazy": True, "cls": cls, "params": params}
+            yield {"name": name, "cls": cls, "params": params}
 ```
 
 Note the **two distinct laziness levels**: spec *enumeration* happens at the
@@ -79,31 +89,37 @@ Note the **two distinct laziness levels**: spec *enumeration* happens at the
 only); instance *construction* happens at materialization. The real saving on
 large trees is the second one.
 
-## Eager vs Lazy
+## Factory (lazy) vs Instance (eager)
 
-- **Eager** (`lazy: False`, the default): materialized at the **first tree
-  access** (`nodes()`, `node()`, …). Equivalent in effect to attaching the
-  instance up front, but deferred to when the tree is first touched.
-- **Lazy** (`lazy: True`): materialized **on demand**, the first time a path
+The timing is **derived from the form** — there is no flag to set:
+
+- **factory** (`{"cls": ...}`): always **lazy**. Nothing is constructed at
+  declaration; the instance is built **on demand**, the first time a path
   traverses that segment. Once built, the branch is a normal child — the
   folder stays open.
+- **instance** (`{"instance": ...}`): **eager**. You built the instance
+  yourself and pass it in; it is linked as a child **immediately**, at the
+  `add_branches` call.
+
+The rule of thumb: *want it lazy → pass the class; want it eager → build it
+yourself and pass the instance.*
 
 ```python
 class Application(RoutingClass):
     def __init__(self):
-        self.add_branches({"name": "sales", "cls": SalesAPI, "lazy": True})
+        self.add_branches({"name": "sales", "cls": SalesAPI})   # factory: lazy
 
 app = Application()
 app.route.nodes()                  # sales NOT built (introspection never builds)
 app.route.node("sales/report")()   # first traversal: SalesAPI() is built HERE
 ```
 
-**Materialization** is the single point where an instance is born: the
+**Materialization** is the single point where a factory instance is born: the
 framework constructs `cls(**params)`, wires the parent chain
 (`_routing_parent`), links the child router, and applies **plugin
-inheritance** — exactly as an explicit `attach_instance` would have done.
-Plugins plugged on the parent *after* the declaration reach the branch too,
-at materialization time.
+inheritance**. Plugins plugged on the parent *after* the declaration reach the
+branch too, at materialization time. An eager instance is wired the same way,
+but immediately at declaration rather than at first traversal.
 
 ## Aliases: Symlinks to Branches
 
@@ -161,26 +177,27 @@ the expansion.
 
 ## Reverse Lookup and Lazy Branches
 
-`node("@endpoint_id")` searches eager and already-materialized branches only:
-it **skips** lazy branches that were never opened (searching them would force
-the whole tree to build, defeating laziness). An endpoint inside a lazy
-branch becomes findable after the branch materializes.
+`node("@endpoint_id")` searches eager instances and already-traversed factory
+branches only: it **skips** lazy factories that were never opened (searching
+them would force the whole tree to build, defeating laziness). An endpoint
+inside a lazy factory becomes findable after the branch is first traversed.
 
 ## Errors Are Deferred and Repeatable
 
-A constructor that raises does so **when the branch is built**, not at
-declaration:
+A factory constructor that raises does so **when the branch is first
+traversed**, not at declaration:
 
-- **lazy** branch: the error surfaces at the first traversal — and at every
-  retry, until the branch is fixed or removed. The spec is never lost.
-- **eager** branch: the error surfaces at the first tree access and repeats
-  on every access — the tree is loudly broken until the branch is fixed or
-  removed with `remove_branch`.
+- the error surfaces at the first traversal — and at every retry, until the
+  branch is fixed or removed with `remove_branch`. The spec is never lost.
+
+An eager instance has no deferred-construction story: you build it yourself,
+so a failing constructor raises at your own `X(...)` call — outside
+`add_branches` entirely.
 
 ## Runtime Management
 
 ```python
-app.add_branches({"name": "extra", "cls": ExtraAPI, "lazy": True})  # add at runtime
+app.add_branches({"name": "extra", "cls": ExtraAPI})  # add a lazy factory at runtime
 app.remove_branch("extra")     # drop a declared branch; if already
                                # materialized, its child is detached
 app.branches                   # dict of DECLARED specs — a branch leaves this
@@ -191,13 +208,31 @@ Note the `branches` property semantics: it lists what is *declared and not
 yet built*. After materialization the branch appears among the router's
 children (e.g. in `nodes()`), not in `branches`.
 
-## Relation to attach_instance
+## Attaching an existing instance
 
-`attach_instance(child, name=...)` (attaching an already-built instance)
-remains fully supported. `add_branches` is the **recommended declarative
-form**: it enables lazy construction, keeps `__init__` free of instantiation
-order concerns, and scales to generated trees. Both wire the same parent
-chain and plugin inheritance.
+To attach an **already-built** instance, use the **instance form** of
+`add_branches`:
+
+```python
+users = UsersAPI()
+app.add_branches({"name": "users", "instance": users})
+```
+
+This is the eager form: the instance is linked as a child immediately, wiring
+the same parent chain and plugin inheritance a factory would get at
+materialization. Constraints:
+
+- `params` is **not** allowed together with `instance` (`ValueError`) — the
+  instance is already built.
+- `instance` must be a `RoutingClass` (`TypeError` otherwise).
+- an instance already bound to another parent raises `ValueError`
+  (*"already bound to another parent"*).
+- an eager instance does **not** appear in `branches` (it is already a child);
+  it shows up among the router's children in `nodes()`.
+
+`add_branches` is the **single entry point** for building a subtree: pass a
+class for lazy construction, or an instance for eager attachment. It keeps
+`__init__` free of instantiation-order concerns and scales to generated trees.
 
 ## Next Steps
 

--- a/docs/guide/hierarchies.md
+++ b/docs/guide/hierarchies.md
@@ -18,12 +18,12 @@ Genro Routes supports hierarchical router composition where:
 
 Genro Routes provides explicit methods for managing RoutingClass hierarchies:
 
-- **`attach_instance(child, name=...)`** - Attach a RoutingClass instance to create parent-child relationship (method on `RoutingClass`)
+- **`add_branches({"name": ..., "instance": child})`** - Attach a RoutingClass instance (instance form of `add_branches`) to create a parent-child relationship (method on `RoutingClass`)
 - **`detach_instance(child)`** - Remove a RoutingClass instance from the hierarchy (method on `Router`)
 - **Parent tracking** - Children track their parent via `_routing_parent` attribute
 - **Auto-detachment** - Replacing a child attribute automatically detaches the old instance
 
-**Important**: `attach_instance` is a method on `RoutingClass` (the owner), not on `Router`. `detach_instance` remains on `Router`.
+**Important**: `add_branches` (instance form) is a method on `RoutingClass` (the owner), not on `Router`. `detach_instance` remains on `Router`.
 
 ## Basic Instance Attachment
 
@@ -42,7 +42,7 @@ class Child(RoutingClass):
 class Parent(RoutingClass):
     def __init__(self):
         # Attach child directly — no need to store as attribute
-        self.attach_instance(Child(), name="sales")
+        self.add_branches({"name": "sales", "instance": Child()})
 
 parent = Parent()
 
@@ -75,8 +75,8 @@ assert child._routing_parent is parent
 
 A RoutingClass owns exactly one router. When a service must expose more than one
 surface (e.g. a public API and an admin area), define **one class per surface**
-and compose them with `attach_instance`. Grouping levels without handlers are
-`Section` instances:
+and compose them with `add_branches` (instance form). Grouping levels without
+handlers are `Section` instances:
 
 ```python
 from genro_routes import RoutingClass, Section, route
@@ -95,10 +95,10 @@ class Application(RoutingClass):
     def __init__(self):
         api = Section("Public API")
         admin = Section("Admin area")
-        self.attach_instance(api, name="api")
-        self.attach_instance(admin, name="admin")
-        api.attach_instance(OrdersApi(), name="orders")
-        admin.attach_instance(OrdersAdmin(), name="orders")
+        self.add_branches({"name": "api", "instance": api})
+        self.add_branches({"name": "admin", "instance": admin})
+        api.add_branches({"name": "orders", "instance": OrdersApi()})
+        admin.add_branches({"name": "orders", "instance": OrdersAdmin()})
 
 app = Application()
 
@@ -127,11 +127,11 @@ class OrganizedService(RoutingClass):
     def __init__(self):
         # Section: pure container, no handlers
         api = Section("API surface")
-        self.attach_instance(api, name="api")
+        self.add_branches({"name": "api", "instance": api})
 
         # Attach handler services as children of the section
-        api.attach_instance(UserService(), name="users")
-        api.attach_instance(ProductService(), name="products")
+        api.add_branches({"name": "users", "instance": UserService()})
+        api.add_branches({"name": "products", "instance": ProductService()})
 
 service = OrganizedService()
 
@@ -151,9 +151,9 @@ service.route.node("api/products/create")()
 ```python
 # Good: Organize related services under an /api namespace
 api = Section("API")
-self.attach_instance(api, name="api")
-api.attach_instance(self.auth, name="auth")
-api.attach_instance(self.users, name="users")
+self.add_branches({"name": "api", "instance": api})
+api.add_branches({"name": "auth", "instance": self.auth})
+api.add_branches({"name": "users", "instance": self.users})
 # Routes: api/auth/login, api/users/list
 ```
 
@@ -165,14 +165,14 @@ organizational containers:
 ```python
 # DON'T: Section with a single child (unnecessary nesting)
 api = Section()
-self.attach_instance(api, name="api")
-api.attach_instance(UserService(), name="users")
+self.add_branches({"name": "api", "instance": api})
+api.add_branches({"name": "users", "instance": UserService()})
 # Result: api/users/list - the "api" level adds nothing
 
 # DO: attach children directly; root-level handlers live on the class itself
 class Application(RoutingClass):
     def __init__(self):
-        self.attach_instance(UserService(), name="users")
+        self.add_branches({"name": "users", "instance": UserService()})
 
     @route()
     def health(self):  # health - root level handler
@@ -207,8 +207,8 @@ class OrdersService(RoutingClass):
 
 class Service(RoutingClass):
     def __init__(self):
-        self.attach_instance(UsersService(), name="users")
-        self.attach_instance(OrdersService(), name="orders")
+        self.add_branches({"name": "users", "instance": UsersService()})
+        self.add_branches({"name": "orders", "instance": OrdersService()})
 
     @route()
     def health(self):
@@ -239,7 +239,7 @@ Replacing a child attribute automatically detaches the old instance:
 class Parent(RoutingClass):
     def __init__(self):
         self.child = Child()
-        self.attach_instance(self.child, name="child")
+        self.add_branches({"name": "child", "instance": self.child})
 
 parent = Parent()
 assert parent.child._routing_parent is parent
@@ -265,11 +265,11 @@ assert "child" not in parent.route._children
 ```python
 # Replacing a service implementation
 parent.auth_service = OldAuthService()
-parent.attach_instance(parent.auth_service, name="auth")
+parent.add_branches({"name": "auth", "instance": parent.auth_service})
 
 # Later: automatic cleanup
 parent.auth_service = NewAuthService()  # Old service auto-detached
-parent.attach_instance(parent.auth_service, name="auth")
+parent.add_branches({"name": "auth", "instance": parent.auth_service})
 ```
 
 ## Parent Tracking
@@ -292,7 +292,7 @@ assert getattr(child, "_routing_parent", None) is None  # Not attached
 
 parent = Parent()
 parent.child = child
-parent.attach_instance(parent.child, name="child")
+parent.add_branches({"name": "child", "instance": parent.child})
 assert child._routing_parent is parent  # Parent tracked
 
 parent.route.detach_instance(child)
@@ -330,7 +330,7 @@ class Application(RoutingClass):
 app = Application()
 
 # Attach child - plugins inherit automatically
-app.attach_instance(app.service, name="service")
+app.add_branches({"name": "service", "instance": app.service})
 
 # Child router has the logging plugin
 assert hasattr(app.service.route, "logging")
@@ -361,7 +361,7 @@ class Child(RoutingClass):
 class Parent(RoutingClass):
     def __init__(self):
         self.child = Child()
-        self.attach_instance(self.child, name="child")
+        self.add_branches({"name": "child", "instance": self.child})
 
 parent = Parent()
 
@@ -389,7 +389,7 @@ Inspect the full hierarchy structure:
 class Inspectable(RoutingClass):
     def __init__(self):
         self.service = Service("child")
-        self.attach_instance(self.service, name="sub")
+        self.add_branches({"name": "sub", "instance": self.service})
 
     @route()
     def action(self):
@@ -449,7 +449,7 @@ class FileService(RoutingClass):
 class Application(RoutingClass):
     def __init__(self):
         self.files = FileService()
-        self.attach_instance(self.files, name="files")
+        self.add_branches({"name": "files", "instance": self.files})
 
 app = Application()
 
@@ -547,8 +547,8 @@ class Application(RoutingClass):
         self.route.plug("logging")
 
         # Create and attach services
-        self.attach_instance(AuthService(), name="auth")
-        self.attach_instance(UserService(), name="users")
+        self.add_branches({"name": "auth", "instance": AuthService()})
+        self.add_branches({"name": "users", "instance": UserService()})
 
 app = Application()
 
@@ -573,16 +573,16 @@ class ReportsAPI(RoutingClass):
 
 class AdminAPI(RoutingClass):
     def __init__(self):
-        self.attach_instance(UserService(), name="users")
-        self.attach_instance(ReportsAPI(), name="reports")
+        self.add_branches({"name": "users", "instance": UserService()})
+        self.add_branches({"name": "reports", "instance": ReportsAPI()})
 
 class Application(RoutingClass):
     def __init__(self):
         # Public API (simplified interface)
-        self.attach_instance(UserService(), name="public")
+        self.add_branches({"name": "public", "instance": UserService()})
 
         # Admin API (protected, more capabilities)
-        self.attach_instance(AdminAPI(), name="admin")
+        self.add_branches({"name": "admin", "instance": AdminAPI()})
 
 app = Application()
 
@@ -608,12 +608,12 @@ class ServiceV2(RoutingClass):
 class Application(RoutingClass):
     def __init__(self):
         self.service = ServiceV1()
-        self.attach_instance(self.service, name="processor")
+        self.add_branches({"name": "processor", "instance": self.service})
 
     def upgrade_service(self):
         # Auto-detachment happens here
         self.service = ServiceV2()
-        self.attach_instance(self.service, name="processor")
+        self.add_branches({"name": "processor", "instance": self.service})
 
 app = Application()
 assert app.route.node("processor/process")("test") == "v1:test"
@@ -630,9 +630,9 @@ assert app.route.node("processor/process")("test") == "v2:test"
 # Compose related services under the root class
 class API(RoutingClass):
     def __init__(self):
-        self.attach_instance(AuthService(), name="auth")
-        self.attach_instance(UserService(), name="users")
-        self.attach_instance(OrderService(), name="orders")
+        self.add_branches({"name": "auth", "instance": AuthService()})
+        self.add_branches({"name": "users", "instance": UserService()})
+        self.add_branches({"name": "orders", "instance": OrderService()})
 ```
 
 ### Shared Plugins at Root
@@ -642,17 +642,17 @@ class API(RoutingClass):
 self.route.plug("logging").plug("pydantic")
 
 # All children inherit both plugins
-self.attach_instance(self.auth, name="auth")
-self.attach_instance(self.users, name="users")
+self.add_branches({"name": "auth", "instance": self.auth})
+self.add_branches({"name": "users", "instance": self.users})
 ```
 
 ### Deep Hierarchies
 
 ```python
 # Organize by domain and subdomain
-app.attach_instance(admin, name="admin")
-admin.attach_instance(user_admin, name="users")
-admin.attach_instance(report_admin, name="reports")
+app.add_branches({"name": "admin", "instance": admin})
+admin.add_branches({"name": "users", "instance": user_admin})
+admin.add_branches({"name": "reports", "instance": report_admin})
 
 # Access: app.route.node("admin/users/create_user")()
 #         app.route.node("admin/reports/sales_report")()
@@ -678,8 +678,8 @@ if should_remove_service:
 
 ```python
 # Use descriptive aliases
-self.attach_instance(self.auth, name="auth_v1")
-self.attach_instance(self.new_auth, name="auth_v2")
+self.add_branches({"name": "auth_v1", "instance": self.auth})
+self.add_branches({"name": "auth_v2", "instance": self.new_auth})
 
 # Access both versions
 self.route.node("auth_v1/login")()
@@ -707,10 +707,10 @@ class Application(RoutingClass):
     def __init__(self, config):
         # Attach based on configuration
         if config.get("enable_auth"):
-            self.attach_instance(AuthService(), name="auth")
+            self.add_branches({"name": "auth", "instance": AuthService()})
 
         if config.get("enable_admin"):
-            self.attach_instance(AdminService(), name="admin")
+            self.add_branches({"name": "admin", "instance": AdminService()})
 ```
 
 ### Multi-Surface Services
@@ -729,8 +729,8 @@ class AdminOrders(RoutingClass):
 # Compose: one class per surface, attached where needed
 api = app.route.nodes(basepath="api")["instance"]
 admin = app.route.nodes(basepath="admin")["instance"]
-api.attach_instance(PublicOrders(), name="orders")
-admin.attach_instance(AdminOrders(), name="orders")
+api.add_branches({"name": "orders", "instance": PublicOrders()})
+admin.add_branches({"name": "orders", "instance": AdminOrders()})
 ```
 
 ## Next Steps

--- a/docs/guide/plugin-configuration.md
+++ b/docs/guide/plugin-configuration.md
@@ -225,7 +225,7 @@ class Root(RoutingClass):
     def __init__(self):
         self.route.plug("logging")
         self.leaf = Leaf()
-        self.attach_instance(self.leaf, name="leaf")
+        self.add_branches({"name": "leaf", "instance": self.leaf})
 
     @route()
     def root_ping(self):

--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -353,7 +353,7 @@ The router automatically collects capabilities from the instance and its entire 
 parent.capabilities = ParentCapabilities()   # has "redis"
 child.capabilities = ChildCapabilities()     # has "email"
 
-parent.attach_instance(child, name="child")
+parent.add_branches({"name": "child", "instance": child})
 
 # child.route.current_capabilities returns {"redis", "email"}
 # (accumulated from parent + child)
@@ -984,7 +984,7 @@ def on_parent_config_changed(self, old_config, new_config):
 
 ## Plugin Inheritance
 
-When a child router is attached to a parent via `attach_instance()`, plugins are inherited
+When a child router is attached to a parent via `add_branches()` (instance form), plugins are inherited
 based on what the child already has.
 
 ### Inheritance Rules
@@ -1026,7 +1026,7 @@ class Parent(RoutingClass):
     def __init__(self):
         self.route.plug("auth", rule="corporate")
         self.child = Child()
-        self.attach_instance(self.child, name="child")
+        self.add_branches({"name": "child", "instance": self.child})
 
 parent = Parent()
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ The routing logic lives in your application objects - the transport adapter (lik
 ## Key Features
 
 - **One class, one router** - Every `RoutingClass` owns exactly one isolated router with its own plugin stack, exposed as the `route` property
-- **Hierarchical organization** - Build router trees with `attach_instance()` and `/` path traversal
+- **Hierarchical organization** - Build router trees with `add_branches()` and `/` path traversal
 - **Composable plugins** - Hook into decoration and handler execution with `BasePlugin`
 - **Plugin inheritance** - Plugins propagate automatically from parent to child routers
 - **Flexible registration** - Use `@route` decorator with prefixes, metadata, and explicit names

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -84,7 +84,7 @@ t = Table()
 assert t.route.node("add")("x") == "added:x"
 ```
 
-Need more than one routing surface (e.g. `api` and `admin`)? Compose separate `RoutingClass` instances with `attach_instance()` - see [Building Hierarchies](#building-hierarchies) below.
+Need more than one routing surface (e.g. `api` and `admin`)? Compose separate `RoutingClass` instances with `add_branches()` (instance form) - see [Building Hierarchies](#building-hierarchies) below.
 
 ## Building Hierarchies
 
@@ -96,8 +96,8 @@ class RootAPI(RoutingClass):
         self.users = SubService("users")
         self.products = SubService("products")
 
-        self.attach_instance(self.users, name="users")
-        self.attach_instance(self.products, name="products")
+        self.add_branches({"name": "users", "instance": self.users})
+        self.add_branches({"name": "products", "instance": self.products})
 
 root = RootAPI()
 

--- a/examples/faker_magic.py
+++ b/examples/faker_magic.py
@@ -41,9 +41,9 @@ class FullFakerService(RoutingClass):
         self.address = MagicFakerRouter(self.fake)
         self.company = MagicFakerRouter(self.fake)
 
-        self.attach_instance(self.person, name="person")
-        self.attach_instance(self.address, name="address")
-        self.attach_instance(self.company, name="company")
+        self.add_branches({"name": "person", "instance": self.person})
+        self.add_branches({"name": "address", "instance": self.address})
+        self.add_branches({"name": "company", "instance": self.company})
 
 if __name__ == "__main__":
     service = FullFakerService()

--- a/examples/faker_standard.py
+++ b/examples/faker_standard.py
@@ -47,8 +47,8 @@ class FakerService(RoutingClass):
         self.address = AddressService(self.fake)
 
         # Different instances are mounted under the main router
-        self.attach_instance(self.person, name="person")
-        self.attach_instance(self.address, name="address")
+        self.add_branches({"name": "person", "instance": self.person})
+        self.add_branches({"name": "address", "instance": self.address})
 
 # -----------------------------------------------------------------------------
 # 3. Usage Example (Developer Experience)

--- a/examples/mcp_bridge/agent_sim.py
+++ b/examples/mcp_bridge/agent_sim.py
@@ -28,7 +28,7 @@ class MathService(RoutingClass):
 class RootApp(RoutingClass):
     def __init__(self):
         self.math = MathService()
-        self.attach_instance(self.math, name="math")
+        self.add_branches({"name": "math", "instance": self.math})
 
 # 2. The Agent Simulation
 def run_agent_demo():

--- a/examples/mcp_bridge/demo.py
+++ b/examples/mcp_bridge/demo.py
@@ -26,7 +26,7 @@ class MathService(RoutingClass):
 class RootApp(RoutingClass):
     def __init__(self):
         self.math = MathService()
-        self.attach_instance(self.math, name="math")
+        self.add_branches({"name": "math", "instance": self.math})
 
 # 2. Run the Demo
 if __name__ == "__main__":

--- a/examples/self_documentation.py
+++ b/examples/self_documentation.py
@@ -35,7 +35,7 @@ class GenroInternalService(RoutingClass):
         # This allows us to "remote control" or "query" the router through itself.
         self.router_ctrl = MagicRouter(self.route)
 
-        self.attach_instance(self.router_ctrl, name="router_inspector")
+        self.add_branches({"name": "router_inspector", "instance": self.router_ctrl})
 
 # -----------------------------------------------------------------------------
 # 3. Running the Meta-Demo

--- a/examples/service_composition.py
+++ b/examples/service_composition.py
@@ -21,8 +21,8 @@ class EnterpriseApp(RoutingClass):
         self.inventory = InventoryModule()
 
         # COMPOSITION: attach their routers to our main API
-        self.attach_instance(self.billing, name="billing")
-        self.attach_instance(self.inventory, name="inventory")
+        self.add_branches({"name": "billing", "instance": self.billing})
+        self.add_branches({"name": "inventory", "instance": self.inventory})
 
 if __name__ == "__main__":
     app = EnterpriseApp()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genro-routes"
-version = "0.28.0"
+version = "0.29.0"
 description = "Instance-scoped routing engine for Python with hierarchical handlers and composable plugins"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/genro_routes/core/base_router.py
+++ b/src/genro_routes/core/base_router.py
@@ -58,8 +58,8 @@ Accepts a Router (child hierarchy) or RouterNode (entry alias).
 
 ``detach_instance(child)`` removes all routers belonging to a child instance.
 
-Instance attachment is handled by ``RoutingClass.attach_instance()``, which
-sets ``_routing_parent`` and delegates the routing link to ``include()``.
+Instance attachment is handled by ``add_branches({"name", "instance"})``, which
+links the instance's router via ``include()`` and sets ``_routing_parent``.
 On the first (primary) attachment ``include()`` triggers plugin inheritance
 via ``_on_attached_to_parent``; subsequent includes of the same router are
 navigational shortcuts only.
@@ -120,7 +120,6 @@ class BaseRouter(RouterInterface):
         "__entries_raw",
         "_children",
         "_branches",
-        "_eager_done",
         "_get_defaults",
         "_bound",
     )
@@ -151,7 +150,6 @@ class BaseRouter(RouterInterface):
         self.__entries_raw: dict[str, MethodEntry] = {}
         self._children: dict[str, BaseRouter] = {}
         self._branches: dict[str, dict[str, Any]] = {}
-        self._eager_done: bool = False
         defaults: dict[str, Any] = dict(get_kwargs or {})
         if get_default_handler is not None:
             defaults.setdefault("default_handler", get_default_handler)
@@ -592,38 +590,63 @@ class BaseRouter(RouterInterface):
     # Branches: declarative factory-based subrouters (lazy/eager)
     # ------------------------------------------------------------------
     def add_branches(self, specs: Any) -> None:
-        """Declare one or more child branches as factory specs.
+        """Declare one or more child branches. The single entry point.
 
         Accepts a single spec dict, a list of dicts, or any iterable/generator
-        of dicts. Each spec is ``{"name", "lazy", "cls", "params"}``. Nothing is
-        constructed here — specs are stored in ``_branches`` and materialized
-        later (eager at first tree access, lazy on first traversal).
+        of dicts. Each spec is one of three mutually exclusive forms:
+
+        - factory ``{"name", "cls", "params"}`` — **lazy**: the instance is
+          constructed on first traversal of the branch;
+        - instance ``{"name", "instance"}`` — **eager**: an already-built
+          instance, linked as a child immediately;
+        - alias ``{"name", "alias"}`` — a symlink to an absolute path.
+
+        The timing is derived from the form (``cls`` → lazy, ``instance`` →
+        eager); there is no ``lazy`` flag.
         """
         items = [specs] if isinstance(specs, dict) else list(specs)
         for spec in items:
             self._add_branch_spec(spec)
 
     def _add_branch_spec(self, spec: dict[str, Any]) -> None:
-        """Validate and store a single branch spec (factory or alias)."""
+        """Validate and store/materialize a single branch spec.
+
+        ``cls``, ``instance`` and ``alias`` are mutually exclusive.
+        """
         name = spec["name"]
         if name in self._branches or name in self._children:
             raise ValueError(f"Branch name collision: {name}")
-        if "alias" in spec:
-            if "cls" in spec:
-                raise ValueError(f"Branch '{name}': 'alias' and 'cls' are mutually exclusive")
+        forms = [k for k in ("cls", "instance", "alias") if k in spec]
+        if len(forms) != 1:
+            raise ValueError(
+                f"Branch '{name}': exactly one of 'cls', 'instance', 'alias' is required"
+            )
+        form = forms[0]
+        if form == "alias":
             # Alias branch: a symlink to an absolute path from the tree root.
             # No instance is ever built for it; navigation rewrites the path.
             self._branches[name] = {"name": name, "alias": spec["alias"]}
             return
+        if form == "instance":
+            if "params" in spec:
+                raise ValueError(f"Branch '{name}': 'params' is not allowed with 'instance'")
+            child = spec["instance"]
+            if not safe_is_instance(child, "genro_routes.core.routing.RoutingClass"):
+                raise TypeError(f"Branch '{name}': 'instance' must be a RoutingClass instance")
+            bound = getattr(child, "_routing_parent", None)
+            if bound is not None and bound is not self.instance:
+                raise ValueError(
+                    f"Branch '{name}': instance already bound to another parent"
+                )
+            # Eager: an already-built instance is linked as a child now.
+            self._include_router(child.route, name)
+            return
+        # Factory: always lazy — built on first traversal.
         self._branches[name] = {
             "name": name,
-            "lazy": bool(spec.get("lazy", False)),
             "cls": spec["cls"],
             "params": dict(spec.get("params") or {}),
         }
-        if not self._branches[name]["lazy"] and self._eager_done:
-            # Added eager after eager pass already ran: materialize now.
-            self._materialize_branch(name)
 
     def remove_branch(self, name: str) -> None:
         """Remove a declared branch. If already materialized, detach its child."""
@@ -655,20 +678,6 @@ class BaseRouter(RouterInterface):
         # silently disappearing.
         self._branches.pop(name, None)
         return self._children[name]
-
-    def _materialize_eager(self) -> None:
-        """Materialize all eager branches once (idempotent guard).
-
-        The guard is set only after the whole pass succeeds: a failing eager
-        constructor keeps the tree loudly broken (every access retries and
-        re-raises) until the branch is fixed or removed.
-        """
-        if self._eager_done:
-            return
-        eager = [n for n, s in self._branches.items() if not s.get("lazy") and "alias" not in s]
-        for name in eager:
-            self._materialize_branch(name)
-        self._eager_done = True
 
     def _root_router(self) -> BaseRouter:
         """Return the tree's root router by walking up the _routing_parent chain."""
@@ -860,8 +869,6 @@ class BaseRouter(RouterInterface):
 
         while parts and router:
             last_router = router
-            if not router._eager_done:
-                router._materialize_eager()
             head = parts.pop(0)
             # Alias branch: rewrite the path to the target (absolute, from root)
             # and resolve from there. Guard against alias cycles.
@@ -929,9 +936,10 @@ class BaseRouter(RouterInterface):
         for entry_name, entry in self._entries.items():
             if entry.endpoint_id == endpoint_id:
                 return self, entry_name, [*path_parts, entry_name]
-        # Eager branches are part of the tree: open them so the search reaches
-        # them. Lazy branches stay in _branches and are intentionally skipped.
-        self._materialize_eager()
+        # Only already-materialized children are searched (eager instances and
+        # factories already traversed). Lazy factory branches stay in _branches
+        # and are intentionally skipped — searching them would force the whole
+        # tree to build.
         for child_alias, child_router in self._children.items():
             result = child_router._search_endpoint_id(
                 endpoint_id, [*path_parts, child_alias]
@@ -1034,9 +1042,8 @@ class BaseRouter(RouterInterface):
                     lazy=lazy, pattern=pattern, forbidden=forbidden, _eager=_eager, **kwargs
                 )
             return {}
-        # Eager branches materialize on first tree access; lazy branches stay
-        # declared and are described (not built) further down.
-        self._materialize_eager()
+        # nodes() never builds: factory branches stay declared and are
+        # described (not built) further down, unless _eager is requested.
         if _eager:
             # Full expansion requested: materialize every declared factory
             # branch (lazy included). Aliases stay as specs, resolved below.

--- a/src/genro_routes/core/routing.py
+++ b/src/genro_routes/core/routing.py
@@ -21,30 +21,29 @@ A mixin class providing:
 
 Branches (declarative, factory-based subrouters)
 ------------------------------------------------
-A branch is a child subrouter declared as a **factory spec** and materialized
-(constructed) only when needed. This lets trees with thousands of leaves start
-cheaply — nothing is instantiated until walked.
+A branch is a child subrouter declared through ``add_branches``, the single
+entry point. Declaring builds nothing at declaration time; this lets trees with
+thousands of leaves start cheaply. A spec is one of three mutually exclusive
+forms::
 
-A branch spec is a self-describing dict::
+    {"name": "beta",  "cls": Beta, "params": {"x": 56}}   # factory  (lazy)
+    {"name": "gamma", "instance": gamma_obj}              # instance (eager)
+    {"name": "fake",  "alias": "alfa/beta"}               # alias    (symlink)
 
-    {"name": "beta", "lazy": True, "cls": Beta, "params": {"x": 56}}
+    name     -- alias under which the child is reachable (path segment)
+    cls      -- the RoutingClass subclass to instantiate; ALWAYS lazy — built
+                on first traversal of the branch
+    params   -- kwargs applied as cls(**params) at materialization (factory only)
+    instance -- an already-built RoutingClass instance; EAGER — linked as a
+                child immediately (it lands in _children, not _branches)
+    alias    -- absolute path from the tree root (symlink, see below)
 
-    name   -- alias under which the child is reachable (path segment)
-    lazy   -- True: materialize on first traversal; False (eager): materialize
-              at first tree access
-    cls    -- the RoutingClass subclass to instantiate
-    params -- kwargs applied as cls(**params) at materialization
-
-``add_branches`` populates the router's ``_branches`` dict; no instance is
-constructed at declaration time. Materialization is the single point where an
-instance is built: construct ``cls(**params)``, set ``_routing_parent``, link
-into ``_children`` (which triggers plugin inheritance), then drop the spec from
-``_branches``. Two timing policies share this one mechanism:
-
-    - eager  -- all eager branches materialize at first tree access
-                (idempotent guard on the router: runs once)
-    - lazy   -- a lazy branch materializes on-demand when a path first
-                traverses its segment
+The timing is derived from the form (``cls`` → lazy, ``instance`` → eager);
+there is no ``lazy`` flag. A factory populates the router's ``_branches`` dict;
+materialization is the single point where its instance is built: construct
+``cls(**params)``, set ``_routing_parent``, link into ``_children`` (which
+triggers plugin inheritance), then drop the spec from ``_branches``. An instance
+skips that path — it is linked into ``_children`` at declaration.
 
 Two distinct laziness levels must not be conflated:
 
@@ -54,8 +53,8 @@ Two distinct laziness levels must not be conflated:
 
 Introspection (``nodes()``) describes a non-materialized lazy branch WITHOUT
 building it, including the class-declared ``@route`` leaves read from the class
-(no instance). Reverse lookup (``node("@endpoint_id")``) searches only eager and
-already-materialized branches; it skips non-materialized lazy branches.
+(no instance). Reverse lookup (``node("@endpoint_id")``) searches only instances
+and already-traversed factories; it skips non-materialized lazy factories.
 
 Alias branches (symlink to a branch)
 ------------------------------------
@@ -95,7 +94,7 @@ Minimal concrete RoutingClass used as a grouping node. A Section carries an
 empty router; children are attached under it to build intermediate levels of
 a routing tree (including dynamically discovered trees)::
 
-    svc.attach_instance(Section("Admin area"), name="admin")
+    svc.add_branches({"name": "admin", "instance": Section("Admin area")})
 
 _RoutingProxy
 -------------
@@ -213,11 +212,13 @@ class RoutingClass:
         return router
 
     def add_branches(self, specs: Any) -> None:
-        """Declare child branches (factory specs) on this instance's router.
+        """Declare child branches on this instance's router. Single entry point.
 
         Accepts one spec dict, a list of dicts, or a generator. Each spec is
-        ``{"name", "lazy", "cls", "params"}``. Delegates to the router; nothing
-        is constructed until materialization (see the Branches section above).
+        one of three mutually exclusive forms: factory ``{"name", "cls",
+        "params"}`` (lazy — built on first traversal), instance ``{"name",
+        "instance"}`` (eager — linked now), or alias ``{"name", "alias"}``.
+        Delegates to the router.
         """
         self.route.add_branches(specs)
 
@@ -242,40 +243,6 @@ class RoutingClass:
         if existing is not None and existing is not router:
             raise ValueError(f"{type(self).__name__} already has a router")
         object.__setattr__(self, _ROUTER_ATTR_NAME, router)
-
-    def attach_instance(self, child: RoutingClass, *, name: str | None = None) -> None:
-        """Attach a child RoutingClass instance.
-
-        Sets ``child._routing_parent = self``. When ``name`` is given,
-        ``child.route`` is linked into ``self.route`` under that alias
-        (plugin inheritance is triggered by the link).
-
-        Args:
-            child: The RoutingClass instance to attach.
-            name: Alias under which the child's router is reachable from
-                this instance's router. If omitted, only the parent
-                relationship is set (no routing link).
-
-        Raises:
-            TypeError: If child is not a RoutingClass instance.
-            ValueError: If child is already bound to another parent.
-            ValueError: If the alias collides with an existing child.
-
-        Example::
-
-            self.attach_instance(child, name="sales")
-        """
-        if not safe_is_instance(child, "genro_routes.core.routing.RoutingClass"):
-            raise TypeError("attach_instance() requires a RoutingClass instance")
-        existing_parent = getattr(child, "_routing_parent", None)
-        if existing_parent is not None and existing_parent is not self:
-            raise ValueError("attach_instance() rejected: child already bound to another parent")
-
-        if name is not None:
-            self.route.include(child.route, name=name)
-
-        if getattr(child, "_routing_parent", None) is not self:
-            object.__setattr__(child, "_routing_parent", self)
 
     @property
     def routing(self) -> _RoutingProxy:
@@ -388,7 +355,7 @@ class Section(RoutingClass):
     defining a dedicated class — e.g. namespacing or dynamically discovered
     hierarchies::
 
-        svc.attach_instance(Section("Admin area"), name="admin")
+        svc.add_branches({"name": "admin", "instance": Section("Admin area")})
     """
 
     def __init__(self, description: str | None = None) -> None:
@@ -405,7 +372,6 @@ class _RoutingProxy:
 
     Main operations:
         - ``configure(target, **options)``: Configure plugin settings
-        - ``attach_instance(child, name=...)``: Delegates to owner's attach_instance
 
     Target syntax for configure():
         - ``"plugin"`` - Global plugin config
@@ -469,18 +435,6 @@ class _RoutingProxy:
                 for child_name, child in router._children.items()
             },
         }
-
-    def attach_instance(self, child: RoutingClass, *, name: str | None = None) -> None:
-        """Attach a child instance. Delegates to owner's attach_instance.
-
-        Args:
-            child: The RoutingClass instance to attach.
-            name: Alias under which the child's router is linked.
-
-        Example:
-            >>> svc.routing.attach_instance(child, name="sales")
-        """
-        self._owner.attach_instance(child, name=name)
 
     def configure(self, target: Any, **options: Any):
         """Configure router plugins.

--- a/tests/test_auth_plugin.py
+++ b/tests/test_auth_plugin.py
@@ -168,7 +168,7 @@ class TestAuthPluginIntegration:
 
         child = Child()
         # Attach child - plugin is inherited from parent
-        parent.attach_instance(child, name="child")
+        parent.add_branches({"name": "child", "instance": child})
 
         # Filter should apply to both parent and child
         result = parent.route.nodes(auth_tags="admin")
@@ -196,7 +196,7 @@ class TestAuthPluginIntegration:
         parent.route.add_entry(lambda: "admin", name="admin_action", auth_rule="admin")
 
         child = Child()
-        parent.attach_instance(child, name="child")
+        parent.add_branches({"name": "child", "instance": child})
 
         # Filter for admin - child has no admin entries
         result = parent.route.nodes(auth_tags="admin")

--- a/tests/test_branch_alias.py
+++ b/tests/test_branch_alias.py
@@ -113,7 +113,7 @@ def test_alias_to_lazy_target_materializes_on_navigation():
         def __init__(self):
             self.add_branches(
                 [
-                    {"name": "real", "lazy": True, "cls": Leaf, "params": {"tag": "lz"}},
+                    {"name": "real", "cls": Leaf, "params": {"tag": "lz"}},
                     {"name": "fake", "alias": "real"},
                 ]
             )
@@ -183,7 +183,7 @@ def test_nodes_alias_to_lazy_target_does_not_build(  # regression: B1 crash
         def __init__(self):
             self.add_branches(
                 [
-                    {"name": "real", "lazy": True, "cls": Leaf, "params": {"tag": "lz"}},
+                    {"name": "real", "cls": Leaf, "params": {"tag": "lz"}},
                     {"name": "fake", "alias": "real"},
                 ]
             )
@@ -202,7 +202,7 @@ def test_nodes_eager_expands_lazy_and_alias():
         def __init__(self):
             self.add_branches(
                 [
-                    {"name": "real", "lazy": True, "cls": Leaf, "params": {"tag": "lz"}},
+                    {"name": "real", "cls": Leaf, "params": {"tag": "lz"}},
                     {"name": "fake", "alias": "real"},
                 ]
             )
@@ -221,7 +221,7 @@ def test_nodes_eager_expands_lazy_and_alias():
 def test_nodes_eager_expands_nested_lazy():
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "sub", "lazy": True, "cls": Sub})
+            self.add_branches({"name": "sub", "cls": Sub})
 
     alfa = Alfa()
     tree = alfa.route.nodes(_eager=True)
@@ -398,7 +398,7 @@ def test_alias_resolves_from_root():
 
 
 # ---------------------------------------------------------------------------
-# 13. @endpoint_id unchanged: found in eager aliased target
+# 13. @endpoint_id unchanged: found in an instance (eager) aliased target
 # ---------------------------------------------------------------------------
 
 
@@ -408,11 +408,15 @@ def test_endpoint_id_still_works_with_alias_present():
         def act(self):
             return "found"
 
+    # The target is an instance branch (eager child), so its endpoint_id is
+    # reachable without traversal even though an alias to it is present.
+    real = WithId()
+
     class Alfa(RoutingClass):
         def __init__(self):
             self.add_branches(
                 [
-                    {"name": "real", "cls": WithId},
+                    {"name": "real", "instance": real},
                     {"name": "fake", "alias": "real"},
                 ]
             )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,7 +92,7 @@ class ParentService(RoutingClass):
 
     def __init__(self):
         self.child = ChildService()
-        self.attach_instance(self.child, name="items")
+        self.add_branches({"name": "items", "instance": self.child})
 
     @route()
     def index(self):

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -112,7 +112,7 @@ def test_inherited_plugin_config_lookup():
     parent.route.logging.configure(before=False, after=True)
 
     # Attach child to parent
-    parent.attach_instance(parent.child, name="child")
+    parent.add_branches({"name": "child", "instance": parent.child})
 
     # Child should inherit the plugin and config
     assert "logging" in parent.child.route._plugins_by_name
@@ -380,7 +380,7 @@ def test_inherited_plugin_is_separate_instance():
             return "parent"
 
     parent = ParentSvc()
-    parent.attach_instance(parent.child, name="child")
+    parent.add_branches({"name": "child", "instance": parent.child})
 
     # Plugin instances should be DIFFERENT objects
     parent_plugin = parent.route._plugins_by_name["logging"]
@@ -414,7 +414,7 @@ def test_inherited_plugin_copies_parent_config():
     parent.route.logging.configure(before=False, after=True)
 
     # Attach child - should copy config
-    parent.attach_instance(parent.child, name="child")
+    parent.add_branches({"name": "child", "instance": parent.child})
 
     # Child should have same config values
     child_cfg = parent.child.route.logging.configuration()
@@ -441,7 +441,7 @@ def test_child_config_independent_from_parent():
 
     parent = ParentSvc()
     parent.route.logging.configure(before=True, after=False)
-    parent.attach_instance(parent.child, name="child")
+    parent.add_branches({"name": "child", "instance": parent.child})
 
     # Child modifies its own config
     parent.child.route.logging.configure(before=False, after=True)
@@ -490,7 +490,7 @@ def test_parent_config_change_notifies_children():
             return "parent"
 
     parent = ParentSvc()
-    parent.attach_instance(parent.child, name="child")
+    parent.add_branches({"name": "child", "instance": parent.child})
 
     # Clear any notifications from __init__
     notifications.clear()
@@ -545,8 +545,8 @@ def test_cascading_notifications():
             return "parent"
 
     parent = ParentSvc()
-    parent.attach_instance(parent.child, name="child")
-    parent.child.attach_instance(parent.child.grandchild, name="grandchild")
+    parent.add_branches({"name": "child", "instance": parent.child})
+    parent.child.add_branches({"name": "grandchild", "instance": parent.child.grandchild})
 
     # Clear notifications
     notifications.clear()
@@ -601,8 +601,8 @@ def test_child_ignores_parent_config_no_cascade():
             return "parent"
 
     parent = ParentSvc()
-    parent.attach_instance(parent.child, name="child")
-    parent.child.attach_instance(parent.child.grandchild, name="grandchild")
+    parent.add_branches({"name": "child", "instance": parent.child})
+    parent.child.add_branches({"name": "grandchild", "instance": parent.child.grandchild})
 
     # Clear notifications
     notifications.clear()
@@ -675,7 +675,7 @@ def test_auth_deny_reason_with_router_interface():
             return "parent"
 
     parent = ParentSvc()
-    parent.attach_instance(parent.child, name="child")
+    parent.add_branches({"name": "child", "instance": parent.child})
 
     # Get child router via parent
     child_router = parent.route._children["child"]
@@ -708,7 +708,7 @@ def test_auth_deny_reason_router_empty():
             return "parent"
 
     parent = ParentSvc()
-    parent.attach_instance(parent.child, name="child")
+    parent.add_branches({"name": "child", "instance": parent.child})
 
     child_router = parent.route._children["child"]
     auth_plugin = parent.route._plugins_by_name["auth"]
@@ -973,7 +973,7 @@ def test_auth_deny_reason_router_with_accessible_child():
         def __init__(self):
             self.route.plug("auth")
             self.child = Child()
-            self.attach_instance(self.child, name="child")
+            self.add_branches({"name": "child", "instance": self.child})
 
     parent = Parent()
     auth_plugin = parent.route._plugins_by_name["auth"]
@@ -1047,7 +1047,7 @@ def test_routing_class_ctx_parent_chain():
 
     parent = Parent()
     child = Child()
-    parent.attach_instance(child, name="child")
+    parent.add_branches({"name": "child", "instance": child})
 
     ctx = RoutingContext()
     ctx.db = "shared_db"
@@ -1070,7 +1070,7 @@ def test_plugin_on_parent_config_changed_propagates():
         def __init__(self):
             self.route.plug("logging")
             self.child = Child()
-            self.attach_instance(self.child, name="child")
+            self.add_branches({"name": "child", "instance": self.child})
 
         @route()
         def parent_handler(self):
@@ -1160,11 +1160,11 @@ def test_require_bound_when_already_bound():
     assert svc.route._bound is True
 
 
-# --- RoutingClass.attach_instance with explicit alias ---
+# --- instance branch reachable under the given alias ---
 
 
-def test_attach_instance_with_alias():
-    """Test attach_instance links the child router under the given alias."""
+def test_instance_branch_reachable_under_alias():
+    """The instance form links the child router under the given alias."""
 
     class Child(RoutingClass):
         @route()
@@ -1176,18 +1176,18 @@ def test_attach_instance_with_alias():
             self.child = Child()
 
     parent = Parent()
-    parent.attach_instance(parent.child, name="child_api")
+    parent.add_branches({"name": "child_api", "instance": parent.child})
 
-    # Should be attached under the given alias
-    assert "child_api" in parent.route._children
-    assert parent.route._children["child_api"] is parent.child.route
-
-
-# --- attach_instance when _routing_parent already set correctly ---
+    # Reachable under the given alias
+    assert parent.route.node("child_api/api_handler")() == "api"
+    assert "child_api" in parent.route.nodes().get("routers", {})
 
 
-def test_attach_instance_routing_parent_already_correct():
-    """Test attach_instance when _routing_parent is already set to correct parent."""
+# --- instance branch when _routing_parent already set correctly ---
+
+
+def test_instance_branch_routing_parent_already_correct():
+    """Re-linking an instance already bound to the correct parent is a no-op."""
 
     class Child(RoutingClass):
         @route()
@@ -1199,12 +1199,13 @@ def test_attach_instance_routing_parent_already_correct():
             self.child = Child()
 
     parent = Parent()
-    # Manually set _routing_parent to correct parent
+    # Instance already bound to the correct parent
     object.__setattr__(parent.child, "_routing_parent", parent)
 
-    # attach_instance should not try to set it again
-    parent.attach_instance(parent.child, name="child")
+    # Adding it as an instance branch must not fail nor rebind
+    parent.add_branches({"name": "child", "instance": parent.child})
     assert parent.child._routing_parent is parent
+    assert parent.route.node("child/handler")() == "ok"
 
 
 # --- base_router.py - detach_instance with plugin_children cleanup ---
@@ -1222,7 +1223,7 @@ def test_detach_instance_cleans_plugin_children():
         def __init__(self):
             self.route.plug("logging")
             self.child = Child()
-            self.attach_instance(self.child, name="child")
+            self.add_branches({"name": "child", "instance": self.child})
 
         @route()
         def parent_handler(self):
@@ -1375,7 +1376,7 @@ def test_on_attached_to_parent_child_has_same_plugin():
             self.child = Child()
 
     parent = Parent()
-    parent.attach_instance(parent.child, name="child")
+    parent.add_branches({"name": "child", "instance": parent.child})
 
     # Child should still have exactly one logging plugin
     assert len([p for p in parent.child.route._plugins if p.name == "logging"]) == 1

--- a/tests/test_env_plugin.py
+++ b/tests/test_env_plugin.py
@@ -319,7 +319,7 @@ class TestEnvPluginHierarchyAccumulation:
                 self.route.plug("env")
                 self.capabilities = RedisCapabilities()
                 self.child = ChildService()
-                self.attach_instance(self.child, name="child")
+                self.add_branches({"name": "child", "instance": self.child})
 
         parent = ParentService()
 
@@ -344,14 +344,14 @@ class TestEnvPluginHierarchyAccumulation:
             def __init__(self):
                 self.capabilities = Level2Capabilities()
                 self.level3 = Level3()
-                self.attach_instance(self.level3, name="level3")
+                self.add_branches({"name": "level3", "instance": self.level3})
 
         class Level1(RoutingClass):
             def __init__(self):
                 self.route.plug("env")
                 self.capabilities = Level1Capabilities()
                 self.level2 = Level2()
-                self.attach_instance(self.level2, name="level2")
+                self.add_branches({"name": "level2", "instance": self.level2})
 
         root = Level1()
 
@@ -376,7 +376,7 @@ class TestEnvPluginHierarchyAccumulation:
                 self.route.plug("env")
                 self.capabilities = ParentCapCapabilities()
                 self.child = Child()
-                self.attach_instance(self.child, name="child")
+                self.add_branches({"name": "child", "instance": self.child})
 
         root = Parent()
 
@@ -495,7 +495,7 @@ class TestEnvPluginSubRouterFiltering:
             def __init__(self):
                 self.route.plug("env")
                 self.child = Child()
-                self.attach_instance(self.child, name="child")
+                self.add_branches({"name": "child", "instance": self.child})
 
         parent = Parent()
 
@@ -516,7 +516,7 @@ class TestEnvPluginSubRouterFiltering:
             def __init__(self):
                 self.route.plug("env")
                 self.child = Child()
-                self.attach_instance(self.child, name="child")
+                self.add_branches({"name": "child", "instance": self.child})
 
         parent = Parent()
 
@@ -667,7 +667,7 @@ class TestNodesForbiddenParameter:
             def __init__(self):
                 self.route.plug("env")
                 self.child = Child()
-                self.attach_instance(self.child, name="child")
+                self.add_branches({"name": "child", "instance": self.child})
 
         parent = Parent()
 

--- a/tests/test_lazy_branches.py
+++ b/tests/test_lazy_branches.py
@@ -12,12 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for lazy/eager branches: declarative, factory-based subrouters.
+"""Tests for declarative branches: factory (lazy) and instance (eager) subrouters.
 
-A branch is a child subrouter declared as a factory spec
-``{"name", "lazy", "cls", "params"}`` and materialized (constructed) only when
-needed. Eager branches materialize at first tree access; lazy branches
-materialize on-demand at first traversal.
+A branch is a child subrouter declared through ``add_branches``. Each spec is one
+of three mutually exclusive forms:
+
+- factory ``{"name", "cls", "params"}`` — always **lazy**: the instance is
+  constructed on the first traversal of the branch (e.g. ``node("beta/ping")``),
+  never at tree access. ``nodes()`` describes the branch from the class alone,
+  without building it.
+- instance ``{"name", "instance"}`` — **eager**: an already-built instance,
+  linked as a child immediately (it enters ``_children`` at once and never
+  appears in ``branches``). ``params`` is not allowed with ``instance``.
+- alias ``{"name", "alias"}`` — a symlink to an absolute path.
+
+There is no ``lazy`` flag: the timing is derived from the form.
 """
 
 import pytest
@@ -86,7 +95,7 @@ def _clear_build_log():
 def test_add_branches_single_dict():
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "beta", "lazy": False, "cls": Beta, "params": {}})
+            self.add_branches({"name": "beta", "cls": Beta, "params": {}})
 
     alfa = Alfa()
     assert alfa.route.node("beta/ping")() == "beta.ping:beta"
@@ -97,8 +106,8 @@ def test_add_branches_list():
         def __init__(self):
             self.add_branches(
                 [
-                    {"name": "beta", "lazy": False, "cls": Beta, "params": {"tag": "b1"}},
-                    {"name": "gamma", "lazy": False, "cls": Gamma, "params": {}},
+                    {"name": "beta", "cls": Beta, "params": {"tag": "b1"}},
+                    {"name": "gamma", "cls": Gamma, "params": {}},
                 ]
             )
 
@@ -109,8 +118,8 @@ def test_add_branches_list():
 
 def test_add_branches_generator():
     def gen():
-        yield {"name": "beta", "lazy": True, "cls": Beta, "params": {}}
-        yield {"name": "gamma", "lazy": True, "cls": Gamma, "params": {}}
+        yield {"name": "beta", "cls": Beta, "params": {}}
+        yield {"name": "gamma", "cls": Gamma, "params": {}}
 
     class Alfa(RoutingClass):
         def __init__(self):
@@ -124,7 +133,7 @@ def test_add_branches_generator():
 def test_params_applied_to_constructor():
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {"tag": "custom"}})
+            self.add_branches({"name": "beta", "cls": Beta, "params": {"tag": "custom"}})
 
     alfa = Alfa()
     assert alfa.route.node("beta/info")(7) == "beta.info:custom:7"
@@ -138,7 +147,7 @@ def test_params_applied_to_constructor():
 def test_lazy_branch_not_built_until_traversed():
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+            self.add_branches({"name": "beta", "cls": Beta, "params": {}})
 
     alfa = Alfa()
     # Touching the tree must NOT build a lazy branch.
@@ -149,15 +158,21 @@ def test_lazy_branch_not_built_until_traversed():
     assert "Beta:beta" in BUILD_LOG
 
 
-def test_eager_branch_built_at_first_tree_access():
+def test_instance_branch_built_immediately():
+    # An instance branch is EAGER: the instance is built by the caller and
+    # linked at once. Since Gamma logs its own construction, the log records
+    # the build before add_branches even runs.
+    gamma = Gamma()
+    assert "Gamma:gamma" in BUILD_LOG
+
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "gamma", "lazy": False, "cls": Gamma, "params": {}})
+            self.add_branches({"name": "gamma", "instance": gamma})
 
     alfa = Alfa()
-    assert BUILD_LOG == []  # declaration does not build
-    alfa.route.nodes()  # first tree access materializes eager branches
-    assert "Gamma:gamma" in BUILD_LOG
+    # No further build happens; the branch is already a live child.
+    assert BUILD_LOG.count("Gamma:gamma") == 1
+    assert alfa.route.node("gamma/ping")() == "gamma.ping:gamma"
 
 
 def test_declaration_builds_nothing():
@@ -165,37 +180,43 @@ def test_declaration_builds_nothing():
         def __init__(self):
             self.add_branches(
                 [
-                    {"name": "beta", "lazy": True, "cls": Beta, "params": {}},
-                    {"name": "gamma", "lazy": False, "cls": Gamma, "params": {}},
+                    {"name": "beta", "cls": Beta, "params": {}},
+                    {"name": "gamma", "cls": Gamma, "params": {}},
                 ]
             )
 
-    Alfa()  # __init__ only declares
+    Alfa()  # __init__ only declares factory branches
     assert BUILD_LOG == []
 
 
-def test_mixed_lazy_and_eager_same_list():
+def test_mixed_lazy_factory_and_eager_instance_same_list():
+    # An eager instance (built by the caller) and a lazy factory in the same
+    # list: the instance is already in the log; the factory is not built until
+    # traversed.
+    gamma = Gamma()
+    assert BUILD_LOG == ["Gamma:gamma"]
+
     class Alfa(RoutingClass):
         def __init__(self):
             self.add_branches(
                 [
-                    {"name": "beta", "lazy": True, "cls": Beta, "params": {}},
-                    {"name": "gamma", "lazy": False, "cls": Gamma, "params": {}},
+                    {"name": "beta", "cls": Beta, "params": {}},  # lazy factory
+                    {"name": "gamma", "instance": gamma},  # eager instance
                 ]
             )
 
     alfa = Alfa()
-    alfa.route.nodes()  # eager gamma built, lazy beta not
-    assert "Gamma:gamma" in BUILD_LOG
+    # Declaration does not build the lazy factory; the instance was already built.
     assert "Beta:beta" not in BUILD_LOG
-    alfa.route.node("beta/ping")()  # now beta builds
+    assert BUILD_LOG.count("Gamma:gamma") == 1
+    alfa.route.node("beta/ping")()  # now the factory builds
     assert "Beta:beta" in BUILD_LOG
 
 
 def test_lazy_built_only_once():
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+            self.add_branches({"name": "beta", "cls": Beta, "params": {}})
 
     alfa = Alfa()
     alfa.route.node("beta/ping")()
@@ -204,10 +225,14 @@ def test_lazy_built_only_once():
     assert BUILD_LOG.count("Beta:beta") == 1
 
 
-def test_eager_guard_idempotent():
+def test_instance_branch_never_rebuilt():
+    # An instance branch is built once by the caller; repeated tree access and
+    # traversal never re-run the constructor.
+    gamma = Gamma()
+
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "gamma", "lazy": False, "cls": Gamma, "params": {}})
+            self.add_branches({"name": "gamma", "instance": gamma})
 
     alfa = Alfa()
     alfa.route.nodes()
@@ -224,7 +249,7 @@ def test_eager_guard_idempotent():
 def test_nodes_lists_lazy_branch_without_building():
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+            self.add_branches({"name": "beta", "cls": Beta, "params": {}})
 
     alfa = Alfa()
     tree = alfa.route.nodes()
@@ -235,7 +260,7 @@ def test_nodes_lists_lazy_branch_without_building():
 def test_nodes_marks_branch_as_lazy():
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+            self.add_branches({"name": "beta", "cls": Beta, "params": {}})
 
     alfa = Alfa()
     tree = alfa.route.nodes()
@@ -246,7 +271,7 @@ def test_nodes_marks_branch_as_lazy():
 def test_nodes_shows_class_declared_leaves_without_building():
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+            self.add_branches({"name": "beta", "cls": Beta, "params": {}})
 
     alfa = Alfa()
     tree = alfa.route.nodes()
@@ -256,10 +281,14 @@ def test_nodes_shows_class_declared_leaves_without_building():
     assert "Beta:beta" not in BUILD_LOG
 
 
-def test_nodes_eager_branch_is_fully_expanded():
+def test_nodes_instance_branch_is_fully_expanded():
+    # An instance branch is already a live child, so nodes() expands it fully
+    # (not as a lazy marker).
+    gamma = Gamma()
+
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "gamma", "lazy": False, "cls": Gamma, "params": {}})
+            self.add_branches({"name": "gamma", "instance": gamma})
 
     alfa = Alfa()
     tree = alfa.route.nodes()
@@ -280,7 +309,7 @@ def test_endpoint_id_skips_lazy_branch():
 
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "child", "lazy": True, "cls": WithId, "params": {}})
+            self.add_branches({"name": "child", "cls": WithId, "params": {}})
 
     alfa = Alfa()
     node = alfa.route.node("@hidden-ep")
@@ -295,7 +324,7 @@ def test_endpoint_id_found_after_materialization():
 
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "child", "lazy": True, "cls": WithId, "params": {}})
+            self.add_branches({"name": "child", "cls": WithId, "params": {}})
 
     alfa = Alfa()
     alfa.route.node("child/action")()  # materialize
@@ -304,15 +333,20 @@ def test_endpoint_id_found_after_materialization():
     assert node() == "visible"
 
 
-def test_endpoint_id_found_in_eager_branch():
+def test_endpoint_id_found_in_instance_branch():
+    # An instance branch is a live child, so its endpoint_id is reachable at
+    # once (no traversal needed). Lazy factory branches, by contrast, stay
+    # hidden from @id lookup until traversed (see test_endpoint_id_skips_lazy_branch).
     class WithId(RoutingClass):
         @route(endpoint_id="eager-ep")
         def action(self):
             return "eager"
 
+    child = WithId()
+
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "child", "lazy": False, "cls": WithId, "params": {}})
+            self.add_branches({"name": "child", "instance": child})
 
     alfa = Alfa()
     assert alfa.route.node("@eager-ep")() == "eager"
@@ -326,7 +360,7 @@ def test_endpoint_id_found_in_eager_branch():
 def test_materialized_branch_has_routing_parent():
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+            self.add_branches({"name": "beta", "cls": Beta, "params": {}})
 
     alfa = Alfa()
     child_router = alfa.route.node("beta/ping")._router
@@ -337,7 +371,7 @@ def test_plugin_inherited_on_materialization():
     class Alfa(RoutingClass):
         def __init__(self):
             self.route.plug("logging")
-            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+            self.add_branches({"name": "beta", "cls": Beta, "params": {}})
 
     alfa = Alfa()
     child_router = alfa.route.node("beta/ping")._router
@@ -347,7 +381,7 @@ def test_plugin_inherited_on_materialization():
 def test_plug_after_declare_reaches_lazy_branch():
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+            self.add_branches({"name": "beta", "cls": Beta, "params": {}})
             self.route.plug("logging")  # plugged after declaration
 
     alfa = Alfa()
@@ -363,7 +397,7 @@ def test_plug_after_declare_reaches_lazy_branch():
 def test_lazy_constructor_error_deferred_to_traversal():
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "boom", "lazy": True, "cls": Boom, "params": {}})
+            self.add_branches({"name": "boom", "cls": Boom, "params": {}})
 
     alfa = Alfa()  # no error at declaration
     assert "Boom" not in BUILD_LOG
@@ -376,31 +410,6 @@ def test_lazy_constructor_error_deferred_to_traversal():
         alfa.route.node("boom/ping")()
 
 
-def test_eager_constructor_error_is_repeatable_not_lost():
-    class Alfa(RoutingClass):
-        def __init__(self):
-            self.add_branches(
-                [
-                    {"name": "boom", "cls": Boom, "params": {}},  # eager, raises
-                    {"name": "ok", "cls": Gamma, "params": {}},  # eager, after boom
-                ]
-            )
-
-    alfa = Alfa()
-    with pytest.raises(RuntimeError, match="boom in __init__"):
-        alfa.route.nodes()  # first tree access: eager pass hits the error
-    # The failing branch is still declared (spec not lost) and the error
-    # repeats on the next tree access — the tree is loudly broken until fixed.
-    assert "boom" in alfa.branches
-    with pytest.raises(RuntimeError, match="boom in __init__"):
-        alfa.route.nodes()
-    # Removing the broken branch unblocks the tree; 'ok' materializes eagerly.
-    alfa.remove_branch("boom")
-    tree = alfa.route.nodes()
-    assert "ok" in tree["routers"]
-    assert alfa.route.node("ok/ping")() == "gamma.ping:gamma"
-
-
 # ---------------------------------------------------------------------------
 # branches property (read view) and remove_branch
 # ---------------------------------------------------------------------------
@@ -411,8 +420,8 @@ def test_branches_property_lists_declared_specs():
         def __init__(self):
             self.add_branches(
                 [
-                    {"name": "beta", "lazy": True, "cls": Beta, "params": {}},
-                    {"name": "gamma", "lazy": False, "cls": Gamma, "params": {}},
+                    {"name": "beta", "cls": Beta, "params": {}},
+                    {"name": "gamma", "cls": Gamma, "params": {}},
                 ]
             )
 
@@ -423,7 +432,7 @@ def test_branches_property_lists_declared_specs():
 def test_remove_branch_before_materialization():
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+            self.add_branches({"name": "beta", "cls": Beta, "params": {}})
 
     alfa = Alfa()
     alfa.remove_branch("beta")
@@ -436,7 +445,7 @@ def test_remove_branch_before_materialization():
 def test_remove_branch_after_materialization_detaches():
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+            self.add_branches({"name": "beta", "cls": Beta, "params": {}})
 
     alfa = Alfa()
     alfa.route.node("beta/ping")()  # materialize
@@ -450,7 +459,7 @@ def test_add_branch_runtime_after_init():
         pass
 
     alfa = Alfa()
-    alfa.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+    alfa.add_branches({"name": "beta", "cls": Beta, "params": {}})
     assert alfa.route.node("beta/ping")() == "beta.ping:beta"
 
 
@@ -471,7 +480,7 @@ def test_nested_lazy_branches_expand_incrementally():
     class Mid(RoutingClass):
         def __init__(self):
             BUILD_LOG.append("Mid")
-            self.add_branches({"name": "inner", "lazy": True, "cls": Inner, "params": {}})
+            self.add_branches({"name": "inner", "cls": Inner, "params": {}})
 
         @route()
         def midleaf(self):
@@ -479,7 +488,7 @@ def test_nested_lazy_branches_expand_incrementally():
 
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "mid", "lazy": True, "cls": Mid, "params": {}})
+            self.add_branches({"name": "mid", "cls": Mid, "params": {}})
 
     alfa = Alfa()
     assert BUILD_LOG == []
@@ -500,40 +509,44 @@ def test_nested_lazy_branches_expand_incrementally():
 def test_branch_name_collision_with_branch_raises():
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+            self.add_branches({"name": "beta", "cls": Beta, "params": {}})
 
     alfa = Alfa()
     with pytest.raises(ValueError, match="collision"):
-        alfa.add_branches({"name": "beta", "lazy": True, "cls": Gamma, "params": {}})
+        alfa.add_branches({"name": "beta", "cls": Gamma, "params": {}})
 
 
 def test_branch_name_collision_with_materialized_child_raises():
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+            self.add_branches({"name": "beta", "cls": Beta, "params": {}})
 
     alfa = Alfa()
     alfa.route.node("beta/ping")()  # materialize -> beta now in _children
     with pytest.raises(ValueError, match="collision"):
-        alfa.add_branches({"name": "beta", "lazy": True, "cls": Gamma, "params": {}})
+        alfa.add_branches({"name": "beta", "cls": Gamma, "params": {}})
 
 
 def test_params_defaults_to_empty():
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "beta", "lazy": True, "cls": Beta})  # no params
+            self.add_branches({"name": "beta", "cls": Beta})  # no params
 
     alfa = Alfa()
     assert alfa.route.node("beta/ping")() == "beta.ping:beta"
 
 
-def test_lazy_defaults_to_eager_when_omitted():
+def test_factory_is_always_lazy():
+    # A factory spec (``cls``) is always lazy: touching the tree with nodes()
+    # never builds it; only a traversal does.
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "gamma", "cls": Gamma, "params": {}})  # no lazy
+            self.add_branches({"name": "gamma", "cls": Gamma, "params": {}})
 
     alfa = Alfa()
-    alfa.route.nodes()  # eager default -> built at first access
+    alfa.route.nodes()  # nodes() never builds a factory
+    assert "Gamma:gamma" not in BUILD_LOG
+    alfa.route.node("gamma/ping")()  # traversal builds it
     assert "Gamma:gamma" in BUILD_LOG
 
 
@@ -553,7 +566,7 @@ def test_remove_nonexistent_branch_is_noop():
 def test_branches_property_drops_spec_after_materialization():
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+            self.add_branches({"name": "beta", "cls": Beta, "params": {}})
 
     alfa = Alfa()
     assert "beta" in alfa.branches
@@ -567,15 +580,18 @@ def test_branches_property_drops_spec_after_materialization():
 # ---------------------------------------------------------------------------
 
 
-def test_lazy_branch_alone_matches_eager_branch_behavior():
+def test_lazy_factory_alone_matches_instance_branch_behavior():
     # A branch reached without a sub-path has no callable entry of its own
-    # (no default_entry): both eager and lazy resolve the same way.
+    # (no default_entry): a lazy factory and an eager instance resolve the
+    # same way.
+    eager = Beta()
+
     class Alfa(RoutingClass):
         def __init__(self):
             self.add_branches(
                 [
-                    {"name": "lz", "lazy": True, "cls": Beta, "params": {}},
-                    {"name": "eg", "lazy": False, "cls": Beta, "params": {}},
+                    {"name": "lz", "cls": Beta, "params": {}},
+                    {"name": "eg", "instance": eager},
                 ]
             )
 
@@ -591,7 +607,7 @@ def test_lazy_branch_alone_matches_eager_branch_behavior():
 def test_nodes_basepath_materializes_lazy_branch():
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+            self.add_branches({"name": "beta", "cls": Beta, "params": {}})
 
     alfa = Alfa()
     sub = alfa.route.nodes(basepath="beta")
@@ -607,11 +623,11 @@ def test_nodes_basepath_deep_into_nested_lazy():
 
     class Mid(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "inner", "lazy": True, "cls": Inner, "params": {}})
+            self.add_branches({"name": "inner", "cls": Inner, "params": {}})
 
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "mid", "lazy": True, "cls": Mid, "params": {}})
+            self.add_branches({"name": "mid", "cls": Mid, "params": {}})
 
     alfa = Alfa()
     sub = alfa.route.nodes(basepath="mid/inner")
@@ -631,7 +647,7 @@ def test_lazy_nodes_shows_route_name_alias():
 
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "child", "lazy": True, "cls": Aliased, "params": {}})
+            self.add_branches({"name": "child", "cls": Aliased, "params": {}})
 
     alfa = Alfa()
     tree = alfa.route.nodes()
@@ -648,7 +664,7 @@ def test_lazy_nodes_shows_route_name_alias():
 def test_nodes_lazy_flag_still_describes_declared_branches():
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+            self.add_branches({"name": "beta", "cls": Beta, "params": {}})
 
     alfa = Alfa()
     tree = alfa.route.nodes(lazy=True)
@@ -664,7 +680,7 @@ def test_nodes_lazy_flag_still_describes_declared_branches():
 def test_materialize_branch_idempotent_direct():
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "beta", "lazy": True, "cls": Beta, "params": {}})
+            self.add_branches({"name": "beta", "cls": Beta, "params": {}})
 
     alfa = Alfa()
     r1 = alfa.route._materialize_branch("beta")
@@ -691,7 +707,7 @@ def test_lazy_nodes_scans_inherited_route_leaves():
 
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "child", "lazy": True, "cls": Derived, "params": {}})
+            self.add_branches({"name": "child", "cls": Derived, "params": {}})
 
     alfa = Alfa()
     tree = alfa.route.nodes()
@@ -710,7 +726,7 @@ def test_lazy_nodes_dedups_same_function_under_two_attrs():
 
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "child", "lazy": True, "cls": Aliased, "params": {}})
+            self.add_branches({"name": "child", "cls": Aliased, "params": {}})
 
     alfa = Alfa()
     entries = alfa.route.nodes()["routers"]["child"]["entries"]
@@ -725,9 +741,67 @@ def test_lazy_nodes_branch_with_no_leaves():
 
     class Alfa(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "child", "lazy": True, "cls": Empty, "params": {}})
+            self.add_branches({"name": "child", "cls": Empty, "params": {}})
 
     alfa = Alfa()
     child_info = alfa.route.nodes()["routers"]["child"]
     assert child_info["lazy"] is True
     assert "entries" not in child_info
+
+
+# ---------------------------------------------------------------------------
+# Instance form: eager, already-built, validated against cls/params
+# ---------------------------------------------------------------------------
+
+
+def test_instance_form_rejects_params():
+    obj = Beta()
+
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "x", "instance": obj, "params": {}})
+
+    with pytest.raises(ValueError, match="params"):
+        Alfa()
+
+
+def test_instance_and_cls_mutually_exclusive():
+    obj = Beta()
+
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "x", "instance": obj, "cls": Beta})
+
+    with pytest.raises(ValueError, match="exactly one"):
+        Alfa()
+
+
+def test_instance_already_bound_rejected():
+    obj = Beta()
+
+    class ParentA(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "x", "instance": obj})
+
+    ParentA()  # obj is now bound to a ParentA instance
+
+    class ParentB(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "x", "instance": obj})
+
+    with pytest.raises(ValueError, match="already bound"):
+        ParentB()
+
+
+def test_instance_not_in_branches_view():
+    obj = Beta()
+
+    class Alfa(RoutingClass):
+        def __init__(self):
+            self.add_branches({"name": "x", "instance": obj})
+
+    alfa = Alfa()
+    # An instance branch is a live child, not a declared spec: it never appears
+    # in the branches view, but nodes() lists it among the child routers.
+    assert "x" not in alfa.branches
+    assert "x" in alfa.route.nodes()["routers"]

--- a/tests/test_node_resolution.py
+++ b/tests/test_node_resolution.py
@@ -23,7 +23,7 @@ class RootService(RoutingClass):
 
     def __init__(self):
         self.admin = AdminService()
-        self.attach_instance(self.admin, name="admin")
+        self.add_branches({"name": "admin", "instance": self.admin})
 
     @route()
     def index(self):

--- a/tests/test_router_basic.py
+++ b/tests/test_router_basic.py
@@ -200,7 +200,7 @@ def test_dotted_path_and_nodes_with_attached_child():
     class Parent(RoutingClass):
         def __init__(self):
             self.child = Child()
-            self.attach_instance(self.child, name="child")
+            self.add_branches({"name": "child", "instance": self.child})
 
     parent = Parent()
     assert parent.route.node("child/ping")() == "pong"
@@ -389,7 +389,7 @@ class TestDefaultEntry:
         class Root(RoutingClass):
             def __init__(self):
                 self.child = Child()
-                self.attach_instance(self.child, name="child")
+                self.add_branches({"name": "child", "instance": self.child})
 
         root = Root()
 

--- a/tests/test_router_edge_cases.py
+++ b/tests/test_router_edge_cases.py
@@ -222,7 +222,7 @@ def test_attach_and_detach_instance_single_router_with_alias():
             self.child = Child()
 
     parent = Parent()
-    parent.attach_instance(parent.child, name="sales")
+    parent.add_branches({"name": "sales", "instance": parent.child})
     # Verify child is accessible via nodes()
     info = parent.route.nodes()
     assert "sales" in info.get("routers", {})
@@ -235,7 +235,7 @@ def test_attach_and_detach_instance_single_router_with_alias():
     assert "sales" not in info.get("routers", {})
 
 
-def test_attach_instance_name_collision():
+def test_instance_branch_name_collision():
     class Child(RoutingClass):
         pass
 
@@ -245,9 +245,9 @@ def test_attach_instance_name_collision():
             self.child2 = Child()
 
     parent = Parent()
-    parent.attach_instance(parent.child1, name="sales")
+    parent.add_branches({"name": "sales", "instance": parent.child1})
     with pytest.raises(ValueError):
-        parent.attach_instance(parent.child2, name="sales")
+        parent.add_branches({"name": "sales", "instance": parent.child2})
 
 
 def test_detach_instance_removes_all_aliases():
@@ -263,7 +263,7 @@ def test_detach_instance_removes_all_aliases():
 
     parent = Parent()
     child = Child()
-    parent.attach_instance(child, name="first")
+    parent.add_branches({"name": "first", "instance": child})
     # Secondary navigation link to the same child router
     parent.route.include(child.route, name="second")
     info = parent.route.nodes()
@@ -275,13 +275,13 @@ def test_detach_instance_removes_all_aliases():
     assert info.get("routers", {}) == {}
 
 
-def test_attach_instance_requires_routing_class():
+def test_instance_branch_requires_routing_class():
     class Parent(RoutingClass):
         pass
 
     parent = Parent()
     with pytest.raises(TypeError):
-        parent.attach_instance(object(), name="x")
+        parent.add_branches({"name": "x", "instance": object()})
     with pytest.raises(TypeError):
         parent.route.detach_instance(object())
 
@@ -295,7 +295,7 @@ def test_auto_detach_on_attribute_replacement():
     class Parent(RoutingClass):
         def __init__(self):
             self.child = Child()
-            self.attach_instance(self.child, name="child")
+            self.add_branches({"name": "child", "instance": self.child})
 
     parent = Parent()
     # Verify child is attached via nodes()
@@ -310,7 +310,7 @@ def test_auto_detach_on_attribute_replacement():
     assert parent.child is None
 
 
-def test_attach_instance_rejects_other_parent_when_already_bound():
+def test_instance_branch_rejects_other_parent_when_already_bound():
     class Child(RoutingClass):
         pass
 
@@ -323,17 +323,17 @@ def test_attach_instance_rejects_other_parent_when_already_bound():
     second = Parent("second")
 
     # Bind to first parent
-    first.attach_instance(first.child, name="child")
+    first.add_branches({"name": "child", "instance": first.child})
     # Verify child is attached via node()
     assert first.route.node("child")
 
     # Attempt to bind same child to another parent should fail
     with pytest.raises(ValueError):
-        second.attach_instance(first.child, name="child")
+        second.add_branches({"name": "child", "instance": first.child})
 
 
-def test_routing_proxy_attach_instance():
-    """Test routing.attach_instance delegates to the owner's attach_instance."""
+def test_instance_branch_via_add_branches():
+    """An already-built instance is attached through add_branches({instance})."""
 
     class Child(RoutingClass):
         @route()
@@ -345,8 +345,7 @@ def test_routing_proxy_attach_instance():
             self.child = Child()
 
     parent = Parent()
-    # Use routing.attach_instance proxy (delegates to owner)
-    parent.routing.attach_instance(parent.child, name="child")
+    parent.add_branches({"name": "child", "instance": parent.child})
 
     # Verify child is accessible
     assert parent.route.node("child/hello")() == "hello from child"
@@ -389,7 +388,9 @@ def test_endpoint_id_in_child_router():
 
     class App(RoutingClass):
         def __init__(self):
-            self.add_branches({"name": "users", "cls": UsersModule})
+            # instance form: eager child, reachable by @endpoint_id without
+            # traversal (a lazy factory would be skipped until first walked).
+            self.add_branches({"name": "users", "instance": UsersModule()})
 
     app = App()
 
@@ -451,8 +452,8 @@ def test_section_creates_hierarchy():
         def __init__(self):
             self.users = Users()
             self.orders = Orders()
-            self.attach_instance(self.users, name="users")
-            self.attach_instance(self.orders, name="orders")
+            self.add_branches({"name": "users", "instance": self.users})
+            self.add_branches({"name": "orders", "instance": self.orders})
 
     svc = Service()
 
@@ -477,7 +478,7 @@ def test_include_router_on_nested_router():
     class Server(RoutingClass):
         def __init__(self):
             self._sys = Section()
-            self.attach_instance(self._sys, name="_sys")
+            self.add_branches({"name": "_sys", "instance": self._sys})
             self.swagger = SysApp()
             self._sys.route.include(self.swagger.route, name="swagger")
 
@@ -749,12 +750,12 @@ def test_include_entry_from_deep_path():
     class Mid(RoutingClass):
         def __init__(self):
             self.deep = Deep()
-            self.attach_instance(self.deep, name="deep")
+            self.add_branches({"name": "deep", "instance": self.deep})
 
     class Root(RoutingClass):
         def __init__(self):
             self.mid = Mid()
-            self.attach_instance(self.mid, name="mid")
+            self.add_branches({"name": "mid", "instance": self.mid})
 
     class Other(RoutingClass):
         @route()
@@ -798,7 +799,7 @@ def test_get_url_with_endpoint_id():
     class App(RoutingClass):
         def __init__(self):
             self.invoices = Invoices()
-            self.attach_instance(self.invoices, name="invoices")
+            self.add_branches({"name": "invoices", "instance": self.invoices})
 
     app = App()
 
@@ -820,7 +821,7 @@ def test_get_url_with_path():
     class App(RoutingClass):
         def __init__(self):
             self.svc = Svc()
-            self.attach_instance(self.svc, name="svc")
+            self.add_branches({"name": "svc", "instance": self.svc})
 
     app = App()
     assert app.route.get_url("svc/action", xx=23, yy="abc") == "svc/action/23/abc"
@@ -887,12 +888,12 @@ def test_get_url_deep_hierarchy():
     class Mid(RoutingClass):
         def __init__(self):
             self.deep = Deep()
-            self.attach_instance(self.deep, name="deep")
+            self.add_branches({"name": "deep", "instance": self.deep})
 
     class Root(RoutingClass):
         def __init__(self):
             self.mid = Mid()
-            self.attach_instance(self.mid, name="mid")
+            self.add_branches({"name": "mid", "instance": self.mid})
 
     root = Root()
 
@@ -1202,7 +1203,7 @@ def test_plug_not_duplicated_on_child_with_own_plugin():
 
     class Api(RoutingClass):
         def __init__(self):
-            self.attach_instance(ChildOwn(), name="c")
+            self.add_branches({"name": "c", "instance": ChildOwn()})
 
     api = Api()
     api.route.plug("pydantic")
@@ -1224,7 +1225,7 @@ def test_config_copied_to_inherited_child_via_plug():
 
     class Api(RoutingClass):
         def __init__(self):
-            self.attach_instance(Child(), name="c")
+            self.add_branches({"name": "c", "instance": Child()})
 
     api = Api()
     api.route.plug("strict")
@@ -1252,7 +1253,7 @@ def test_inherit_strict_signature_plugin_no_enabled_crash():
         def __init__(self):
             self.route.plug("strict")
             self.route.strict.configure(mode="special")  # non-default parent config
-            self.attach_instance(Child(), name="c")  # must not raise
+            self.add_branches({"name": "c", "instance": Child()})  # must not raise
 
     api = Api()
     child_plugin = api.route._children["c"]._plugins_by_name["strict"]

--- a/tests/test_router_runtime_extras.py
+++ b/tests/test_router_runtime_extras.py
@@ -291,8 +291,8 @@ def test_router_nodes_with_basepath():
         def __init__(self):
             self.child = Child()
             self.child.grandchild = Grandchild()
-            self.attach_instance(self.child, name="child")
-            self.child.attach_instance(self.child.grandchild, name="grandchild")
+            self.add_branches({"name": "child", "instance": self.child})
+            self.child.add_branches({"name": "grandchild", "instance": self.child.grandchild})
 
         @route()
         def root_action(self):
@@ -338,7 +338,7 @@ def test_nodes_lazy_returns_router_references():
     class Root(RoutingClass):
         def __init__(self):
             self.child = Child()
-            self.attach_instance(self.child, name="child")
+            self.add_branches({"name": "child", "instance": self.child})
 
         @route()
         def root_action(self):

--- a/tests/test_routing_context.py
+++ b/tests/test_routing_context.py
@@ -131,7 +131,7 @@ class TestCtxSlot:
 
         parent = Parent()
         child = Child()
-        parent.attach_instance(child, name="child")
+        parent.add_branches({"name": "child", "instance": child})
 
         ctx = RoutingContext()
         ctx.db = "shared_db"
@@ -151,7 +151,7 @@ class TestCtxSlot:
 
         parent = Parent()
         child = Child()
-        parent.attach_instance(child, name="child")
+        parent.add_branches({"name": "child", "instance": child})
 
         parent_ctx = RoutingContext()
         parent_ctx.label = "parent"
@@ -174,7 +174,7 @@ class TestCtxSlot:
 
         parent = Parent()
         child = Child()
-        parent.attach_instance(child, name="child")
+        parent.add_branches({"name": "child", "instance": child})
 
         parent_ctx = RoutingContext()
         parent_ctx.label = "parent"


### PR DESCRIPTION
## Summary

`add_branches` becomes the **single entry point** for declaring a subtree, in
three mutually exclusive spec forms; `attach_instance` is removed. Breaking, by
design — the project is in prototyping, no compatibility shim.

| Form | Keys | Timing |
|------|------|--------|
| factory | `cls` (+ `params`) | **lazy** — built on first traversal |
| instance | `instance` | **eager** — already-built RoutingClass, linked now |
| alias | `alias` | never (symlink) |

The timing is derived from the form, so the `lazy` flag is **removed**. The 0.27
eager-factory (a class built at first tree access) is gone: to build a subtree
up front, pass a pre-built **instance**. This also resolves the "child as
attribute" friction (`self.commander = X(self)` + attach) — now
`add_branches({"name": ..., "instance": self.commander})`.

## Changes

- `add_branches`/`_add_branch_spec`: three-form spec, mutual exclusivity, factory
  always lazy, instance linked eagerly via the existing `_include_router` path
  (same parent-chain wiring + plugin inheritance), already-bound and
  non-RoutingClass instances rejected, `params` rejected with `instance`.
- `attach_instance` removed (owner + proxy). `detach_instance` stays as the
  internal inverse used by `remove_branch`.
- The now-dead eager apparatus (`_materialize_eager`, `_eager_done`) removed.
- ~64 test call-sites migrated; eager-factory tests rewritten to the new model;
  new tests for the instance form. Examples and full docs migrated.

## BREAKING CHANGES

- `attach_instance(child, name=...)` → `add_branches({"name": ..., "instance": child})`
- `add_branches` `lazy` flag removed
- factory branches are now always lazy (were eager by default)

## Downstream impact (Sourcerer cross-repo review)

`genro-asgi` uses `attach_instance` in three real call-sites and will need to
migrate (separate PR on that repo, not this one):

- `applications/asgi_application/asgi_application.py` — `Backoffice(self)` docstring example
- `applications/mcp_application/tests/test_mcp_application.py` — `_TargetDb()`
- `applications/multi_worker_application/multi_worker_application.py` — `self.commander = CommanderServices(self)` + attach (the "child as attribute" pattern)

All three are `attach_instance(obj, name=...)` → `add_branches({"name": ..., "instance": obj})`.
No other repo (smartpublisher, smartswitch) uses `attach_instance`.

## Test plan

- Full suite green: **409 passed**.
- Targeted coverage: `routing.py` 99%, `base_router.py` 98% (improved — the
  removed `attach_instance` name=None branch was previously uncovered).
- `ruff check .` clean; `mypy src/` advisory clean.
- Smoke end-to-end (in-process): factory=lazy (not built until traversed),
  instance=eager (built immediately, not in `branches`), key exclusivity, type
  check, `nodes(basepath=)` and `nodes(_eager=True)` materialization.
- Examples migrated compile and run.